### PR TITLE
:seedling: Define HCloudClient centrally in tests

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/controllers"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,9 +50,10 @@ func TestControllers(t *testing.T) {
 }
 
 var (
-	testEnv *helpers.TestEnvironment
-	ctx     = ctrl.SetupSignalHandler()
-	wg      sync.WaitGroup
+	testEnv      *helpers.TestEnvironment
+	hcloudClient hcloudclient.Client
+	ctx          = ctrl.SetupSignalHandler()
+	wg           sync.WaitGroup
 )
 
 var _ = BeforeSuite(func() {
@@ -59,6 +61,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 
 	testEnv = helpers.NewTestEnvironment()
+	hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 
 	wg.Add(1)
 

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -169,10 +169,8 @@ var _ = Describe("VsphereMachineReconciler", func() {
 		})
 
 		It("creates the HCloud machine in Hetzner", func() {
-			hcc := testEnv.HCloudClientFactory.NewClient("")
-
 			Eventually(func() bool {
-				servers, err := hcc.ListServers(ctx, hcloud.ServerListOpts{
+				servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(infraCluster.Name): "owned"}),
 					},
@@ -194,7 +192,7 @@ var _ = Describe("VsphereMachineReconciler", func() {
 			}, timeout, time.Second).Should(BeNil())
 
 			Eventually(func() int {
-				servers, err := hcc.ListServers(ctx, hcloud.ServerListOpts{
+				servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(infraCluster.Name): "owned"}),
 					},
@@ -284,9 +282,8 @@ var _ = Describe("VsphereMachineReconciler", func() {
 			})
 
 			It("creates the HCloud machine in Hetzner", func() {
-				hcc := testEnv.HCloudClientFactory.NewClient("")
 				Eventually(func() int {
-					servers, err := hcc.ListServers(ctx, hcloud.ServerListOpts{
+					servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 						ListOpts: hcloud.ListOpts{
 							LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(infraCluster.Name): "owned"}),
 						},
@@ -308,9 +305,8 @@ var _ = Describe("VsphereMachineReconciler", func() {
 			})
 
 			It("creates the HCloud machine in Hetzner", func() {
-				hcc := testEnv.HCloudClientFactory.NewClient("")
 				Eventually(func() int {
-					servers, err := hcc.ListServers(ctx, hcloud.ServerListOpts{
+					servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 						ListOpts: hcloud.ListOpts{
 							LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(infraCluster.Name): "owned"}),
 						},

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -212,9 +212,8 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			}, timeout).Should(BeNil())
 
 			// Check in hetzner API
-			hcc := testEnv.HCloudClientFactory.NewClient("")
 			Eventually(func() error {
-				loadBalancers, err := hcc.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
+				loadBalancers, err := hcloudClient.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 					},
@@ -253,7 +252,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			}, timeout).Should(BeNil())
 
 			Eventually(func() int {
-				loadBalancers, err := hcc.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
+				loadBalancers, err := hcloudClient.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 					},
@@ -287,7 +286,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			}, timeout).Should(BeNil())
 
 			Eventually(func() int {
-				loadBalancers, err := hcc.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
+				loadBalancers, err := hcloudClient.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 					},
@@ -315,7 +314,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			}, timeout).Should(BeNil())
 
 			Eventually(func() int {
-				loadBalancers, err := hcc.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
+				loadBalancers, err := hcloudClient.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 					},
@@ -422,10 +421,9 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			}, timeout).Should(BeTrue())
 
 			By("checking for presence of HCloudMachine objects")
-			hcc := testEnv.HCloudClientFactory.NewClient("")
 			// Check if machines have been created
 			Eventually(func() int {
-				servers, err := hcc.ListServers(ctx, hcloud.ServerListOpts{
+				servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 					ListOpts: hcloud.ListOpts{
 						LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 					},
@@ -524,10 +522,9 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 				}, timeout).Should(BeTrue())
 
 				By("checking for presence of HCloudPlacementGroup objects")
-				hcc := testEnv.HCloudClientFactory.NewClient("")
 				// Check if placement groups have been created
 				Eventually(func() int {
-					pgs, err := hcc.ListPlacementGroups(ctx, hcloud.PlacementGroupListOpts{
+					pgs, err := hcloudClient.ListPlacementGroups(ctx, hcloud.PlacementGroupListOpts{
 						ListOpts: hcloud.ListOpts{
 							LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 						},
@@ -568,8 +565,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 					Expect(ph.Patch(ctx, instance, patch.WithStatusObservedGeneration{})).To(Succeed())
 
 					Eventually(func() int {
-						hcc := testEnv.HCloudClientFactory.NewClient("")
-						pgs, err := hcc.ListPlacementGroups(ctx, hcloud.PlacementGroupListOpts{
+						pgs, err := hcloudClient.ListPlacementGroups(ctx, hcloud.PlacementGroupListOpts{
 							ListOpts: hcloud.ListOpts{
 								LabelSelector: utils.LabelsToLabelSelector(map[string]string{infrav1.ClusterTagKey(instance.Name): "owned"}),
 							},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Defining HCloudClient centrally in controller_suite_test is more efficient than always using the HCloudClientFactory to create HCloudClients in individual tests.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

