### PR TITLE
:bug: Remove finalizers from certain secrets

### DIFF
--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -152,7 +152,7 @@ func (s *ClusterScope) ClientConfig(ctx context.Context) (clientcmd.ClientConfig
 	}
 
 	secretManager := secretutil.NewSecretManager(*s.Logger, s.Client, s.APIReader)
-	kubeconfigSecret, err := secretManager.AcquireSecret(ctx, cluster, s.HetznerCluster, false, s.HetznerCluster.DeletionTimestamp.IsZero())
+	kubeconfigSecret, err := secretManager.AcquireSecret(ctx, cluster, s.HetznerCluster, false, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to acquire secret")
 	}

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -146,7 +146,7 @@ func (m *MachineScope) GetRawBootstrapData(ctx context.Context) ([]byte, error) 
 
 	key := types.NamespacedName{Namespace: m.Namespace(), Name: *m.Machine.Spec.Bootstrap.DataSecretName}
 	secretManager := secretutil.NewSecretManager(*m.Logger, m.Client, m.APIReader)
-	secret, err := secretManager.AcquireSecret(ctx, key, m.HCloudMachine, false, m.HCloudMachine.DeletionTimestamp.IsZero())
+	secret, err := secretManager.AcquireSecret(ctx, key, m.HCloudMachine, false, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to acquire secret")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
With the secret manager we introduced finalizers on secrets. These are
currently set everywhere. However, this introduces some issues as it
requires to remove those finalizers in the delete process again. As we 
don't do this currently, the secrets do not get deleted at all.

Instead, we now do not set the finalizers on bootstrap secret and kubeconfig. 
secret.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

