### PR TITLE
:seedling: Refactor/rename network enabled

### DIFF
--- a/api/v1beta1/hetznercluster_webhook.go
+++ b/api/v1beta1/hetznercluster_webhook.go
@@ -72,7 +72,7 @@ func (r *HetznerCluster) ValidateCreate() error {
 	var allErrs field.ErrorList
 
 	// Check whether regions are all in same network zone
-	if !r.Spec.HCloudNetwork.NetworkEnabled {
+	if !r.Spec.HCloudNetwork.Enabled {
 		if err := isNetworkZoneSameForAllRegions(r.Spec.ControlPlaneRegions, nil); err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -116,7 +116,7 @@ func (r *HetznerCluster) ValidateUpdate(old runtime.Object) error {
 	}
 
 	// Check if all regions are in the same network zone if a private network is enabled
-	if oldC.Spec.HCloudNetwork.NetworkEnabled {
+	if oldC.Spec.HCloudNetwork.Enabled {
 		var defaultNetworkZone *string
 		if len(oldC.Spec.ControlPlaneRegions) > 0 {
 			str := regionNetworkZoneMap[string(oldC.Spec.ControlPlaneRegions[0])]

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -154,8 +154,8 @@ type LoadBalancerStatus struct {
 
 // HCloudNetworkSpec defines the desired state of the HCloud Private Network.
 type HCloudNetworkSpec struct {
-	// NetworkEnabled defines whether the network should be enabled or not
-	NetworkEnabled bool `json:"enabled"`
+	// Enabled defines whether the network should be enabled or not
+	Enabled bool `json:"enabled"`
 
 	// CIDRBlock defines the cidrBlock of the HCloud Network. A Subnet is required.
 	// +kubebuilder:default="10.0.0.0/16"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -168,8 +168,8 @@ spec:
                       A Subnet is required.
                     type: string
                   enabled:
-                    description: NetworkEnabled defines whether the network should
-                      be enabled or not
+                    description: Enabled defines whether the network should be enabled
+                      or not
                     type: boolean
                   networkZone:
                     default: eu-central

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -205,8 +205,8 @@ spec:
                               Network. A Subnet is required.
                             type: string
                           enabled:
-                            description: NetworkEnabled defines whether the network
-                              should be enabled or not
+                            description: Enabled defines whether the network should
+                              be enabled or not
                             type: boolean
                           networkZone:
                             default: eu-central

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -125,7 +125,7 @@ func getDefaultHetznerClusterSpec() infrav1.HetznerClusterSpec {
 		ControlPlaneRegions:  []infrav1.Region{"fsn1"},
 		HCloudNetwork: infrav1.HCloudNetworkSpec{
 			CIDRBlock:       "10.0.0.0/16",
-			NetworkEnabled:  true,
+			Enabled:         true,
 			NetworkZone:     "eu-central",
 			SubnetCIDRBlock: "10.0.0.0/24",
 		},

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -278,7 +278,7 @@ var _ = Describe("VsphereMachineReconciler", func() {
 
 		Context("without network", func() {
 			BeforeEach(func() {
-				infraCluster.Spec.HCloudNetwork.NetworkEnabled = false
+				infraCluster.Spec.HCloudNetwork.Enabled = false
 				Expect(testEnv.Create(ctx, infraCluster)).To(Succeed())
 				Expect(testEnv.Create(ctx, infraMachine)).To(Succeed())
 			})

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -351,7 +351,7 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 		data := make(map[string][]byte)
 		data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HCloudToken] = hetznerToken
 		// Save network ID in secret
-		if clusterScope.HetznerCluster.Spec.HCloudNetwork.NetworkEnabled {
+		if clusterScope.HetznerCluster.Spec.HCloudNetwork.Enabled {
 			data["network"] = []byte(strconv.Itoa(clusterScope.HetznerCluster.Status.Network.ID))
 		}
 		// Save api server information

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -599,7 +599,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 		)
 
 		hetznerClusterSpecWithDisabledNetwork := getDefaultHetznerClusterSpec()
-		hetznerClusterSpecWithDisabledNetwork.HCloudNetwork.NetworkEnabled = false
+		hetznerClusterSpecWithDisabledNetwork.HCloudNetwork.Enabled = false
 		hetznerClusterSpecWithoutNetwork := getDefaultHetznerClusterSpec()
 		hetznerClusterSpecWithoutNetwork.HCloudNetwork = infrav1.HCloudNetworkSpec{}
 

--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -47,7 +47,7 @@ func NewService(scope *scope.ClusterScope) *Service {
 
 // Reconcile implements life cycle of networks.
 func (s *Service) Reconcile(ctx context.Context) (err error) {
-	if !s.scope.HetznerCluster.Spec.HCloudNetwork.NetworkEnabled {
+	if !s.scope.HetznerCluster.Spec.HCloudNetwork.Enabled {
 		conditions.MarkFalse(s.scope.HetznerCluster, infrav1.NetworkAttached, infrav1.NetworkDisabledReason, clusterv1.ConditionSeverityInfo, "")
 		return nil
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
We have a double naming here: HCloudNetwork.NetworkEnabled instead of Enabled.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

