### PR TITLE
:warning: Aligning naming convention to use the plural form on arrays

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -46,7 +46,7 @@ type HCloudMachineSpec struct {
 
 	// define Machine specific SSH keys, overrides cluster wide SSH keys
 	// +optional
-	SSHKey []SSHKeySpec `json:"sshKey,omitempty"`
+	SSHKey []SSHKeySpec `json:"sshKeys,omitempty"`
 
 	// +optional
 	PlacementGroupName *string `json:"placementGroupName,omitempty"`

--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -44,10 +44,10 @@ type HetznerClusterSpec struct {
 	// have a very low latency we could assume in some use-cases that a region is behaving like a zone
 	// https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone
 	// +kubebuilder:validation:MinItems=1
-	ControlPlaneRegion []Region `json:"controlPlaneRegion"`
+	ControlPlaneRegion []Region `json:"controlPlaneRegions"`
 
 	// define cluster wide SSH keys. Valid values are a valid SSH key name, or a valid ID.
-	SSHKey []SSHKeySpec `json:"sshKey,omitempty"`
+	SSHKey []SSHKeySpec `json:"sshKeys,omitempty"`
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint *clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
@@ -57,7 +57,7 @@ type HetznerClusterSpec struct {
 	ControlPlaneLoadBalancer LoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`
 
 	// +optional
-	HCloudPlacementGroupSpec []HCloudPlacementGroupSpec `json:"hcloudPlacementGroup,omitempty"`
+	HCloudPlacementGroupSpec []HCloudPlacementGroupSpec `json:"hcloudPlacementGroups,omitempty"`
 
 	// HetznerSecretRef is a reference to a token to be used when reconciling this cluster.
 	// This is generated in the Security section under API TOKENS. Read & Write is necessary.
@@ -101,7 +101,7 @@ type LoadBalancerSpec struct {
 
 	// Defines how traffic will be routed from the Load Balancer to your target server.
 	// +optional
-	Targets []LoadBalancerTargetSpec `json:"extraTarget,omitempty"`
+	Targets []LoadBalancerTargetSpec `json:"extraTargets,omitempty"`
 
 	Region Region `json:"region"`
 }
@@ -112,7 +112,7 @@ type LoadBalancerStatus struct {
 	IPv4       string `json:"ipv4,omitempty"`
 	IPv6       string `json:"ipv6,omitempty"`
 	InternalIP string `json:"internalIP,omitempty"`
-	Target     []int  `json:"target,omitempty"`
+	Target     []int  `json:"targets,omitempty"`
 	Protected  bool   `json:"protected,omitempty"`
 }
 
@@ -126,7 +126,7 @@ type HetznerClusterStatus struct {
 
 	ControlPlaneLoadBalancer *LoadBalancerStatus `json:"controlPlaneLoadBalancer,omitempty"`
 	// +optional
-	HCloudPlacementGroup []HCloudPlacementGroupStatus `json:"hcloudPlacementGroup,omitempty"`
+	HCloudPlacementGroup []HCloudPlacementGroupStatus `json:"hcloudPlacementGroups,omitempty"`
 	FailureDomains       clusterv1.FailureDomains     `json:"failureDomains,omitempty"`
 	Conditions           clusterv1.Conditions         `json:"conditions,omitempty"`
 }

--- a/api/v1beta1/network_types.go
+++ b/api/v1beta1/network_types.go
@@ -35,7 +35,7 @@ type HCloudNetworkSpec struct {
 type NetworkStatus struct {
 	ID             int               `json:"id,omitempty"`
 	Labels         map[string]string `json:"-"`
-	AttachedServer []int             `json:"attachedServer,omitempty"`
+	AttachedServer []int             `json:"attachedServers,omitempty"`
 }
 
 // Region is a Hetzner Location

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -42,7 +42,7 @@ type HCloudPlacementGroupSpec struct {
 // HCloudPlacementGroupStatus returns the status of a Placementgroup.
 type HCloudPlacementGroupStatus struct {
 	ID     int    `json:"id,omitempty"`
-	Server []int  `json:"server,omitempty"`
+	Server []int  `json:"servers,omitempty"`
 	Name   string `json:"name,omitempty"`
 	Type   string `json:"type,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -71,7 +71,7 @@ spec:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
                 type: string
-              sshKey:
+              sshKeys:
                 description: define Machine specific SSH keys, overrides cluster wide
                   SSH keys
                 items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -80,7 +80,7 @@ spec:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
                         type: string
-                      sshKey:
+                      sshKeys:
                         description: define Machine specific SSH keys, overrides cluster
                           wide SSH keys
                         items:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -86,7 +86,7 @@ spec:
                     description: Could be round_robin or least_connection. The default
                       value is "round_robin".
                     type: string
-                  extraTarget:
+                  extraTargets:
                     description: Defines how traffic will be routed from the Load
                       Balancer to your target server.
                     items:
@@ -141,7 +141,7 @@ spec:
                 required:
                 - region
                 type: object
-              controlPlaneRegion:
+              controlPlaneRegions:
                 description: ControlPlaneRegion consists of a list of HCloud Regions
                   (fsn, nbg, hel). Because HCloud Networks have a very low latency
                   we could assume in some use-cases that a region is behaving like
@@ -177,7 +177,7 @@ spec:
                 required:
                 - enabled
                 type: object
-              hcloudPlacementGroup:
+              hcloudPlacementGroups:
                 items:
                   description: HCloudPlacementGroupSpec defines a PlacementGroup.
                   properties:
@@ -208,7 +208,7 @@ spec:
                 - key
                 - name
                 type: object
-              sshKey:
+              sshKeys:
                 description: define cluster wide SSH keys. Valid values are a valid
                   SSH key name, or a valid ID.
                 items:
@@ -221,7 +221,7 @@ spec:
                   type: object
                 type: array
             required:
-            - controlPlaneRegion
+            - controlPlaneRegions
             - hetznerSecretRef
             type: object
           status:
@@ -287,7 +287,7 @@ spec:
                     type: string
                   protected:
                     type: boolean
-                  target:
+                  targets:
                     items:
                       type: integer
                     type: array
@@ -311,7 +311,7 @@ spec:
                   type: object
                 description: FailureDomains is a slice of FailureDomains.
                 type: object
-              hcloudPlacementGroup:
+              hcloudPlacementGroups:
                 items:
                   description: HCloudPlacementGroupStatus returns the status of a
                     Placementgroup.
@@ -320,7 +320,7 @@ spec:
                       type: integer
                     name:
                       type: string
-                    server:
+                    servers:
                       items:
                         type: integer
                       type: array
@@ -332,7 +332,7 @@ spec:
                 description: NetworkStatus defines the observed state of the HCloud
                   Private Network.
                 properties:
-                  attachedServer:
+                  attachedServers:
                     items:
                       type: integer
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -121,7 +121,7 @@ spec:
                             description: Could be round_robin or least_connection.
                               The default value is "round_robin".
                             type: string
-                          extraTarget:
+                          extraTargets:
                             description: Defines how traffic will be routed from the
                               Load Balancer to your target server.
                             items:
@@ -177,7 +177,7 @@ spec:
                         required:
                         - region
                         type: object
-                      controlPlaneRegion:
+                      controlPlaneRegions:
                         description: ControlPlaneRegion consists of a list of HCloud
                           Regions (fsn, nbg, hel). Because HCloud Networks have a
                           very low latency we could assume in some use-cases that
@@ -213,7 +213,7 @@ spec:
                         required:
                         - enabled
                         type: object
-                      hcloudPlacementGroup:
+                      hcloudPlacementGroups:
                         items:
                           description: HCloudPlacementGroupSpec defines a PlacementGroup.
                           properties:
@@ -246,7 +246,7 @@ spec:
                         - key
                         - name
                         type: object
-                      sshKey:
+                      sshKeys:
                         description: define cluster wide SSH keys. Valid values are
                           a valid SSH key name, or a valid ID.
                         items:
@@ -259,7 +259,7 @@ spec:
                           type: object
                         type: array
                     required:
-                    - controlPlaneRegion
+                    - controlPlaneRegions
                     - hetznerSecretRef
                     type: object
                 required:

--- a/templates/cluster-template-hcloud-network.yaml
+++ b/templates/cluster-template-hcloud-network.yaml
@@ -24,19 +24,19 @@ metadata:
 spec:
   hcloudNetwork:
     enabled: true
-  controlPlaneRegion: 
+  controlPlaneRegions: 
     - "${REGION}"
   controlPlaneEndpoint:
     host: ""
     port: 443
   controlPlaneLoadBalancer:
     region: "${REGION}"
-  hcloudPlacementGroup:
+  hcloudPlacementGroups:
   - name: control-plane
     type: spread
   - name: md-0
     type: spread
-  sshKey:
+  sshKeys:
   - name: "${SSH_KEY}"
   hetznerSecretRef:
     name: hetzner

--- a/templates/cluster-template-packer-hcloud-network.yaml
+++ b/templates/cluster-template-packer-hcloud-network.yaml
@@ -24,19 +24,19 @@ metadata:
 spec:
   hcloudNetwork:
     enabled: true
-  controlPlaneRegion: 
+  controlPlaneRegions: 
     - "${REGION}"
   controlPlaneEndpoint:
     host: ""
     port: 443
   controlPlaneLoadBalancer:
     region: "${REGION}"
-  hcloudPlacementGroup:
+  hcloudPlacementGroups:
   - name: control-plane
     type: spread
   - name: md-0
     type: spread
-  sshKey:
+  sshKeys:
   - name: "${SSH_KEY}"
   hetznerSecretRef:
     name: hetzner

--- a/templates/cluster-template-packer-talos.yaml
+++ b/templates/cluster-template-packer-talos.yaml
@@ -23,20 +23,20 @@ metadata:
   name: "${CLUSTER_NAME}"
 spec:
   hcloudNetwork:
-    enabled: true
-  controlPlaneRegion: 
+    enabled: false
+  controlPlaneRegions: 
     - "${REGION}"
   controlPlaneEndpoint:
     host: ""
     port: 443
   controlPlaneLoadBalancer:
     region: "${REGION}"
-  hcloudPlacementGroup:
+  hcloudPlacementGroups:
   - name: control-plane
     type: spread
   - name: md-0
     type: spread
-  sshKey:
+  sshKeys:
   - name: "${SSH_KEY}"
   hetznerSecretRef:
     name: hetzner
@@ -81,7 +81,7 @@ spec:
     spec:
       type: "${HETZNER_CONTROL_PLANE_MACHINE_TYPE}"
       imageName: "${IMAGE_NAME}"
-      placementGroup: control-plane
+      placementGroupName: control-plane
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
@@ -136,7 +136,7 @@ spec:
     spec:
       type: "${HETZNER_NODE_MACHINE_TYPE}"
       imageName: "${IMAGE_NAME}"
-      placementGroup: md-0
+      placementGroupName: md-0
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: TalosConfigTemplate

--- a/templates/cluster-template-packer.yaml
+++ b/templates/cluster-template-packer.yaml
@@ -24,19 +24,19 @@ metadata:
 spec:
   hcloudNetwork:
     enabled: false
-  controlPlaneRegion: 
+  controlPlaneRegions: 
     - "${REGION}"
   controlPlaneEndpoint:
     host: ""
     port: 443
   controlPlaneLoadBalancer:
     region: "${REGION}"
-  hcloudPlacementGroup:
+  hcloudPlacementGroups:
   - name: control-plane
     type: spread
   - name: md-0
     type: spread
-  sshKey:
+  sshKeys:
   - name: "${SSH_KEY}"
   hetznerSecretRef:
     name: hetzner

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -24,19 +24,19 @@ metadata:
 spec:
   hcloudNetwork:
     enabled: false
-  controlPlaneRegion: 
+  controlPlaneRegions: 
     - "${REGION}"
   controlPlaneEndpoint:
     host: ""
     port: 443
   controlPlaneLoadBalancer:
     region: "${REGION}"
-  hcloudPlacementGroup:
+  hcloudPlacementGroups:
   - name: control-plane
     type: spread
   - name: md-0
     type: spread
-  sshKey:
+  sshKeys:
   - name: "${SSH_KEY}"
   hetznerSecretRef:
     name: hetzner


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change        Adds, removes, or changes an API

**What this PR does / why we need it**:
Aligning the naming convention to use the plural form of a word if the type is an array.