### PR TITLE
:bug: Fix bug in fake CreateServer

### DIFF
--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -319,7 +319,7 @@ func (c *cacheHCloudClient) CreateServer(ctx context.Context, opts hcloud.Server
 	}
 
 	for _, network := range opts.Networks {
-		server.PrivateNet = append(server.PrivateNet, hcloud.ServerPrivateNet{IP: network.IPRange.IP})
+		server.PrivateNet = append(server.PrivateNet, hcloud.ServerPrivateNet{IP: c.networkCache.idMap[network.ID].IPRange.IP})
 	}
 
 	// Add server to cache


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The network that is inputted into CreateServer only contains an ID.
Despite that, we used the pointer to IP range in the CreateServer
function of the fake HCloudClient. This fix switches to the cached
information about networks instead. Nil pointer errors can therefore
 be avoided.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

