### PR TITLE
:sparkles: New secret management with caching and finalizers

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -62,3 +62,12 @@ const (
 	// PlacementGroupsUnreachableReason indicates that network is disabled.
 	PlacementGroupsUnreachableReason = "PlacementGroupsUnreachable"
 )
+
+const (
+	// HetznerClusterReady reports on whether the Hetzner cluster is in ready state.
+	HetznerClusterReady clusterv1.ConditionType = "HetznerClusterReady"
+	// HetznerSecretUnreachableReason indicates that Hetzner secret is unreachable.
+	HetznerSecretUnreachableReason = "HetznerSecretUnreachable" // #nosec
+	// HCloudCredentialsInvalidReason indicates that credentials for HCloud are invalid.
+	HCloudCredentialsInvalidReason = "HCloudCredentialsInvalid" // #nosec
+)

--- a/pkg/secrets/error.go
+++ b/pkg/secrets/error.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretutil
+
+import (
+	"fmt"
+)
+
+// ResolveSecretRefError is returned when the  secret
+// for a host is defined but cannot be found.
+type ResolveSecretRefError struct {
+	Message string
+}
+
+func (e ResolveSecretRefError) Error() string {
+	return fmt.Sprintf("Secret doesn't exist %s",
+		e.Message)
+}
+
+// HCloudTokenValidationError is returned when the HCloud token in Hetzner secret is invalid.
+type HCloudTokenValidationError struct{}
+
+func (e HCloudTokenValidationError) Error() string {
+	return "hcloud token cannot be an empty string"
+}

--- a/pkg/secrets/label.go
+++ b/pkg/secrets/label.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secretutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+const (
+	// LabelEnvironmentName is used as key of the label for secrets that should be included in cache.
+	LabelEnvironmentName = "caph.environment"
+	// LabelEnvironmentValue is the value of the label for secrets that should be included in cache.
+	LabelEnvironmentValue = "owned"
+)
+
+// AddSecretSelector adds a selector to a cache.SelectorsByObject that filters
+// Secrets so that only those labelled as part of the environment get
+// cached. The input may be nil.
+func AddSecretSelector(selectors cache.SelectorsByObject) cache.SelectorsByObject {
+	secret := &corev1.Secret{}
+	newSelectors := cache.SelectorsByObject{
+		secret: {
+			Label: labels.SelectorFromSet(
+				labels.Set{
+					LabelEnvironmentName: LabelEnvironmentValue,
+				}),
+		},
+	}
+	if selectors == nil {
+		return newSelectors
+	}
+	selectors[secret] = newSelectors[secret]
+	return selectors
+}

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package secretutil contains functions to manage secrets and strategies to manage secret cache.
+package secretutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// SecretFinalizer is the finalizer for secrets.
+	SecretFinalizer = infrav1.ClusterFinalizer + "/secret"
+)
+
+// SecretManager is a type for fetching Secrets whether or not they are in the
+// client cache, labelling so that they will be included in the client cache,
+// and optionally setting an owner reference.
+type SecretManager struct {
+	log       logr.Logger
+	client    client.Client
+	apiReader client.Reader
+}
+
+// NewSecretManager returns a new SecretManager.
+func NewSecretManager(log logr.Logger, cacheClient client.Client, apiReader client.Reader) *SecretManager {
+	return &SecretManager{
+		log:       log.WithName("secret_manager"),
+		client:    cacheClient,
+		apiReader: apiReader,
+	}
+}
+
+// claimSecret ensures that the Secret has a label that will ensure it is
+// present in the cache (and that we can watch for changes), and optionally
+// that it has a particular owner reference.
+func (sm *SecretManager) claimSecret(ctx context.Context, secret *corev1.Secret, owner client.Object, ownerIsController, addFinalizer bool) error {
+	log := sm.log.WithValues("secret", secret.Name, "secretNamespace", secret.Namespace)
+	needsUpdate := false
+	if !metav1.HasLabel(secret.ObjectMeta, LabelEnvironmentName) {
+		log.Info("setting secret environment label")
+		metav1.SetMetaDataLabel(&secret.ObjectMeta, LabelEnvironmentName, LabelEnvironmentValue)
+		needsUpdate = true
+	}
+	if owner != nil {
+		ownerLog := log.WithValues(
+			"ownerKind", owner.GetObjectKind().GroupVersionKind().Kind,
+			"owner", owner.GetNamespace()+"/"+owner.GetName(),
+			"ownerUID", owner.GetUID())
+		if ownerIsController {
+			if !metav1.IsControlledBy(secret, owner) {
+				ownerLog.Info("setting secret controller reference")
+				if err := controllerutil.SetControllerReference(owner, secret, sm.client.Scheme()); err != nil {
+					return errors.Wrap(err, "failed to set secret controller reference")
+				}
+				needsUpdate = true
+			}
+		} else {
+			alreadyOwned := false
+			ownerUID := owner.GetUID()
+			for _, ref := range secret.GetOwnerReferences() {
+				if ref.UID == ownerUID {
+					alreadyOwned = true
+					break
+				}
+			}
+			if !alreadyOwned {
+				ownerLog.Info("setting secret owner reference")
+				if err := controllerutil.SetOwnerReference(owner, secret, sm.client.Scheme()); err != nil {
+					return errors.Wrap(err, "failed to set secret owner reference")
+				}
+				needsUpdate = true
+			}
+		}
+	}
+
+	if addFinalizer && !utils.StringInList(secret.Finalizers, SecretFinalizer) {
+		log.Info("setting secret finalizer")
+		secret.Finalizers = append(secret.Finalizers, SecretFinalizer)
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if err := sm.client.Update(ctx, secret); err != nil {
+			return errors.Wrap(err, fmt.Sprintf("failed to update secret %s in namespace %s", secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+		}
+	}
+
+	return nil
+}
+
+// AcquireSecret retrieves a Secret and ensures that it has a label that will
+// ensure it is present in the cache (and that we can watch for changes), and
+// that it has a particular owner reference. The owner reference may optionally
+// be a controller reference.
+func (sm *SecretManager) AcquireSecret(ctx context.Context, key types.NamespacedName, owner client.Object, ownerIsController, addFinalizer bool) (*corev1.Secret, error) {
+	if owner == nil {
+		panic("AcquireSecret called with no owner")
+	}
+
+	secret := &corev1.Secret{}
+
+	// Look for secret in the filtered cache
+	err := sm.client.Get(ctx, key, secret)
+	if err == nil {
+		return secret, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Secret not in cache; check API directly for unlabelled Secret
+	err = sm.apiReader.Get(ctx, key, secret)
+	if err != nil {
+		return nil, err
+	}
+
+	err = sm.claimSecret(ctx, secret, owner, ownerIsController, addFinalizer)
+
+	return secret, err
+}
+
+// ReleaseSecret removes secrets manager finalizer from specified secret when needed.
+func (sm *SecretManager) ReleaseSecret(ctx context.Context, secret *corev1.Secret) error {
+	if !utils.StringInList(secret.Finalizers, SecretFinalizer) {
+		return nil
+	}
+
+	// Remove finalizer from secret to allow deletion
+	secret.Finalizers = utils.FilterStringFromList(
+		secret.Finalizers, SecretFinalizer)
+
+	if err := sm.client.Update(ctx, secret); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to remove finalizer from secret %s in namespace %s",
+			secret.ObjectMeta.Name, secret.ObjectMeta.Namespace))
+	}
+
+	sm.log.Info("removed secret finalizer",
+		"remaining", secret.Finalizers)
+
+	return nil
+}

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -201,13 +201,14 @@ func (c *cacheHCloudClient) AttachLoadBalancerToNetwork(ctx context.Context, lb 
 	}
 
 	// Check if network exists
-	if _, found := c.networkCache.idMap[opts.Network.ID]; !found {
+	network, found := c.networkCache.idMap[opts.Network.ID]
+	if !found {
 		return nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
 
 	// check if already exists
 	for _, s := range c.loadBalancerCache.idMap[lb.ID].PrivateNet {
-		if s.IP.Equal(opts.Network.IPRange.IP) {
+		if s.IP.Equal(network.IPRange.IP) {
 			return nil, fmt.Errorf("already added")
 		}
 	}
@@ -215,7 +216,7 @@ func (c *cacheHCloudClient) AttachLoadBalancerToNetwork(ctx context.Context, lb 
 	// Add it
 	c.loadBalancerCache.idMap[lb.ID].PrivateNet = append(
 		c.loadBalancerCache.idMap[lb.ID].PrivateNet,
-		hcloud.LoadBalancerPrivateNet{IP: opts.Network.IPRange.IP},
+		hcloud.LoadBalancerPrivateNet{IP: network.IPRange.IP},
 	)
 	return &hcloud.Action{}, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -110,6 +110,28 @@ func DifferenceOfIntSlices(a, b []int) (onlyInA []int, onlyInB []int) {
 	return
 }
 
+// StringInList returns a boolean indicating whether strToSearch is a
+// member of the string slice passed as the first argument.
+func StringInList(list []string, strToSearch string) bool {
+	for _, item := range list {
+		if item == strToSearch {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterStringFromList produces a new string slice that does not
+// include the strToFilter argument.
+func FilterStringFromList(list []string, strToFilter string) (newList []string) {
+	for _, item := range list {
+		if item != strToFilter {
+			newList = append(newList, item)
+		}
+	}
+	return
+}
+
 // GenerateName takes a name as string pointer. It returns name if pointer is not nil, otherwise it returns fallback with random suffix.
 func GenerateName(name *string, fallback string) string {
 	if name != nil {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -94,3 +94,23 @@ var _ = Describe("DifferenceOfIntSlices", func() {
 		Entry("entry3", []int{1, 2}, nil, []int{1, 2}, nil),
 		Entry("entry4", nil, []int{1, 2}, nil, []int{1, 2}))
 })
+
+var _ = Describe("StringInList", func() {
+	DescribeTable("Test string in list",
+		func(list []string, str string, expectedOutcome bool) {
+			out := utils.StringInList(list, str)
+			Expect(out).To(Equal(expectedOutcome))
+		},
+		Entry("entry1", []string{"a", "b", "c"}, "a", true),
+		Entry("entry2", []string{"a", "b", "c"}, "d", false))
+})
+
+var _ = Describe("FilterStringFromList", func() {
+	DescribeTable("Test filter string from list",
+		func(list []string, str string, expectedOutcome []string) {
+			out := utils.FilterStringFromList(list, str)
+			Expect(out).To(Equal(expectedOutcome))
+		},
+		Entry("entry1", []string{"a", "b", "c"}, "a", []string{"b", "c"}),
+		Entry("entry2", []string{"a", "b", "c"}, "d", []string{"a", "b", "c"}))
+})

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -28,6 +28,7 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	fakeclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -120,6 +122,9 @@ func NewTestEnvironment() *TestEnvironment {
 		Port:               env.WebhookInstallOptions.LocalServingPort,
 		CertDir:            env.WebhookInstallOptions.LocalServingCertDir,
 		MetricsBindAddress: "0",
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: secretutil.AddSecretSelector(nil),
+		}),
 	})
 	if err != nil {
 		klog.Fatalf("unable to create manager: %s", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduces a central way to handle secrets with two functions in pkg folder to acquire and release a secret. This means that from now on the finalizer will be set on secrets that are relevant to certain objects like HetznerCluster. 

Additionally, the cache of the manager is changed, so that it does not include all secrets from the beginning on. Instead, only relevant secrets are included via specific labels which are set. 

As there are some tests failing because the HetznerCluster object is not deleted properly, the tests manually remove the finalizer and delete the secret. This should be investigated in the future. 
 
**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

