### PR TITLE
:seedling: revert k8s version of kindest/node

### DIFF
--- a/hack/kind-dev.sh
+++ b/hack/kind-dev.sh
@@ -17,7 +17,7 @@
 set -o errexit
 set -o pipefail
 
-K8S_VERSION=v1.23.4
+K8S_VERSION=v1.23.3
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}" || exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind other           

**What this PR does / why we need it**:
Reverts k8s version of kindest/node from v1.23.4 to v1.23.3, because it's not published yet.