### PR TITLE
:sparkles: Handle stuck servers that do not switch on

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0  # https://github.com/golangci/golangci-lint/releases
+          version: v1.45.2  # https://github.com/golangci/golangci-lint/releases
           working-directory: ${{matrix.working-directory}}

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -41,8 +41,8 @@ const (
 	InstanceTerminatedReason = "InstanceTerminated"
 	// InstanceHasNonExistingPlacementGroupReason instance has a placement group name that does not exist.
 	InstanceHasNonExistingPlacementGroupReason = "InstanceHasNonExistingPlacementGroup"
-	// InstanceHasNoValidSSHKeyReason instance has no valid ssh key.
-	InstanceHasNoValidSSHKeyReason = "InstanceHasNoValidSSHKey"
+	// ServerOffReason instance is off.
+	ServerOffReason = "ServerOff"
 	// InstanceAsControlPlaneUnreachableReason control plane is (not yet) reachable.
 	InstanceAsControlPlaneUnreachableReason = "InstanceAsControlPlaneUnreachable"
 )

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -26,6 +26,7 @@ import (
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -100,6 +101,14 @@ func (m *MachineScope) Namespace() string {
 // PatchObject persists the machine spec and status.
 func (m *MachineScope) PatchObject(ctx context.Context) error {
 	return m.patchHelper.Patch(ctx, m.HCloudMachine)
+}
+
+// SetError sets the ErrorMessage and ErrorReason fields on the machine and logs
+// the message. It assumes the reason is invalid configuration, since that is
+// currently the only relevant MachineStatusError choice.
+func (m *MachineScope) SetError(message string, reason capierrors.MachineStatusError) {
+	m.HCloudMachine.Status.FailureMessage = &message
+	m.HCloudMachine.Status.FailureReason = &reason
 }
 
 // IsBootstrapDataReady checks the readiness of a capi machine's bootstrap data.

--- a/pkg/services/hcloud/server/server_suite_test.go
+++ b/pkg/services/hcloud/server/server_suite_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud/schema"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -205,3 +208,14 @@ var _ = BeforeSuite(func() {
 
 	server = hcloud.ServerFromSchema(serverSchema)
 })
+
+func newTestService(hcloudMachine *infrav1.HCloudMachine, hcloudClient hcloudclient.Client) *Service {
+	return &Service{
+		&scope.MachineScope{
+			HCloudMachine: hcloudMachine,
+			ClusterScope: scope.ClusterScope{
+				HCloudClient: hcloudClient,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
In HCloud, servers sometimes get stuck in status off. Even repeatedly
powering them on does not help. This commit introduces a logic that
makes sure, these servers get marked as failed after a certain timeout.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

