### PR TITLE
:sparkles: Handle rate limit errors in HCloud

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -71,3 +71,10 @@ const (
 	// HCloudCredentialsInvalidReason indicates that credentials for HCloud are invalid.
 	HCloudCredentialsInvalidReason = "HCloudCredentialsInvalid" // #nosec
 )
+
+const (
+	// RateLimitExceeded reports whether the rate limit has been reached.
+	RateLimitExceeded clusterv1.ConditionType = "RateLimitExceeded"
+	// RateLimitNotReachedReason indicates that the rate limit is not reached yet.
+	RateLimitNotReachedReason = "RateLimitNotReached"
+)

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers_test
+package controllers
 
 import (
 	"sync"
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	"github.com/syself/cluster-api-provider-hetzner/controllers"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +68,7 @@ var _ = BeforeSuite(func() {
 
 	wg.Add(1)
 
-	Expect((&controllers.HetznerClusterReconciler{
+	Expect((&HetznerClusterReconciler{
 		Client:                         testEnv.Manager.GetClient(),
 		APIReader:                      testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory:            testEnv.HCloudClientFactory,
@@ -77,7 +76,7 @@ var _ = BeforeSuite(func() {
 		TargetClusterManagersWaitGroup: &wg,
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
-	Expect((&controllers.HCloudMachineReconciler{
+	Expect((&HCloudMachineReconciler{
 		Client:              testEnv.Manager.GetClient(),
 		APIReader:           testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory: testEnv.HCloudClientFactory,

--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -138,6 +139,11 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			reterr = err
 		}
 	}()
+
+	// check whether rate limit has been reached and if so, then wait.
+	if wait := reconcileRateLimit(hcloudMachine); wait {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 
 	if !hcloudMachine.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, machineScope)

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers_test
+package controllers
 
 import (
 	"time"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We now wait for a fixed time if a rate limit error occurs while
reconciling a machine or the cluster object. The logic relies on
conditions, where RateLimitExceeded is set to true. The machine and
cluster controller requeue reconciling at the beginning for a fixed time
period, until the waiting time is over and the reconciling can start
again.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

