### PR TITLE
:sparkles: Changes Templates to fedora for easier cgroup v2 handling

### DIFF
--- a/templates/cluster-template-hcloud-network.yaml
+++ b/templates/cluster-template-hcloud-network.yaml
@@ -109,7 +109,7 @@ spec:
           cloud-provider: external
           cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
           cluster-signing-key-file: /etc/kubernetes/pki/ca.key
-          cluster-signing-duration: 6h0m0s
+          cluster-signing-duration: 1h35m0s
           terminated-pod-gc-threshold: "10"
           profiling: "false"
           use-service-account-credentials: "true"
@@ -149,6 +149,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          cgroup-driver: systemd
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"
@@ -162,6 +163,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          cgroup-driver: systemd
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"
@@ -187,6 +189,118 @@ spec:
                   - name: key1
                     secret: 8d7iAcg3/NwN9aijhtEXj5kL2NOHIgokGFjbIBfL6X0=
               - identity: {}
+      - path: /etc/systemd/system/sys-fs-bpf.mount
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          [Unit]
+          Description=Cilium BPF mounts
+          Documentation=https://docs.cilium.io/
+          DefaultDependencies=no
+          Before=local-fs.target umount.target
+          After=swap.target
+
+          [Mount]
+          What=bpffs
+          Where=/sys/fs/bpf
+          Type=bpf
+          Options=rw,nosuid,nodev,noexec,relatime,mode=700
+
+          [Install]
+          WantedBy=multi-user.target
+      - path: /etc/sysctl.d/99-cilium.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          net.ipv4.conf.lxc*.rp_filter = 0
+      - path: /etc/modules-load.d/crio.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          overlay
+          br_netfilter
+      - path: /etc/crio/crio.conf.d/02-cgroup-manager.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          [crio]
+          log_dir = "/var/log/crio/pods"
+          grpc_max_send_msg_size = 16777216
+          grpc_max_recv_msg_size = 16777216
+          [crio.runtime]
+          default_runtime = "runc"
+          conmon = "/usr/local/bin/conmon"
+          conmon_env = [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          ]
+          default_env = [
+          ]
+          selinux = false
+          seccomp_profile = ""
+          apparmor_profile = "crio-default"
+          default_capabilities = [
+            "CHOWN",
+            "DAC_OVERRIDE",
+            "FSETID",
+            "FOWNER",
+            "SETGID",
+            "SETUID",
+            "SETPCAP",
+            "NET_BIND_SERVICE",
+            "KILL",
+              "MKNOD",
+          ]
+          [crio.runtime.runtimes.runc]
+          runtime_path = ""
+          runtime_type = "oci"
+          runtime_root = "/run/runc"
+      - path: /etc/yum.repos.d/kubernetes.repo
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          [kubernetes]
+          name=Kubernetes
+          baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+          enabled=1
+          gpgcheck=1
+          repo_gpgcheck=1
+          gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+      - path: /etc/sysctl.d/99-kubernetes-cri.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward                 = 1
+      - path: /etc/sysctl.d/99-kubelet.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          vm.overcommit_memory=1
+          kernel.panic=10
+          kernel.panic_on_oops=1
+    preKubeadmCommands:
+      - localectl set-locale LANG=en_US.UTF-8
+      - localectl set-locale LANGUAGE=en_US.UTF-8
+      - dnf update -y
+      - dnf -y install at jq unzip wget socat mtr firewalld
+      - sed -i '/swap/d' /etc/fstab
+      - swapoff -a
+      - modprobe overlay && modprobe br_netfilter && sysctl --system
+      - wget https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.amd64 -O /usr/local/sbin/runc && chmod +x /usr/local/sbin/runc
+      - wget https://github.com/containers/conmon/releases/download/v2.0.31/conmon-x86.zip -O conmon.zip && unzip conmon.zip -d conmon && mv conmon/bin/conmon /usr/local/bin/conmon && chmod +x /usr/local/bin/conmon && rm -rf conmon.zip conmon
+      - dnf -y module enable cri-o:1.22 && dnf -y install cri-o
+      - wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz && tar zxvf crictl-v1.22.0-linux-amd64.tar.gz -C /usr/local/bin && rm -f crictl-v1.22.0-linux-amd64.tar.gz
+      - rm -f /etc/cni/net.d/100-crio-bridge.conf /etc/cni/net.d/200-loopback.conf
+      - systemctl enable crio.service && systemctl daemon-reload && systemctl enable crio
+      - dnf install --setopt=obsoletes=0 -y kubelet-0:1.22.4-0 kubeadm-0:1.22.4-0 kubectl-0:1.22.4-0 python3-dnf-plugin-versionlock bash-completion --disableexcludes=kubernetes && dnf versionlock kubelet kubectl kubeadm && systemctl enable kubelet && systemctl start crio && kubeadm config images pull --kubernetes-version 1.22.4
+      - dnf install -y policycoreutils-python-utils
+      - semanage fcontext -a -t container_file_t /var/lib/etcd && mkdir -p /var/lib/etcd && restorecon -rv /var /etc
+      - echo 'source <(kubectl completion bash)' >>~/.bashrc
+      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+      - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
+      - dnf -y remove firewalld
+      - dnf -y autoremove && dnf -y clean all
   version: "${KUBERNETES_VERSION}"
 ---
 kind: HCloudMachineTemplate
@@ -197,7 +311,7 @@ spec:
   template:
     spec:
       type: "${HCLOUD_CONTROL_PLANE_MACHINE_TYPE}"
-      imageName: "${HCLOUD_IMAGE_NAME}"
+      imageName: "fedora-35"
       placementGroup: control-plane
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -207,6 +321,7 @@ metadata:
 spec:
   clusterName: "${CLUSTER_NAME}"
   maxUnhealthy: 100%
+  nodeStartupTimeout: 20m
   selector:
     matchLabels:
       cluster.x-k8s.io/control-plane: ""
@@ -252,7 +367,7 @@ spec:
   template:
     spec:
       type: "${HCLOUD_NODE_MACHINE_TYPE}"
-      imageName: "${HCLOUD_IMAGE_NAME}"
+      imageName: "fedora-35"
       placementGroup: md-0
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -266,6 +381,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+            cgroup-driver: systemd
             tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
             kubeconfig: /etc/kubernetes/kubelet.conf
             authentication-token-webhook: "true"
@@ -275,6 +391,113 @@ spec:
             event-qps: "5"
             rotate-server-certificates: "true"
             max-pods: "220"
+      files:
+        - path: /etc/systemd/system/sys-fs-bpf.mount
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            [Unit]
+            Description=Cilium BPF mounts
+            Documentation=https://docs.cilium.io/
+            DefaultDependencies=no
+            Before=local-fs.target umount.target
+            After=swap.target
+
+            [Mount]
+            What=bpffs
+            Where=/sys/fs/bpf
+            Type=bpf
+            Options=rw,nosuid,nodev,noexec,relatime,mode=700
+
+            [Install]
+            WantedBy=multi-user.target
+        - path: /etc/sysctl.d/99-cilium.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            net.ipv4.conf.lxc*.rp_filter = 0
+        - path: /etc/modules-load.d/crio.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            overlay
+            br_netfilter
+        - path: /etc/crio/crio.conf.d/02-cgroup-manager.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            [crio.runtime]
+            default_runtime = "runc"
+            conmon = "/usr/local/bin/conmon"
+            conmon_env = [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            ]
+            selinux = false
+            seccomp_profile = ""
+            apparmor_profile = "crio-default"
+            default_capabilities = [
+              "CHOWN",
+              "DAC_OVERRIDE",
+              "FSETID",
+              "FOWNER",
+              "SETGID",
+              "SETUID",
+              "SETPCAP",
+              "NET_BIND_SERVICE",
+              "KILL",
+              "MKNOD",
+            ]
+            [crio.runtime.runtimes.runc]
+            runtime_path = ""
+            runtime_type = "oci"
+            runtime_root = "/run/runc"
+        - path: /etc/yum.repos.d/kubernetes.repo
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            [kubernetes]
+            name=Kubernetes
+            baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+            enabled=1
+            gpgcheck=1
+            repo_gpgcheck=1
+            gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+        - path: /etc/sysctl.d/99-kubernetes-cri.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+            net.ipv4.ip_forward                 = 1
+        - path: /etc/sysctl.d/99-kubelet.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            vm.overcommit_memory=1
+            kernel.panic=10
+            kernel.panic_on_oops=1
+      preKubeadmCommands:
+        - localectl set-locale LANG=en_US.UTF-8
+        - localectl set-locale LANGUAGE=en_US.UTF-8
+        - dnf update -y
+        - dnf -y install at jq unzip wget socat mtr firewalld
+        - sed -i '/swap/d' /etc/fstab
+        - swapoff -a
+        - modprobe overlay && modprobe br_netfilter && sysctl --system
+        - wget https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.amd64 -O /usr/local/sbin/runc && chmod +x /usr/local/sbin/runc
+        - wget https://github.com/containers/conmon/releases/download/v2.0.31/conmon-x86.zip -O conmon.zip && unzip conmon.zip -d conmon && mv conmon/bin/conmon /usr/local/bin/conmon && chmod +x /usr/local/bin/conmon && rm -rf conmon.zip conmon
+        - dnf -y module enable cri-o:1.22 && dnf -y install cri-o
+        - wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz && tar zxvf crictl-v1.22.0-linux-amd64.tar.gz -C /usr/local/bin && rm -f crictl-v1.22.0-linux-amd64.tar.gz
+        - rm -f /etc/cni/net.d/100-crio-bridge.conf /etc/cni/net.d/200-loopback.conf
+        - systemctl enable crio.service && systemctl daemon-reload && systemctl enable crio
+        - dnf install --setopt=obsoletes=0 -y kubelet-0:1.22.4-0 kubeadm-0:1.22.4-0 kubectl-0:1.22.4-0 python3-dnf-plugin-versionlock bash-completion --disableexcludes=kubernetes && dnf versionlock kubelet kubectl kubeadm && systemctl enable kubelet && systemctl start crio && kubeadm config images pull --kubernetes-version 1.22.4
+        - dnf install -y policycoreutils-python-utils
+        - semanage fcontext -a -t container_file_t /var/lib/etcd && mkdir -p /var/lib/etcd && restorecon -rv /var /etc
+        - echo 'source <(kubectl completion bash)' >>~/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
+        - dnf -y remove firewalld
+        - dnf -y autoremove && dnf -y clean all
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
@@ -283,7 +506,7 @@ metadata:
 spec:
   clusterName: "${CLUSTER_NAME}"
   maxUnhealthy: 100%
-  nodeStartupTimeout: 10m
+  nodeStartupTimeout: 20m
   selector:
     matchLabels:
       nodepool: "${CLUSTER_NAME}-md-0"

--- a/templates/cluster-template-packer.yaml
+++ b/templates/cluster-template-packer.yaml
@@ -64,20 +64,129 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
+          # CA certificate for validating API clients.
+          client-ca-file: /etc/kubernetes/pki/ca.crt # enable X509 Client Certs Auth
+          # TLS certificates for HTTPS serving.
+          tls-cert-file: /etc/kubernetes/pki/apiserver.crt
+          tls-private-key-file: /etc/kubernetes/pki/apiserver.key
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          # Required for kubelet communication.
+          kubelet-client-certificate: /etc/kubernetes/pki/apiserver-kubelet-client.crt
+          kubelet-client-key: /etc/kubernetes/pki/apiserver-kubelet-client.key
+          # Secure communication to etcd servers.
+          etcd-cafile: /etc/kubernetes/pki/etcd/ca.crt
+          etcd-certfile: /etc/kubernetes/pki/etcd/server.crt
+          etcd-keyfile: /etc/kubernetes/pki/etcd/server.key
+          # Required to validate service account tokens created by controller manager.
+          service-account-lookup: "true"
+          service-account-key-file: /etc/kubernetes/pki/sa.pub
+          # Required for aggregation layer
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          proxy-client-key-file: /etc/kubernetes/pki/front-proxy-client.key
+          proxy-client-cert-file: /etc/kubernetes/pki/front-proxy-client.crt
+          requestheader-allowed-names: front-proxy-client
+          requestheader-extra-headers-prefix: X-Remote-Extra-
+          requestheader-group-headers: X-Remote-Group
+          requestheader-username-headers: X-Remote-User
+          enable-aggregator-routing: "true"
+          # Etcd Secret Encrytion
+          encryption-provider-config: /etc/kubernetes/encryption-provider.yaml
+          # Additional Configuration
           cloud-provider: external
+          authorization-mode: "Node,RBAC"
+          kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
+          profiling: "false"
+          enable-bootstrap-token-auth: "true"
+          insecure-port: "0"
+          default-not-ready-toleration-seconds: "45"
+          default-unreachable-toleration-seconds: "45"
+        extraVolumes:
+        - name: encryption-provider
+          hostPath: /etc/kubernetes/encryption-provider.yaml
+          mountPath: /etc/kubernetes/encryption-provider.yaml
       controllerManager:
         extraArgs:
           cloud-provider: external
+          cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
+          cluster-signing-key-file: /etc/kubernetes/pki/ca.key
+          cluster-signing-duration: 6h0m0s
+          terminated-pod-gc-threshold: "10"
+          profiling: "false"
+          use-service-account-credentials: "true"
+          service-account-private-key-file: /etc/kubernetes/pki/sa.key
+          root-ca-file: /etc/kubernetes/pki/ca.crt
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          kubeconfig: /etc/kubernetes/controller-manager.conf
+          authentication-kubeconfig: /etc/kubernetes/controller-manager.conf
+          authorization-kubeconfig: /etc/kubernetes/controller-manager.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10257"
+          allocate-node-cidrs: "true"
+          pod-eviction-timeout: 2m
+      scheduler:
+        extraArgs:
+          profiling: "false"
+          kubeconfig: /etc/kubernetes/scheduler.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10259"
+      etcd:
+        local:
+          dataDir: /var/lib/etcd
+          extraArgs:
+            cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            cert-file: /etc/kubernetes/pki/etcd/server.crt
+            key-file: /etc/kubernetes/pki/etcd/server.key
+            client-cert-auth: "true"
+            auto-tls: "false"
+            peer-client-cert-auth: "true"
+            peer-auto-tls: "false"
+            trusted-ca-file: /etc/kubernetes/pki/etcd/ca.crt
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          cgroup-driver: "cgroup2fs"
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          cgroup-driver: "cgroup2fs"
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
+    files:
+      - path: /etc/kubernetes/encryption-provider.yaml
+        owner: "root:root"
+        permissions: "0600"
+        content: |
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+            - resources:
+              - secrets
+              providers:
+              - aescbc:
+                  keys:
+                  - name: key1
+                    secret: 8d7iAcg3/NwN9aijhtEXj5kL2NOHIgokGFjbIBfL6X0=
+              - identity: {}
   version: "${KUBERNETES_VERSION}"
 ---
 kind: HCloudMachineTemplate
@@ -157,7 +266,15 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            cgroup-driver: "cgroup2fs"
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            kubeconfig: /etc/kubernetes/kubelet.conf
+            authentication-token-webhook: "true"
+            authorization-mode: Webhook
+            anonymous-auth: "false"
+            read-only-port: "0"
+            event-qps: "5"
+            rotate-server-certificates: "true"
+            max-pods: "220"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -64,21 +64,129 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
+          # CA certificate for validating API clients.
+          client-ca-file: /etc/kubernetes/pki/ca.crt # enable X509 Client Certs Auth
+          # TLS certificates for HTTPS serving.
+          tls-cert-file: /etc/kubernetes/pki/apiserver.crt
+          tls-private-key-file: /etc/kubernetes/pki/apiserver.key
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          # Required for kubelet communication.
+          kubelet-client-certificate: /etc/kubernetes/pki/apiserver-kubelet-client.crt
+          kubelet-client-key: /etc/kubernetes/pki/apiserver-kubelet-client.key
+          # Secure communication to etcd servers.
+          etcd-cafile: /etc/kubernetes/pki/etcd/ca.crt
+          etcd-certfile: /etc/kubernetes/pki/etcd/server.crt
+          etcd-keyfile: /etc/kubernetes/pki/etcd/server.key
+          # Required to validate service account tokens created by controller manager.
+          service-account-lookup: "true"
+          service-account-key-file: /etc/kubernetes/pki/sa.pub
+          # Required for aggregation layer
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          proxy-client-key-file: /etc/kubernetes/pki/front-proxy-client.key
+          proxy-client-cert-file: /etc/kubernetes/pki/front-proxy-client.crt
+          requestheader-allowed-names: front-proxy-client
+          requestheader-extra-headers-prefix: X-Remote-Extra-
+          requestheader-group-headers: X-Remote-Group
+          requestheader-username-headers: X-Remote-User
+          enable-aggregator-routing: "true"
+          # Etcd Secret Encrytion
+          encryption-provider-config: /etc/kubernetes/encryption-provider.yaml
+          # Additional Configuration
           cloud-provider: external
+          authorization-mode: "Node,RBAC"
+          kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
+          profiling: "false"
+          enable-bootstrap-token-auth: "true"
+          insecure-port: "0"
+          default-not-ready-toleration-seconds: "45"
+          default-unreachable-toleration-seconds: "45"
+        extraVolumes:
+        - name: encryption-provider
+          hostPath: /etc/kubernetes/encryption-provider.yaml
+          mountPath: /etc/kubernetes/encryption-provider.yaml
       controllerManager:
         extraArgs:
           cloud-provider: external
+          cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
+          cluster-signing-key-file: /etc/kubernetes/pki/ca.key
+          cluster-signing-duration: 6h0m0s
+          terminated-pod-gc-threshold: "10"
+          profiling: "false"
+          use-service-account-credentials: "true"
+          service-account-private-key-file: /etc/kubernetes/pki/sa.key
+          root-ca-file: /etc/kubernetes/pki/ca.crt
+          requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
+          kubeconfig: /etc/kubernetes/controller-manager.conf
+          authentication-kubeconfig: /etc/kubernetes/controller-manager.conf
+          authorization-kubeconfig: /etc/kubernetes/controller-manager.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10257"
+          allocate-node-cidrs: "true"
+          pod-eviction-timeout: 2m
+      scheduler:
+        extraArgs:
+          profiling: "false"
+          kubeconfig: /etc/kubernetes/scheduler.conf
+          address: "127.0.0.1"
+          bind-address: "0.0.0.0"
+          port: "0"
+          secure-port: "10259"
+      etcd:
+        local:
+          dataDir: /var/lib/etcd
+          extraArgs:
+            cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            cert-file: /etc/kubernetes/pki/etcd/server.crt
+            key-file: /etc/kubernetes/pki/etcd/server.key
+            client-cert-auth: "true"
+            auto-tls: "false"
+            peer-client-cert-auth: "true"
+            peer-auto-tls: "false"
+            trusted-ca-file: /etc/kubernetes/pki/etcd/ca.crt
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          cgroup-driver: "cgroup2fs"
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          cgroup-driver: "cgroup2fs"
+          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          kubeconfig: /etc/kubernetes/kubelet.conf
+          authentication-token-webhook: "true"
+          authorization-mode: Webhook
+          anonymous-auth: "false"
+          read-only-port: "0"
+          event-qps: "5"
+          rotate-server-certificates: "true"
+          max-pods: "120"
     files:
+      - path: /etc/kubernetes/encryption-provider.yaml
+        owner: "root:root"
+        permissions: "0600"
+        content: |
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+            - resources:
+              - secrets
+              providers:
+              - aescbc:
+                  keys:
+                  - name: key1
+                    secret: 8d7iAcg3/NwN9aijhtEXj5kL2NOHIgokGFjbIBfL6X0=
+              - identity: {}
       - path: /etc/systemd/system/sys-fs-bpf.mount
         owner: "root:root"
         permissions: "0744"
@@ -109,30 +217,17 @@ spec:
         content: |
           overlay
           br_netfilter
-      - path: /etc/crio/crio.conf
+      - path: /etc/crio/crio.conf.d/02-cgroup-manager.conf
         owner: "root:root"
         permissions: "0744"
         content: |
           [crio]
           log_dir = "/var/log/crio/pods"
-          version_file = "/var/run/crio/version"
-          version_file_persist = "/var/lib/crio/version"
-          [crio.api]
-          listen = "/var/run/crio/crio.sock"
-          stream_address = "127.0.0.1"
-          stream_port = "0"
-          stream_enable_tls = false
-          stream_tls_cert = ""
-          stream_tls_key = ""
-          stream_tls_ca = ""
           grpc_max_send_msg_size = 16777216
           grpc_max_recv_msg_size = 16777216
           [crio.runtime]
           default_runtime = "runc"
-          no_pivot = false
-          decryption_keys_path = "/etc/crio/keys/"
           conmon = "/usr/local/bin/conmon"
-          conmon_cgroup = "pod"
           conmon_env = [
               "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
           ]
@@ -141,7 +236,6 @@ spec:
           selinux = false
           seccomp_profile = ""
           apparmor_profile = "crio-default"
-          cgroup_manager = "cgroupfs"
           default_capabilities = [
             "CHOWN",
             "DAC_OVERRIDE",
@@ -154,55 +248,10 @@ spec:
             "KILL",
               "MKNOD",
           ]
-          default_sysctls = [
-              "net.ipv4.ping_group_range=0 65535",
-          ]
-          additional_devices = [
-          ]
-          hooks_dir = [
-            "/usr/share/containers/oci/hooks.d",
-          ]
-          default_mounts = [
-          ]
-          pids_limit = 4096
-          log_size_max = -1
-          log_to_journald = false
-          container_exits_dir = "/var/run/crio/exits"
-          container_attach_socket_dir = "/var/run/crio"
-          bind_mount_prefix = ""
-          read_only = false
-          log_level = "info"
-          log_filter = ""
-          uid_mappings = ""
-          gid_mappings = ""
-          ctr_stop_timeout = 30
-          manage_ns_lifecycle = true
-          drop_infra_ctr = false
-          namespaces_dir = "/var/run"
-          pinns_path = ""
           [crio.runtime.runtimes.runc]
           runtime_path = ""
           runtime_type = "oci"
           runtime_root = "/run/runc"
-          [crio.image]
-          default_transport = "docker://"
-          global_auth_file = ""
-          pause_image = "k8s.gcr.io/pause:3.5"
-          pause_image_auth_file = ""
-          pause_command = "/pause"
-          signature_policy = ""
-          image_volumes = "mkdir"
-          big_files_temporary_dir = ""
-          [crio.network]
-          network_dir = "/etc/cni/net.d/"
-          plugin_dirs = [
-            "/opt/cni/bin",
-            "/usr/libexec/cni"
-          ]
-          [crio.metrics]
-          enable_metrics = true
-          metrics_port = 9090
-          metrics_socket = ""
       - path: /etc/yum.repos.d/kubernetes.repo
         owner: "root:root"
         permissions: "0744"
@@ -231,16 +280,14 @@ spec:
     preKubeadmCommands:
       - localectl set-locale LANG=en_US.UTF-8
       - localectl set-locale LANGUAGE=en_US.UTF-8
-      - dnf -y install epel-release dnf-plugins-core
-      - dnf config-manager --set-enabled baseos appstream extras epel epel-modular powertools 
       - dnf update -y
       - dnf -y install at jq unzip wget socat mtr firewalld
+      - sed -i '/swap/d' /etc/fstab
+      - swapoff -a
       - modprobe overlay && modprobe br_netfilter && sysctl --system
       - wget https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.amd64 -O /usr/local/sbin/runc && chmod +x /usr/local/sbin/runc
       - wget https://github.com/containers/conmon/releases/download/v2.0.31/conmon-x86.zip -O conmon.zip && unzip conmon.zip -d conmon && mv conmon/bin/conmon /usr/local/bin/conmon && chmod +x /usr/local/bin/conmon && rm -rf conmon.zip conmon
-      - curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_8/devel:kubic:libcontainers:stable.repo
-      - curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:1.22.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:1.22/CentOS_8/devel:kubic:libcontainers:stable:cri-o:1.22.repo
-      - dnf -y install cri-o
+      - dnf -y module enable cri-o:1.22 && dnf -y install cri-o
       - wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz && tar zxvf crictl-v1.22.0-linux-amd64.tar.gz -C /usr/local/bin && rm -f crictl-v1.22.0-linux-amd64.tar.gz
       - rm -f /etc/cni/net.d/100-crio-bridge.conf /etc/cni/net.d/200-loopback.conf
       - systemctl enable crio.service && systemctl daemon-reload && systemctl enable crio
@@ -250,8 +297,8 @@ spec:
       - echo 'source <(kubectl completion bash)' >>~/.bashrc
       - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
       - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
+      - dnf -y remove firewalld
       - dnf -y autoremove && dnf -y clean all
-
   version: "${KUBERNETES_VERSION}"
 ---
 kind: HCloudMachineTemplate
@@ -262,7 +309,7 @@ spec:
   template:
     spec:
       type: "${HCLOUD_CONTROL_PLANE_MACHINE_TYPE}"
-      imageName: "${HCLOUD_IMAGE_NAME}"
+      imageName: "fedora-35"
       placementGroup: control-plane
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -272,6 +319,7 @@ metadata:
 spec:
   clusterName: "${CLUSTER_NAME}"
   maxUnhealthy: 100%
+  nodeStartupTimeout: 20m
   selector:
     matchLabels:
       cluster.x-k8s.io/control-plane: ""
@@ -317,7 +365,7 @@ spec:
   template:
     spec:
       type: "${HCLOUD_NODE_MACHINE_TYPE}"
-      imageName: "${HCLOUD_IMAGE_NAME}"
+      imageName: "fedora-35"
       placementGroup: md-0
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -331,7 +379,15 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            cgroup-driver: "cgroup2fs"
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            kubeconfig: /etc/kubernetes/kubelet.conf
+            authentication-token-webhook: "true"
+            authorization-mode: Webhook
+            anonymous-auth: "false"
+            read-only-port: "0"
+            event-qps: "5"
+            rotate-server-certificates: "true"
+            max-pods: "220"
       files:
         - path: /etc/systemd/system/sys-fs-bpf.mount
           owner: "root:root"
@@ -363,39 +419,19 @@ spec:
           content: |
             overlay
             br_netfilter
-        - path: /etc/crio/crio.conf
+        - path: /etc/crio/crio.conf.d/02-cgroup-manager.conf
           owner: "root:root"
           permissions: "0744"
           content: |
-            [crio]
-            log_dir = "/var/log/crio/pods"
-            version_file = "/var/run/crio/version"
-            version_file_persist = "/var/lib/crio/version"
-            [crio.api]
-            listen = "/var/run/crio/crio.sock"
-            stream_address = "127.0.0.1"
-            stream_port = "0"
-            stream_enable_tls = false
-            stream_tls_cert = ""
-            stream_tls_key = ""
-            stream_tls_ca = ""
-            grpc_max_send_msg_size = 16777216
-            grpc_max_recv_msg_size = 16777216
             [crio.runtime]
             default_runtime = "runc"
-            no_pivot = false
-            decryption_keys_path = "/etc/crio/keys/"
             conmon = "/usr/local/bin/conmon"
-            conmon_cgroup = "pod"
             conmon_env = [
                 "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            ]
-            default_env = [
             ]
             selinux = false
             seccomp_profile = ""
             apparmor_profile = "crio-default"
-            cgroup_manager = "cgroupfs"
             default_capabilities = [
               "CHOWN",
               "DAC_OVERRIDE",
@@ -406,57 +442,12 @@ spec:
               "SETPCAP",
               "NET_BIND_SERVICE",
               "KILL",
-                "MKNOD",
+              "MKNOD",
             ]
-            default_sysctls = [
-                "net.ipv4.ping_group_range=0 65535",
-            ]
-            additional_devices = [
-            ]
-            hooks_dir = [
-              "/usr/share/containers/oci/hooks.d",
-            ]
-            default_mounts = [
-            ]
-            pids_limit = 4096
-            log_size_max = -1
-            log_to_journald = false
-            container_exits_dir = "/var/run/crio/exits"
-            container_attach_socket_dir = "/var/run/crio"
-            bind_mount_prefix = ""
-            read_only = false
-            log_level = "info"
-            log_filter = ""
-            uid_mappings = ""
-            gid_mappings = ""
-            ctr_stop_timeout = 30
-            manage_ns_lifecycle = true
-            drop_infra_ctr = false
-            namespaces_dir = "/var/run"
-            pinns_path = ""
             [crio.runtime.runtimes.runc]
             runtime_path = ""
             runtime_type = "oci"
             runtime_root = "/run/runc"
-            [crio.image]
-            default_transport = "docker://"
-            global_auth_file = ""
-            pause_image = "k8s.gcr.io/pause:3.5"
-            pause_image_auth_file = ""
-            pause_command = "/pause"
-            signature_policy = ""
-            image_volumes = "mkdir"
-            big_files_temporary_dir = ""
-            [crio.network]
-            network_dir = "/etc/cni/net.d/"
-            plugin_dirs = [
-              "/opt/cni/bin",
-              "/usr/libexec/cni"
-            ]
-            [crio.metrics]
-            enable_metrics = true
-            metrics_port = 9090
-            metrics_socket = ""
         - path: /etc/yum.repos.d/kubernetes.repo
           owner: "root:root"
           permissions: "0744"
@@ -485,16 +476,14 @@ spec:
       preKubeadmCommands:
         - localectl set-locale LANG=en_US.UTF-8
         - localectl set-locale LANGUAGE=en_US.UTF-8
-        - dnf -y install epel-release dnf-plugins-core
-        - dnf config-manager --set-enabled baseos appstream extras epel epel-modular powertools 
         - dnf update -y
         - dnf -y install at jq unzip wget socat mtr firewalld
+        - sed -i '/swap/d' /etc/fstab
+        - swapoff -a
         - modprobe overlay && modprobe br_netfilter && sysctl --system
         - wget https://github.com/opencontainers/runc/releases/download/v1.0.3/runc.amd64 -O /usr/local/sbin/runc && chmod +x /usr/local/sbin/runc
         - wget https://github.com/containers/conmon/releases/download/v2.0.31/conmon-x86.zip -O conmon.zip && unzip conmon.zip -d conmon && mv conmon/bin/conmon /usr/local/bin/conmon && chmod +x /usr/local/bin/conmon && rm -rf conmon.zip conmon
-        - curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_8/devel:kubic:libcontainers:stable.repo
-        - curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:1.22.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:1.22/CentOS_8/devel:kubic:libcontainers:stable:cri-o:1.22.repo
-        - dnf -y install cri-o
+        - dnf -y module enable cri-o:1.22 && dnf -y install cri-o
         - wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.22.0/crictl-v1.22.0-linux-amd64.tar.gz && tar zxvf crictl-v1.22.0-linux-amd64.tar.gz -C /usr/local/bin && rm -f crictl-v1.22.0-linux-amd64.tar.gz
         - rm -f /etc/cni/net.d/100-crio-bridge.conf /etc/cni/net.d/200-loopback.conf
         - systemctl enable crio.service && systemctl daemon-reload && systemctl enable crio
@@ -504,8 +493,8 @@ spec:
         - echo 'source <(kubectl completion bash)' >>~/.bashrc
         - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
         - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
+        - dnf -y remove firewalld
         - dnf -y autoremove && dnf -y clean all
-
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
@@ -514,7 +503,7 @@ metadata:
 spec:
   clusterName: "${CLUSTER_NAME}"
   maxUnhealthy: 100%
-  nodeStartupTimeout: 10m
+  nodeStartupTimeout: 20m
   selector:
     matchLabels:
       nodepool: "${CLUSTER_NAME}-md-0"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature           New functionality.

**What this PR does / why we need it**:
aligns the changes from switching to fedora-35 in the packer image to the cloud-init templates. And adds some basic flags for better testing and enables the csr controller by default.

