### PR TITLE
:bug: fixing certificate name for hetzner controller

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -22,4 +22,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: caph-webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  subject:
+    organizations:
+      - k8s-sig-cluster-lifecycle

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -20,4 +20,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: caph-webhook-server-cert


### PR DESCRIPTION
/kind bug               Fixes a newly discovered bug.


**What this PR does / why we need it**:
Fixes the certificate name for the controller aligning to upstream cluster-api naming convention.

