### PR TITLE
:seedling: Remove host logic from individual clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ test/e2e/data/infrastructure-hetzner/v1beta1/env*
 /tilt.d
 tilt-settings.json
 tilt_config.json
-
+baremetalhosts.yaml
 
 # kubeconfigs
 kind.kubeconfig
@@ -67,3 +67,4 @@ __pycache__/
 *.py[cod]
 *$py.class
 /_output
+

--- a/Tiltfile
+++ b/Tiltfile
@@ -28,6 +28,7 @@ settings = {
         "HCLOUD_REGION": "fsn1",
         "CONTROL_PLANE_MACHINE_COUNT": "3",
         "WORKER_MACHINE_COUNT": "3",
+        "BM_WORKER_MACHINE_COUNT": "3",
         "KUBERNETES_VERSION": "v1.21.1",
         "HCLOUD_IMAGE_NAME": "test-image",
         "HCLOUD_CONTROL_PLANE_MACHINE_TYPE": "cpx31",
@@ -190,6 +191,11 @@ def caph():
     k8s_resource(
         objects = [
             "cluster-api-provider-hetzner-system:namespace",
+            "hetznerbaremetalhosts.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+            "hetznerbaremetalmachines.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+            "hetznerbaremetalmachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+            "hetznerbaremetalremediations.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+            "hetznerbaremetalremediationtemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
             "hcloudmachines.infrastructure.cluster.x-k8s.io:customresourcedefinition",
             "hcloudmachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
             "hetznerclusters.infrastructure.cluster.x-k8s.io:customresourcedefinition",
@@ -209,6 +215,19 @@ def caph():
         new_name = "caph-misc",
         labels = ["CAPH"],
     )
+
+    if os.path.exists('baremetalhosts.yaml'):
+        k8s_custom_deploy(
+            'baremetal-hosts',
+            deps=['caph-controller-manager', 'caph-misc'],
+            apply_cmd="kubectl apply -f baremetalhosts.yaml 1>&2",
+            delete_cmd="kubectl delete -f baremetalhosts.yaml")
+        k8s_resource(
+            'baremetal-hosts',
+            labels=['CAPH'],
+            resource_deps=['caph-controller-manager', 'caph-misc']
+        )
+
 
 def base64_encode(to_encode):
     encode_blob = local("echo '{}' | tr -d '\n' | base64 - | tr -d '\n'".format(to_encode), quiet = True)

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -95,11 +95,11 @@ const (
 	// StateNone means the state is unknown.
 	StateNone ProvisioningState = ""
 
-	// StateRegistering means we are checking if server exists in robot api and get hardware details.
-	StateRegistering ProvisioningState = "registering"
+	// StatePreparing means we are checking if server exists and prepare it.
+	StatePreparing ProvisioningState = "preparing"
 
-	// StateAvailable means the server is registered and waits for provisioning.
-	StateAvailable ProvisioningState = "available"
+	// StateRegistering means we are getting hardware details.
+	StateRegistering ProvisioningState = "registering"
 
 	// StateImageInstalling means we install a new image.
 	StateImageInstalling ProvisioningState = "image-installing"
@@ -115,6 +115,9 @@ const (
 
 	// StateDeprovisioning means we are removing all machine-specific information from host.
 	StateDeprovisioning ProvisioningState = "deprovisioning"
+
+	// StateDeleting means we are deleting the host.
+	StateDeleting ProvisioningState = "deleting"
 )
 
 // RebootType defines the reboot type of servers via Hetzner robot API.
@@ -159,10 +162,6 @@ type HetznerBareMetalHostSpec struct {
 	// +optional
 	Description string `json:"description,omitempty"`
 
-	// HetznerClusterRef is the name of the HetznerCluster object which is
-	// needed as some necessary information is stored there, e.g. the hrobot password
-	HetznerClusterRef string `json:"hetznerClusterRef"`
-
 	// Status contains all status information. DO NOT EDIT!!!
 	// +optional
 	Status ControllerGeneratedStatus `json:"status,omitempty"`
@@ -170,6 +169,10 @@ type HetznerBareMetalHostSpec struct {
 
 // ControllerGeneratedStatus contains all status information which is important to persist.
 type ControllerGeneratedStatus struct {
+	// HetznerClusterRef is the name of the HetznerCluster object which is
+	// needed as some necessary information is stored there, e.g. the hrobot password
+	HetznerClusterRef string `json:"hetznerClusterRef"`
+
 	// UserData holds the reference to the Secret containing the user
 	// data to be passed to the host before it boots.
 	// +optional
@@ -212,7 +215,8 @@ type ControllerGeneratedStatus struct {
 	ErrorCount int `json:"errorCount"`
 
 	// Information tracked by the provisioner.
-	ProvisioningState ProvisioningState `json:"provisioningState"`
+	// +optional
+	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
 
 	// the last error message reported by the provisioning subsystem.
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -107,11 +107,6 @@ spec:
                 description: Description is a human-entered text used to help identify
                   the host
                 type: string
-              hetznerClusterRef:
-                description: HetznerClusterRef is the name of the HetznerCluster object
-                  which is needed as some necessary information is stored there, e.g.
-                  the hrobot password
-                type: string
               maintenanceMode:
                 description: MaintenanceMode indicates that a machine is supposed
                   to be deprovisioned and won't be selected by any Hetzner bare metal
@@ -241,6 +236,11 @@ spec:
                           type: object
                         type: array
                     type: object
+                  hetznerClusterRef:
+                    description: HetznerClusterRef is the name of the HetznerCluster
+                      object which is needed as some necessary information is stored
+                      there, e.g. the hrobot password
+                    type: string
                   installImage:
                     description: InstallImage is the configuration which is used for
                       the autosetup configuration for installing an OS via InstallImage.
@@ -504,10 +504,9 @@ spec:
                     type: object
                 required:
                 - errorCount
-                - provisioningState
+                - hetznerClusterRef
                 type: object
             required:
-            - hetznerClusterRef
             - serverID
             type: object
           status:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -217,7 +217,7 @@ spec:
                 type: object
               providerID:
                 description: ProviderID will be the hetznerbaremetalmachine in ProviderID
-                  format (hetzner://<server-id>)
+                  format (hcloud://<server-id>)
                 type: string
               sshSpec:
                 description: SSHSpec gives a reference on the secret where SSH details

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -212,7 +212,7 @@ spec:
                         type: object
                       providerID:
                         description: ProviderID will be the hetznerbaremetalmachine
-                          in ProviderID format (hetzner://<server-id>)
+                          in ProviderID format (hcloud://<server-id>)
                         type: string
                       sshSpec:
                         description: SSHSpec gives a reference on the secret where

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -338,6 +338,8 @@ spec:
                     type: boolean
                   targets:
                     items:
+                      description: LoadBalancerTarget defines the target of a load
+                        balancer.
                       properties:
                         ip:
                           type: string

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -293,7 +293,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 				if err := testEnv.Get(ctx, hostKey, host); err != nil {
 					return false
 				}
-				return host.Spec.Status.ProvisioningState == infrav1.StateAvailable
+				return host.Spec.Status.ProvisioningState == infrav1.StateNone
 			}, timeout, time.Second).Should(BeTrue())
 		})
 

--- a/pkg/scope/baremetalhost.go
+++ b/pkg/scope/baremetalhost.go
@@ -63,9 +63,6 @@ func NewBareMetalHostScope(ctx context.Context, params BareMetalHostScopeParams)
 	if params.SSHClientFactory == nil {
 		return nil, errors.New("cannot create baremetal host scope without ssh client factory")
 	}
-	if params.RescueSSHSecret == nil {
-		return nil, errors.New("cannot create baremetal host scope without rescue ssh secret")
-	}
 	if params.SecretManager == nil {
 		return nil, errors.New("cannot create baremetal host scope without secret manager")
 	}

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -55,7 +55,7 @@ var _ = Describe("chooseHost", func() {
 				Namespace: defaultNamespace,
 			},
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -73,7 +73,7 @@ var _ = Describe("chooseHost", func() {
 				APIVersion: infrav1.GroupVersion.String(),
 			},
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -86,7 +86,7 @@ var _ = Describe("chooseHost", func() {
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			MaintenanceMode: true,
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -100,7 +100,7 @@ var _ = Describe("chooseHost", func() {
 		},
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -113,7 +113,7 @@ var _ = Describe("chooseHost", func() {
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
 				ErrorMessage:      "some error",
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -139,7 +139,7 @@ var _ = Describe("chooseHost", func() {
 		},
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -151,7 +151,7 @@ var _ = Describe("chooseHost", func() {
 		},
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -163,7 +163,7 @@ var _ = Describe("chooseHost", func() {
 		},
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -176,7 +176,7 @@ var _ = Describe("chooseHost", func() {
 		},
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}
@@ -190,7 +190,7 @@ var _ = Describe("chooseHost", func() {
 		Spec: infrav1.HetznerBareMetalHostSpec{
 			MaintenanceMode: true,
 			Status: infrav1.ControllerGeneratedStatus{
-				ProvisioningState: infrav1.StateAvailable,
+				ProvisioningState: infrav1.StateNone,
 			},
 		},
 	}

--- a/pkg/services/baremetal/host/action_result.go
+++ b/pkg/services/baremetal/host/action_result.go
@@ -63,6 +63,17 @@ func (r actionComplete) Result() (result reconcile.Result, err error) {
 	return
 }
 
+// deleteComplete is a result indicating that the deletion action has
+// completed, and that the resource has now been deleted.
+type deleteComplete struct {
+	actionComplete
+}
+
+func (r deleteComplete) Result() (result reconcile.Result, err error) {
+	// Don't requeue, since the CR has been successfully deleted
+	return
+}
+
 // actionError is a result indicating that an error occurred while attempting
 // to advance the current action, and that reconciliation should be retried.
 type actionError struct {

--- a/pkg/services/baremetal/host/state_machine_test.go
+++ b/pkg/services/baremetal/host/state_machine_test.go
@@ -85,23 +85,23 @@ var _ = Describe("updateSSHKey", func() {
 		},
 		Entry(
 			"nothing changed",
-			"1",                    // osSecretVersion string
-			"1",                    // rescueSecretVersion string
-			infrav1.StateAvailable, // currentState infrav1.ProvisioningState
-			actionComplete{},       // expectedActionResult actionResult
-			infrav1.StateAvailable, // expectedNextState infrav1.ProvisioningState
-			"1",                    // expectedOSSecretVersion string
-			"1",                    // expectedRescueSecretVersion string
+			"1",                      // osSecretVersion string
+			"1",                      // rescueSecretVersion string
+			infrav1.StateRegistering, // currentState infrav1.ProvisioningState
+			actionComplete{},         // expectedActionResult actionResult
+			infrav1.StateRegistering, // expectedNextState infrav1.ProvisioningState
+			"1",                      // expectedOSSecretVersion string
+			"1",                      // expectedRescueSecretVersion string
 		),
 		Entry(
 			"os secret changed - state available",
-			"0",                    // osSecretVersion string
-			"1",                    // rescueSecretVersion string
-			infrav1.StateAvailable, // currentState infrav1.ProvisioningState
-			actionComplete{},       // expectedActionResult actionResult
-			infrav1.StateAvailable, // expectedNextState infrav1.ProvisioningState
-			"1",                    // expectedOSSecretVersion string
-			"1",                    // expectedRescueSecretVersion string
+			"0",                      // osSecretVersion string
+			"1",                      // rescueSecretVersion string
+			infrav1.StateRegistering, // currentState infrav1.ProvisioningState
+			actionComplete{},         // expectedActionResult actionResult
+			infrav1.StateRegistering, // expectedNextState infrav1.ProvisioningState
+			"1",                      // expectedOSSecretVersion string
+			"1",                      // expectedRescueSecretVersion string
 		),
 		Entry(
 			"os secret changed - state provisioned",
@@ -135,13 +135,13 @@ var _ = Describe("updateSSHKey", func() {
 		),
 		Entry(
 			"rescue secret changed - state available",
-			"1",                    // osSecretVersion string
-			"0",                    // rescueSecretVersion string
-			infrav1.StateAvailable, // currentState infrav1.ProvisioningState
-			actionComplete{},       // expectedActionResult actionResult
-			infrav1.StateNone,      // expectedNextState infrav1.ProvisioningState
-			"1",                    // expectedOSSecretVersion string
-			"1",                    // expectedRescueSecretVersion string
+			"1",                      // osSecretVersion string
+			"0",                      // rescueSecretVersion string
+			infrav1.StateRegistering, // currentState infrav1.ProvisioningState
+			actionComplete{},         // expectedActionResult actionResult
+			infrav1.StateNone,        // expectedNextState infrav1.ProvisioningState
+			"1",                      // expectedOSSecretVersion string
+			"1",                      // expectedRescueSecretVersion string
 		),
 	)
 })

--- a/templates/cluster-template-baremetal-control-planes.yaml
+++ b/templates/cluster-template-baremetal-control-planes.yaml
@@ -519,39 +519,3 @@ spec:
             name: sshkey-name
             publicKey: ssh-publickey
             privateKey: ssh-privatekey
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-control-plane-0"
-spec:
-  serverID: ${BAREMETAL_SERVER_0_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_0_WWN}
-  maintenanceMode: false
-  description: Test Machine 0
-  hetznerClusterRef: "${CLUSTER_NAME}"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-control-plane-1"
-spec:
-  serverID: ${BAREMETAL_SERVER_1_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_1_WWN}
-  maintenanceMode: false
-  description: Test Machine 1
-  hetznerClusterRef: "${CLUSTER_NAME}"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-control-plane-2"
-spec:
-  serverID: ${BAREMETAL_SERVER_2_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_2_WWN}
-  maintenanceMode: false
-  description: Test Machine 2
-  hetznerClusterRef: "${CLUSTER_NAME}"

--- a/templates/cluster-template-baremetal.yaml
+++ b/templates/cluster-template-baremetal.yaml
@@ -323,6 +323,43 @@ spec:
       status: "False"
       timeout: 300s
 ---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  labels:
+    nodepool: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      failureDomain: "${HCLOUD_REGION}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: HCloudMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCloudMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      type: "${HCLOUD_WORKER_MACHINE_TYPE}"
+      imageName: "ubuntu-20.04"
+      placementGroupName: md-0
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -464,15 +501,156 @@ spec:
       status: "False"
       timeout: 300s
 ---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-1"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+            kubeconfig: /etc/kubernetes/kubelet.conf
+            authentication-token-webhook: "true"
+            authorization-mode: Webhook
+            anonymous-auth: "false"
+            read-only-port: "0"
+            event-qps: "5"
+            rotate-server-certificates: "true"
+            max-pods: "220"
+            resolv-conf: /etc/kubernetes/resolv.conf
+      files:
+        - path: /etc/systemd/system/sys-fs-bpf.mount
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            [Unit]
+            Description=Cilium BPF mounts
+            Documentation=https://docs.cilium.io/
+            DefaultDependencies=no
+            Before=local-fs.target umount.target
+            After=swap.target
+
+            [Mount]
+            What=bpffs
+            Where=/sys/fs/bpf
+            Type=bpf
+            Options=rw,nosuid,nodev,noexec,relatime,mode=700
+
+            [Install]
+            WantedBy=multi-user.target
+        - path: /etc/sysctl.d/99-cilium.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            net.ipv4.conf.lxc*.rp_filter = 0
+        - path: /etc/modules-load.d/crio.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            overlay
+            br_netfilter
+        - path: /etc/containerd/config.toml
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            version = 2
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+              runtime_type = "io.containerd.runc.v2"
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              SystemdCgroup = true
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun]
+              runtime_type = "io.containerd.runc.v2"
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun.options]
+              BinaryName = "crun"
+              Root = "/usr/local/sbin"
+              SystemdCgroup = true
+            [plugins."io.containerd.grpc.v1.cri".containerd]
+              default_runtime_name = "crun"
+            [plugins."io.containerd.runtime.v1.linux"]
+              runtime = "crun"
+              runtime_root = "/usr/local/sbin"
+        - path: /etc/sysctl.d/99-kubernetes-cri.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+            net.ipv4.ip_forward                 = 1
+        - path: /etc/sysctl.d/99-kubelet.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            vm.overcommit_memory=1
+            kernel.panic=10
+            kernel.panic_on_oops=1
+        - path: /etc/kubernetes/resolv.conf
+          owner: "root:root"
+          permissions: "0744"
+          content: |
+            nameserver 1.1.1.1
+            nameserver 1.0.0.1
+            nameserver 2606:4700:4700::1111
+      preKubeadmCommands:
+        - export CRUN=1.4.3
+        - export CONTAINERD=1.6.1
+        - export KUBERNETES_VERSION=1.23.4
+        - localectl set-locale LANG=en_US.UTF-8
+        - localectl set-locale LANGUAGE=en_US.UTF-8
+        - apt-get update -y
+        - apt-get -y install at jq unzip wget socat mtr logrotate apt-transport-https
+        - sed -i '/swap/d' /etc/fstab
+        - swapoff -a
+        - modprobe overlay && modprobe br_netfilter && sysctl --system
+        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz
+        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
+        - sha256sum --check cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
+        - tar --no-overwrite-dir -C / -xzf cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz
+        - rm -f cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
+        - wget https://github.com/containers/crun/releases/download/$CRUN/crun-$CRUN-linux-amd64 -O /usr/local/sbin/crun && chmod +x /usr/local/sbin/crun
+        - rm -f /etc/cni/net.d/10-containerd-net.conflist
+        - chmod -R 644 /etc/cni && chown -R root:root /etc/cni
+        - systemctl daemon-reload && systemctl enable containerd && systemctl start containerd
+        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+        - apt-get update
+        - apt-get install -y kubelet=$KUBERNETES_VERSION-00 kubeadm=$KUBERNETES_VERSION-00 kubectl=$KUBERNETES_VERSION-00  bash-completion && apt-mark hold kubelet kubectl kubeadm && systemctl enable kubelet
+        - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
+        - echo 'source <(kubectl completion bash)' >>~/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - apt-get -y autoremove && apt-get -y clean all
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-md-1-unhealthy-5m"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 20m
+  selector:
+    matchLabels:
+      nodepool: "${CLUSTER_NAME}-md-1"
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: "${CLUSTER_NAME}-md-0"
+  name: "${CLUSTER_NAME}-md-1"
   labels:
-    nodepool: "${CLUSTER_NAME}-md-0"
+    nodepool: "${CLUSTER_NAME}-md-1"
 spec:
   clusterName: "${CLUSTER_NAME}"
-  replicas: ${WORKER_MACHINE_COUNT}
+  replicas: ${BM_WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
   template:
@@ -481,18 +659,18 @@ spec:
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
-          name: "${CLUSTER_NAME}-md-0"
+          name: "${CLUSTER_NAME}-md-1"
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
       infrastructureRef:
-        name: "${CLUSTER_NAME}-md-0"
+        name: "${CLUSTER_NAME}-md-1"
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: HetznerBareMetalMachineTemplate
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalMachineTemplate
 metadata:
-  name: "${CLUSTER_NAME}-md-0"
+  name: "${CLUSTER_NAME}-md-1"
 spec:
   template:
     spec:
@@ -518,39 +696,3 @@ spec:
             name: sshkey-name
             publicKey: ssh-publickey
             privateKey: ssh-privatekey
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-md-0"
-spec:
-  serverID: ${BAREMETAL_SERVER_0_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_0_WWN}
-  maintenanceMode: false
-  description: Test Machine 0
-  hetznerClusterRef: "${CLUSTER_NAME}"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-md-1"
-spec:
-  serverID: ${BAREMETAL_SERVER_1_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_1_WWN}
-  maintenanceMode: false
-  description: Test Machine 1
-  hetznerClusterRef: "${CLUSTER_NAME}"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "${CLUSTER_NAME}-md-2"
-spec:
-  serverID: ${BAREMETAL_SERVER_2_ID}
-  rootDeviceHints:
-    wwn: ${BAREMETAL_SERVER_2_WWN}
-  maintenanceMode: false
-  description: Test Machine 2
-  hetznerClusterRef: "${CLUSTER_NAME}"

--- a/test/helpers/defaults.go
+++ b/test/helpers/defaults.go
@@ -88,7 +88,7 @@ func WithRootDeviceHints() HostOpts {
 // WithHetznerClusterRef gives the option to define a host with cluster ref.
 func WithHetznerClusterRef(hetznerClusterRef string) HostOpts {
 	return func(host *infrav1.HetznerBareMetalHost) {
-		host.Spec.HetznerClusterRef = hetznerClusterRef
+		host.Spec.Status.HetznerClusterRef = hetznerClusterRef
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As it makes more sense to have a separate host inventory, we remove the
reference to the Hetzner cluster from the host object. This requires
some changes in the states, as we cannot continue with pre-processing,
before a bare metal machine consumes a host. Now all information and
credentials come directly or indirectly from the bare metal machine.
Therefore, the host waits in StateNone until a consumer ref is set.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

