### PR TITLE
:bug: Fix makefile envsubst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,25 +544,25 @@ install-manifests:
 .PHONY: create-workload-cluster
 create-workload-cluster-with-network-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
-	$(ENVSUBST) -i templates/cluster-template-packer-hcloud-network.yaml | kubectl apply -f -
+	cat templates/cluster-template-packer-hcloud-network.yaml | $(ENVSUBST) - | kubectl apply -f -
 	$(MAKE) wait-and-get-secret
 	$(MAKE) install-manifests PRIVATE_NETWORK=true
 
 create-workload-cluster-with-network: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
-	$(ENVSUBST) -i templates/cluster-template-hcloud-network.yaml | kubectl apply -f -
+	cat templates/cluster-template-hcloud-network.yaml | $(ENVSUBST) - | kubectl apply -f -
 	$(MAKE) wait-and-get-secret
 	$(MAKE) install-manifests PRIVATE_NETWORK=true
 
 create-workload-cluster-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
-	$(ENVSUBST) -i templates/cluster-template-packer.yaml | kubectl apply -f -
+	cat templates/cluster-template-packer.yaml | $(ENVSUBST) - | kubectl apply -f -
 	$(MAKE) wait-and-get-secret
 	$(MAKE) install-manifests PRIVATE_NETWORK=false
 
 create-workload-cluster: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
-	$(ENVSUBST) -i templates/cluster-template.yaml | kubectl apply -f -
+	cat templates/cluster-template.yaml | $(ENVSUBST) - | kubectl apply -f -
 	$(MAKE) wait-and-get-secret
 	$(MAKE) install-manifests PRIVATE_NETWORK=false
 
@@ -573,7 +573,7 @@ move-to-workload-cluster:
 
 create-talos-workload-cluster-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
-	$(ENVSUBST) -i templates/cluster-template-packer-talos.yaml | kubectl apply -f -
+	cat templates/cluster-template-packer-talos.yaml | $(ENVSUBST) - | kubectl apply -f -
 	$(MAKE) wait-and-get-secret
 	$(MAKE) install-manifests
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug               Fixes a newly discovered bug.

**What this PR does / why we need it**:
Fixing envsubst in Makefile for creating clusters. This bug was introduced by switching from https://github.com/a8m/envsubst to https://github.com/drone/envsubst