### PR TITLE
:book: removing clusterctl override as we are now a official provider integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ CI_KIND ?= true
 #
 # Binaries.
 #
-MINIMUM_CLUSTERCTL_VERSION=1.1.0				# https://github.com/kubernetes-sigs/cluster-api/releases
+MINIMUM_CLUSTERCTL_VERSION=1.1.1				# https://github.com/kubernetes-sigs/cluster-api/releases
 MINIMUM_CTLPTL_VERSION=0.7.4						# https://github.com/tilt-dev/ctlptl/releases
-MINIMUM_GO_VERSION=go$(GO_VERSION)						# Check current project go version
+MINIMUM_GO_VERSION=go$(GO_VERSION)			# Check current project go version
 MINIMUM_HCLOUD_VERSION=1.29.0						# https://github.com/hetznercloud/cli/releases
 MINIMUM_HELMFILE_VERSION=v0.143.0				# https://github.com/roboll/helmfile/releases
 MINIMUM_KIND_VERSION=v0.11.1						# https://github.com/kubernetes-sigs/kind/releases
@@ -54,7 +54,7 @@ MINIMUM_KUBECTL_VERSION=v1.23.0					# https://github.com/kubernetes/kubernetes/r
 MINIMUM_PACKER_VERSION=1.7.10						# https://github.com/hashicorp/packer/releases
 MINIMUM_TILT_VERSION=0.24.1							# https://github.com/tilt-dev/tilt/releases
 CONTROLLER_GEN_VERSION=v.0.4.1					# https://github.com/kubernetes-sigs/controller-tools/releases
-KUSTOMIZE_VERSION=4.5.1								# https://github.com/kubernetes-sigs/kustomize/releases
+KUSTOMIZE_VERSION=4.5.1									# https://github.com/kubernetes-sigs/kustomize/releases
 
 #
 # Tooling Binaries.

--- a/docs/topics/quickstart.md
+++ b/docs/topics/quickstart.md
@@ -12,9 +12,9 @@ It is a common practice to create a temporary, local bootstrap cluster which is 
 ## Choose one of the options below:
 
 ### 1. Existing Management Cluster.
-    For production use-cases a “real” Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place. The Kubernetes cluster must be at least v1.22.1.
+For production use-cases a “real” Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place. The Kubernetes cluster must be at least v1.22.1.
 ### 2. Kind. 
-    kind can be used for creating a local Kubernetes cluster for development environments or for the creation of a temporary bootstrap cluster used to provision a target management cluster on the selected infrastructure provider.
+kind can be used for creating a local Kubernetes cluster for development environments or for the creation of a temporary bootstrap cluster used to provision a target management cluster on the selected infrastructure provider.
 
     
 ## Install clusterctl
@@ -26,19 +26,8 @@ or use: `make install-clusterctl`
 ## Initialize the management cluster
 Now that we’ve got clusterctl installed and all the prerequisites in place, let’s transform the Kubernetes cluster into a management cluster by using `clusterctl init`. More informations about clusterctl can be found [here](https://cluster-api.sigs.k8s.io/clusterctl/commands/commands.html).
 
-### Deploying the hetzner provider
-The recommended method is using Clusterctl.
-#### Register the hetzner provider 
-$HOME/.cluster-api/clusterctl.yaml
 
-```
-providers:
-  - name: "hetzner"
-    url: "https://github.com/syself/cluster-api-provider-hetzner/releases/latest/infrastructure-components.yaml"
-    type: "InfrastructureProvider"
-```
-
-#### Initialization of cluster-api provider hetzner
+### Initialization of the cluster-api components
 
 For the latest version:
 ```shell
@@ -105,7 +94,7 @@ Required Variables:
 Optional Variables:
   - CLUSTER_NAME                 (defaults to my-cluster)
   - CONTROL_PLANE_MACHINE_COUNT  (defaults to 1)
-  - KUBERNETES_VERSION           (defaults to 1.21.1)
+  - KUBERNETES_VERSION           
   - WORKER_MACHINE_COUNT         (defaults to 1)
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation  

**What this PR does / why we need it**:
This removes the need of defining a local clusterctl override file for using this provider integration. 
Since clusterctl v1.1.1 we are official supported and could be used by `clusterctl init --infrastructure hetzner` 
