### PR TITLE
:seedling: Use conditions for unready control planes

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -43,6 +43,8 @@ const (
 	InstanceHasNonExistingPlacementGroupReason = "InstanceHasNonExistingPlacementGroup"
 	// InstanceHasNoValidSSHKeyReason instance has no valid ssh key.
 	InstanceHasNoValidSSHKeyReason = "InstanceHasNoValidSSHKey"
+	// InstanceAsControlPlaneUnreachableReason control plane is (not yet) reachable.
+	InstanceAsControlPlaneUnreachableReason = "InstanceAsControlPlaneUnreachable"
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use conditions instead of error messages to mark control plane as not
ready when no connection to API server could be established.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

