### PR TITLE
:bug: Fix reboot logic in host provisioning

### DIFF
--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -69,10 +69,6 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
-	if hbmMachine.Status.FailureMessage != nil {
-		log.Info("FailureMessage set", "failureMessage", hbmMachine.Status.FailureMessage)
-		return ctrl.Result{}, nil
-	}
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r.Client, hbmMachine.ObjectMeta)
 	if err != nil {

--- a/pkg/services/baremetal/host/state_machine.go
+++ b/pkg/services/baremetal/host/state_machine.go
@@ -172,13 +172,10 @@ func (hsm *hostStateMachine) handleRegistering() actionResult {
 		hsm.nextState = infrav1.StateDeprovisioning
 		return actionComplete{}
 	}
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(rescue, nil)
+
+	actResult := hsm.reconciler.actionRegistering()
 	if _, ok := actResult.(actionComplete); ok {
-		actResult := hsm.reconciler.actionRegistering()
-		if _, ok := actResult.(actionComplete); ok {
-			hsm.nextState = infrav1.StateImageInstalling
-		}
-		return actResult
+		hsm.nextState = infrav1.StateImageInstalling
 	}
 	return actResult
 }
@@ -189,16 +186,9 @@ func (hsm *hostStateMachine) handleImageInstalling() actionResult {
 		return actionComplete{}
 	}
 
-	// If the ssh reboot can be used, then only in the case where the server has been deprovisioned before
-	// and still uses the port after cloud init.
-	port := hsm.host.Spec.Status.SSHSpec.PortAfterCloudInit
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(rescue, &port)
+	actResult := hsm.reconciler.actionImageInstalling()
 	if _, ok := actResult.(actionComplete); ok {
-		actResult := hsm.reconciler.actionImageInstalling()
-		if _, ok := actResult.(actionComplete); ok {
-			hsm.nextState = infrav1.StateProvisioning
-		}
-		return actResult
+		hsm.nextState = infrav1.StateProvisioning
 	}
 	return actResult
 }
@@ -209,14 +199,9 @@ func (hsm *hostStateMachine) handleProvisioning() actionResult {
 		return actionComplete{}
 	}
 
-	port := hsm.host.Spec.Status.SSHSpec.PortAfterInstallImage
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(infrav1.BareMetalHostNamePrefix+hsm.host.Spec.ConsumerRef.Name, &port)
+	actResult := hsm.reconciler.actionProvisioning()
 	if _, ok := actResult.(actionComplete); ok {
-		actResult := hsm.reconciler.actionProvisioning()
-		if _, ok := actResult.(actionComplete); ok {
-			hsm.nextState = infrav1.StateEnsureProvisioned
-		}
-		return actResult
+		hsm.nextState = infrav1.StateEnsureProvisioned
 	}
 	return actResult
 }
@@ -227,14 +212,9 @@ func (hsm *hostStateMachine) handleEnsureProvisioned() actionResult {
 		return actionComplete{}
 	}
 
-	port := hsm.host.Spec.Status.SSHSpec.PortAfterCloudInit
-	actResult := hsm.reconciler.actionEnsureCorrectBoot(infrav1.BareMetalHostNamePrefix+hsm.host.Spec.ConsumerRef.Name, &port)
+	actResult := hsm.reconciler.actionEnsureProvisioned()
 	if _, ok := actResult.(actionComplete); ok {
-		actResult := hsm.reconciler.actionEnsureProvisioned()
-		if _, ok := actResult.(actionComplete); ok {
-			hsm.nextState = infrav1.StateProvisioned
-		}
-		return actResult
+		hsm.nextState = infrav1.StateProvisioned
 	}
 	return actResult
 }

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -181,11 +181,10 @@ func (s *Service) createServer(ctx context.Context, failureDomain string) (*hclo
 		return nil, errors.Wrap(err, "failed to get server image")
 	}
 
-	name := infrav1.HCloudHostNamePrefix + s.scope.Name()
 	automount := false
 	startAfterCreate := true
 	opts := hcloud.ServerCreateOpts{
-		Name:   name,
+		Name:   s.scope.Name(),
 		Labels: createLabels(s.scope.HetznerCluster.Name, s.scope.Name(), s.scope.IsControlPlane()),
 		Image:  image,
 		Location: &hcloud.Location{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The reboot logic in host provisioning had some logical errors. These
errors were quite small and mostly affected cases, where both the user
might have done something wrong, or a Hetzner reboot has not been
triggered. To implement a better fitting solution, the old function
actionEnsureCorrectBoot has been replaced and more logic is now in the
functions calling actionEnsureCorrectBoot before.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

