### PR TITLE
:seedling: Add prefix to hostnames

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -29,6 +29,9 @@ const (
 	// resources associated with HCloudMachine before removing it from the
 	// apiserver.
 	MachineFinalizer = "hcloudmachine.infrastructure.cluster.x-k8s.io"
+
+	// HCloudHostNamePrefix is a prefix for all hostNames of hcloud servers.
+	HCloudHostNamePrefix = "hcloud-"
 )
 
 // HCloudMachineSpec defines the desired state of HCloudMachine.

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -32,6 +32,9 @@ const (
 	// BareMetalMachineFinalizer allows Reconcilehetznerbaremetalmachine to clean up resources associated with hetznerbaremetalmachine before
 	// removing it from the apiserver.
 	BareMetalMachineFinalizer = "hetznerbaremetalmachine.infrastructure.cluster.x-k8s.io"
+
+	// BareMetalHostNamePrefix is a prefix for all hostNames of bare metal servers.
+	BareMetalHostNamePrefix = "robot-"
 )
 
 var errUnknownSuffix = errors.New("unknown suffix")

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -95,7 +95,7 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 	var hcloudMachine infrav1.HCloudMachine
 	err = r.mCluster.Get(ctx, types.NamespacedName{
 		Namespace: r.mCluster.Namespace(),
-		Name:      strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix),
+		Name:      strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix+infrav1.HCloudHostNamePrefix),
 	}, &hcloudMachine)
 
 	if err == nil {
@@ -106,11 +106,11 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 		var bmMachine infrav1.HetznerBareMetalMachine
 		if err := r.mCluster.Get(ctx, types.NamespacedName{
 			Namespace: r.mCluster.Namespace(),
-			Name:      strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix),
+			Name:      strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix+infrav1.BareMetalHostNamePrefix),
 		}, &bmMachine); err != nil {
 			log.Error(err, "found an error while getting machine - bm machine or hcloud machine", "namespacedName", req.NamespacedName,
 				"userName", certificateSigningRequest.Spec.Username,
-				"trimmedUserName", strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix),
+				"nodePrefix", nodePrefix,
 			)
 			return reconcile.Result{}, err
 		}

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -434,6 +434,15 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 		var immutable bool
 		data := make(map[string][]byte)
 		data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HCloudToken] = hetznerToken
+
+		// Save robot credentials if available
+		robotUserName, keyExists := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser]
+		if keyExists {
+			data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser] = robotUserName
+			robotPassword := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword]
+			data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword] = robotPassword
+		}
+
 		// Save network ID in secret
 		if clusterScope.HetznerCluster.Spec.HCloudNetwork.Enabled {
 			data["network"] = []byte(strconv.Itoa(clusterScope.HetznerCluster.Status.Network.ID))

--- a/pkg/services/baremetal/host/state_machine.go
+++ b/pkg/services/baremetal/host/state_machine.go
@@ -182,7 +182,7 @@ func (hsm *hostStateMachine) handleProvisioning() actionResult {
 	}
 
 	port := hsm.host.Spec.Status.SSHSpec.PortAfterInstallImage
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(hsm.host.Spec.ConsumerRef.Name, &port)
+	actResult := hsm.reconciler.actionEnsureCorrectBoot(infrav1.BareMetalHostNamePrefix+hsm.host.Spec.ConsumerRef.Name, &port)
 	if _, ok := actResult.(actionComplete); ok {
 		actResult := hsm.reconciler.actionProvisioning()
 		if _, ok := actResult.(actionComplete); ok {
@@ -200,7 +200,7 @@ func (hsm *hostStateMachine) handleEnsureProvisioned() actionResult {
 	}
 
 	port := hsm.host.Spec.Status.SSHSpec.PortAfterCloudInit
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(hsm.host.Spec.ConsumerRef.Name, &port)
+	actResult := hsm.reconciler.actionEnsureCorrectBoot(infrav1.BareMetalHostNamePrefix+hsm.host.Spec.ConsumerRef.Name, &port)
 	if _, ok := actResult.(actionComplete); ok {
 		actResult := hsm.reconciler.actionEnsureProvisioned()
 		if _, ok := actResult.(actionComplete); ok {
@@ -220,9 +220,12 @@ func (hsm *hostStateMachine) handleProvisioned() actionResult {
 }
 
 func (hsm *hostStateMachine) handleDeprovisioning() actionResult {
-	hsm.reconciler.actionDeprovisioning()
-	hsm.nextState = infrav1.StateAvailable
-	return actionComplete{}
+	actResult := hsm.reconciler.actionDeprovisioning()
+	if _, ok := actResult.(actionComplete); ok {
+		hsm.nextState = infrav1.StateAvailable
+		return actionComplete{}
+	}
+	return actResult
 }
 
 func (hsm *hostStateMachine) provisioningCancelled() bool {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -181,7 +181,7 @@ func (s *Service) createServer(ctx context.Context, failureDomain string) (*hclo
 		return nil, errors.Wrap(err, "failed to get server image")
 	}
 
-	name := s.scope.Name()
+	name := infrav1.HCloudHostNamePrefix + s.scope.Name()
 	automount := false
 	startAfterCreate := true
 	opts := hcloud.ServerCreateOpts{

--- a/templates/cluster-template-baremetal.yaml
+++ b/templates/cluster-template-baremetal.yaml
@@ -531,3 +531,27 @@ spec:
   maintenanceMode: false
   description: Test Machine 0
   hetznerClusterRef: "${CLUSTER_NAME}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "${CLUSTER_NAME}-md-1"
+spec:
+  serverID: ${BAREMETAL_SERVER_1_ID}
+  rootDeviceHints:
+    wwn: ${BAREMETAL_SERVER_1_WWN}
+  maintenanceMode: false
+  description: Test Machine 1
+  hetznerClusterRef: "${CLUSTER_NAME}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "${CLUSTER_NAME}-md-2"
+spec:
+  serverID: ${BAREMETAL_SERVER_2_ID}
+  rootDeviceHints:
+    wwn: ${BAREMETAL_SERVER_2_WWN}
+  maintenanceMode: false
+  description: Test Machine 2
+  hetznerClusterRef: "${CLUSTER_NAME}"


### PR DESCRIPTION
**What type of PR is this?**
/kind other

**What this PR does / why we need it**:
Add a prefix to hostnames to let the cloud controller manager
differentiate bare metal and cloud servers. Update server name in robot
API accordingly.

Small fixes: Add robot credentials into secret for target cluster, add
three host servers in cluster template

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

