### PR TITLE
:seedling: Make lb spec required

### DIFF
--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -48,7 +48,6 @@ type HetznerClusterSpec struct {
 	ControlPlaneEndpoint *clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
 	// ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior. Naming convention is from upstream cluster-api project.
-	// +optional
 	ControlPlaneLoadBalancer LoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`
 
 	// +optional

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -168,6 +168,7 @@ type HCloudNetworkSpec struct {
 	SubnetCIDRBlock string `json:"subnetCidrBlock,omitempty"`
 
 	// NetworkZone specifies the HCloud network zone of the private network.
+	// +kubebuilder:validation:Enum=eu-central;us-east
 	// +kubebuilder:default=eu-central
 	// +optional
 	NetworkZone HCloudNetworkZone `json:"networkZone,omitempty"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -176,6 +176,9 @@ spec:
                     default: eu-central
                     description: NetworkZone specifies the HCloud network zone of
                       the private network.
+                    enum:
+                    - eu-central
+                    - us-east
                     type: string
                   subnetCidrBlock:
                     default: 10.0.0.0/24

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -212,6 +212,9 @@ spec:
                             default: eu-central
                             description: NetworkZone specifies the HCloud network
                               zone of the private network.
+                            enum:
+                            - eu-central
+                            - us-east
                             type: string
                           subnetCidrBlock:
                             default: 10.0.0.0/24


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Load balancer specs are required in cluster spec - remove the optional tag of kubebuilder.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

