### PR TITLE
:bug: Adds a resolv.conf for the kubelet to omit the warning nameserver limit exceeded

### DIFF
--- a/templates/cluster-template-hcloud-network.yaml
+++ b/templates/cluster-template-hcloud-network.yaml
@@ -154,6 +154,7 @@ spec:
           event-qps: "5"
           rotate-server-certificates: "true"
           max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -168,6 +169,7 @@ spec:
           event-qps: "5"
           rotate-server-certificates: "true"
           max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
     files:
       - path: /etc/kubernetes/encryption-provider.yaml
         owner: "root:root"
@@ -274,6 +276,13 @@ spec:
           vm.overcommit_memory=1
           kernel.panic=10
           kernel.panic_on_oops=1
+      - path: /etc/kubernetes/resolv.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          nameserver 1.1.1.1
+          nameserver 1.0.0.1
+          nameserver 2606:4700:4700::1111
     preKubeadmCommands:
       - localectl set-locale LANG=en_US.UTF-8
       - localectl set-locale LANGUAGE=en_US.UTF-8
@@ -386,6 +395,7 @@ spec:
             event-qps: "5"
             rotate-server-certificates: "true"
             max-pods: "220"
+            resolv-conf: /etc/kubernetes/resolv.conf
       files:
         - path: /etc/systemd/system/sys-fs-bpf.mount
           owner: "root:root"
@@ -471,6 +481,13 @@ spec:
             vm.overcommit_memory=1
             kernel.panic=10
             kernel.panic_on_oops=1
+        - path: /etc/kubernetes/resolv.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            nameserver 1.1.1.1
+            nameserver 1.0.0.1
+            nameserver 2606:4700:4700::1111
       preKubeadmCommands:
         - localectl set-locale LANG=en_US.UTF-8
         - localectl set-locale LANGUAGE=en_US.UTF-8

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -153,6 +153,7 @@ spec:
           event-qps: "5"
           rotate-server-certificates: "true"
           max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -166,6 +167,7 @@ spec:
           event-qps: "5"
           rotate-server-certificates: "true"
           max-pods: "120"
+          resolv-conf: /etc/kubernetes/resolv.conf
     files:
       - path: /etc/kubernetes/encryption-provider.yaml
         owner: "root:root"
@@ -272,6 +274,13 @@ spec:
           vm.overcommit_memory=1
           kernel.panic=10
           kernel.panic_on_oops=1
+      - path: /etc/kubernetes/resolv.conf
+        owner: "root:root"
+        permissions: "0744"
+        content: |
+          nameserver 1.1.1.1
+          nameserver 1.0.0.1
+          nameserver 2606:4700:4700::1111
     preKubeadmCommands:
       - localectl set-locale LANG=en_US.UTF-8
       - localectl set-locale LANGUAGE=en_US.UTF-8
@@ -383,6 +392,7 @@ spec:
             event-qps: "5"
             rotate-server-certificates: "true"
             max-pods: "220"
+            resolv-conf: /etc/kubernetes/resolv.conf
       files:
         - path: /etc/systemd/system/sys-fs-bpf.mount
           owner: "root:root"
@@ -468,6 +478,13 @@ spec:
             vm.overcommit_memory=1
             kernel.panic=10
             kernel.panic_on_oops=1
+        - path: /etc/kubernetes/resolv.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            nameserver 1.1.1.1
+            nameserver 1.0.0.1
+            nameserver 2606:4700:4700::1111
       preKubeadmCommands:
         - localectl set-locale LANG=en_US.UTF-8
         - localectl set-locale LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
**What type of PR is this?**

/kind bug               Fixes a newly discovered bug.

**What this PR does / why we need it**:
Adds a resolv.conf for the kubelet to prevent the warning "nameserver limit exceeded"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #77 
