### PR TITLE
:book: Add object references in docs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,7 @@
+## Object Reference
+
+In this object reference, we introduce all objects that are specific for this provider integration. The naming of objects, servers, machines, etc. can be confusing. Without claiming to be consistent throughout these docs, we would like to give an overview of how we name things here.
+
+First, there are some important counterparts of our objects and CAPI objects. ```HetznerCluster``` has CAPI's ```Cluster``` object. CAPI's ```Machine``` object is the counterpart of both ```HCloudMachine``` and ```HetznerBareMetalMachine```. These two are objects of the provider integration that are reconciled by the ```HCloudMachineController``` and the ```HetznerBareMetalMachineController``` respectively. The ```HCloudMachineController``` checks whether there is a server in the HCloud API already and if not, buys/creates one that corresponds to a ```HCloudMachine``` object. The ```HetznerBareMetalMachineController``` does not buy new bare metal machines, but instead consumes a host of the inventory of ```HetznerBareMetalHosts```, which have a one-to-one relationship to Hetzner dedicated/root/bare metal servers that have been bought manually by the user. 
+
+Therefore, there is an important difference between the ```HCloudMachine``` object and a server in the HCloud API. For bare metal, we have even three terms: the ```HetznerBareMetalMachine``` object, the ```HetznerBareMetalHost``` object, and the actual bare metal server that can be accessed through Hetzner's robot API.

--- a/docs/reference/hcloud-machine-template.md
+++ b/docs/reference/hcloud-machine-template.md
@@ -1,0 +1,15 @@
+## HCloudMachineTemplate
+
+In ```HCloudMachineTemplate``` you can define all important properties for ```HCloudMachines```. ```HCloudMachines``` are reconciled by the ```HCloudMachineController```, which creates and deletes servers in Hetzner Cloud. 
+
+### Overview of HCloudMachineTemplate.Spec
+| Key | Type | Default | Required | Description |
+|-----|-----|------|---------|-------------|
+| template.spec.providerID | string |  | no | ProviderID set by controller |
+| template.spec.type | string |  | yes | Desired server type of server in Hetzner's Cloud API. Example: cpx11 |
+| template.spec.imageName | string | | yes | Specifies desired image of server. ImageName can reference an image uploaded to Hetzner API in two ways: either directly as name of an image, or as label of an image (see [here](https://github.com/syself/cluster-api-provider-hetzner/blob/main/docs/topics/node-image.md) for more details) |
+| template.spec.sshKeys | object | | no | SSHKeys that are scoped to this machine |
+| template.spec.sshKeys.hcloud | []object | | no | SSH keys for HCloud |
+| template.spec.sshKeys.hcloud.name | string | | yes | Name of SSH key |
+| template.spec.sshKeys.hcloud.fingerprint | string | | no| Fingerprint of SSH key - used by the controller |
+| template.spec.placementGroupName | string | | no | Placement group of the machine in HCloud API, must be referencing an existing placement group |

--- a/docs/reference/hetzner-bare-metal-host.md
+++ b/docs/reference/hetzner-bare-metal-host.md
@@ -1,0 +1,27 @@
+## HetznerBareMetalHost
+
+The ```HetznerBareMetalHost``` object has a one-to-one relationship to a Hetzner dedicated server. Its ID is specified in the specs. The host object does not belong to a certain ```HetznerCluster```, but can be used by multiple clusters. This is useful, as one host object per server is enough and you can easily see whether a host is used by one of your clusters or not.
+
+ There are not many properties that are relevant for the host object. The WWN of the storage device that should be used for provisioning has to be specified in ```rootDeviceHints``` - but not right from the start. This property can be updated after the host started the provisioning phase and wrote all ```hardwareDetails``` in the host's status. From there, you can copy the WWN of the storage device that suits your needs. 
+
+### Lifecycle of a HetznerBareMetalHost
+
+A host object is available for consumption right after it has been created. When a ```HetznerBareMetalMachine``` chooses the host, it updates the host's status. This triggers the provisioning of the host. When the ```HetznerBareMetalMachine``` gets deleted, then the host deprovisions and returns to the state where it is available for new consumers.
+
+```HetznerBareMetalHosts``` can only be deleted when they are in the neutral state. In order to delete them, they should be first set to maintenance mode, so that no ```HetznerBareMetalMachine``` consumes it.
+
+Host objects cannot be updated and have to be deleted and re-created if some of the properties change. 
+
+#### Maintenance mode
+Maintenance mode means that the host will not be consumed by any ```HetznerBareMetalMachine```. If it is already consumed, then the corresponding ```HetznerBareMetalMachine``` will be deleted and the ```HetznerBareMetalHost``` deprovisioned. 
+
+### Overview of HetznerBareMetalHost.Spec
+| Key | Type | Default | Required | Description |
+|-----|-----|------|---------|-------------|
+| serverID | int | | yes | Server ID of the Hetzner dedicated server |
+| rootDeviceHints | object | | no | Important to find the correct root device. If none are specified, the host will stop provisioning in between to wait for the details to be specified. HardwareDetails in the host's status can be used to find the correct device. Currently, only WWN is supported |
+| rootDeviceHints.wwn | string | | yes | Unique storage identifier |
+| consumerRef | object | | no | Used by the controller and references the bare metal machine that consumes this host |
+| maintenanceMode | bool | | no | If set to true, the host deprovisions and will not be consumed by any bare metal machine |
+| description | string | | no | Description can be used to store some valuable information about this host |
+| status | object | | no | The controller writes this status. As there are some that cannot be regenerated during any reconcilement, the status is in the specs of the object - not the actual status. DO NOT EDIT!!! |

--- a/docs/reference/hetzner-bare-metal-machine-template.md
+++ b/docs/reference/hetzner-bare-metal-machine-template.md
@@ -1,0 +1,68 @@
+## HetznerBareMetalMachineTemplate
+
+In ```HetznerBareMetalMachineTemplate``` you can define all important properties for the ```HetznerBareMetalMachines```. ```HetznerBareMetalMachines``` are reconciled by the ```HetznerBareMetalMachineController```, which DOES NOT create or delete Hetzner dedicated machines. Instead, it uses the inventory of ```HetznerBareMetalHosts```. These hosts correspond to already existing bare metal servers, which get provisioned when selected by a ```HetznerBareMetalMachine```.
+
+### Lifecycle of a HetznerBareMetalMachine
+
+#### Creating of a HetznerBareMetalMachine
+Simply put, the specs of a ```HetznerBareMetalMachine``` consist of two parts. First, there is information about how the bare metal server is supposed to be provisioned. Second, there are properties where you can specify which host to select. If these selectors correspond to a host that is not consumed yet, then the ```HetznerBareMetalMachine``` transfers important information to the host object. This information is used to provision the host according to what you specified in the specs of ```HetznerBareMetalMachineTemplate```. If a host has provisioned successfully, then the ```HetznerBareMetalMachine``` is considered to be ready. 
+
+#### Deleting of a HetznerBareMetalMachine
+When the ```HetznerBareMetalMachine``` object gets deleted, it removes the information from the host that the latter used for provisioning. The host then triggers the deprovisioning. As soon as this has completed, the ```HetznerBareMetalMachineController``` removes the owner and consumer reference of the host and deletes the finalizer of the machine, so that it can be finally deleted. 
+
+#### Updating a HetznerBareMetalMachine
+Updating a ```HetznerBareMetalMachineTemplate``` is not possible. Instead, a new template should be created.
+
+## cloud-init and install-image
+Both in install-image and cloud-init the ports used for SSH can be changed, e.g. with the following code snippet:
+```
+sed -i -e '/^\(#\|\)Port/s/^.*$/Port 2223/' /etc/ssh/sshd_config
+```
+As the controller needs to know this to be able to successfully provision the server, these ports can be specified in ```SSHSpec``` of ```HetznerBareMetalMachineTemplate```.
+
+When the port is changed in cloud-init, then we additionally need to use the following command to make sure that the change of ports takes immediate effect: 
+```systemctl restart sshd``` 
+
+## Choosing the right host
+
+Via MatchLabels you can specify a certain label (key and value) that identifies the host. You get more flexibility with MatchExpressions. This allows decisions like "take any host that has the key "mykey" and let this key have either one of the values "val1", "val2", and "val3".
+
+### Overview of HetznerBareMetalMachineTemplate.Spec
+| Key | Type | Default | Required | Description |
+|-----|-----|------|---------|-------------|
+| template.spec.providerID | string |  | no | Provider ID set by controller |
+| template.spec.installImage | object | | yes | Configuration used in autosetup |
+| template.spec.installImage.image | object | | yes | Defines image for bm machine. Must specify either name and url, or a (local) path |
+| template.spec.installImage.image.url | string | | no | Remote URL of image. Can be tar, tar.gz, tar.bz, tar.bz2, tar.xz, tgz, tbz, txz |
+| template.spec.installImage.image.name | string | | no | Name of the image |
+| template.spec.installImage.image.path | string | | no | Local path of a pre-installed image |
+| template.spec.installImage.postInstallScript | string | | no | PostInstallScript that is used for commands that will be executed after install image |
+| template.spec.installImage.partitions | []object | | yes | Partitions that should be created in installimage |
+| template.spec.installImage.partitions.mount | string | | yes | Mount defines the mount path of the filesystem |
+| template.spec.installImage.partitions.fileSystem | string | | yes | Filesystem that should  be used. Can be ext2, ext3, ext4, btrfs, reiserfs, xfs, swap, or the name of the LVM volume group, if the partition is a VG|
+| template.spec.installImage.partitions.size | string | | yes | Size of the partition. Use 'all' to use all remaining space of the drive. M/G/T can be used as unit specifications for MiB, GiB, TiB |
+| template.spec.installImage.logicalVolumeDefinitions | []object | | no | Defines the logical volume definitions that should be created |
+| template.spec.installImage.logicalVolumeDefinitions.vg | string | | yes | Defines the vg name |
+| template.spec.installImage.logicalVolumeDefinitions.name | string | | yes | Defines the volume name |
+| template.spec.installImage.logicalVolumeDefinitions.mount | string | | yes | Defines the mount path |
+| template.spec.installImage.logicalVolumeDefinitions.fileSystem | string | | yes | Defines the file system |
+| template.spec.installImage.logicalVolumeDefinitions.size | string | | yes | Defines size with unit M/G/T or MiB/GiB/TiB |
+| template.spec.installImage.btrfsDefinitions | []object | | no | Defines the btrfs sub-volume definitions that should be created |
+| template.spec.installImage.btrfsDefinitions.volume | string | | yes | Defines the btrfs volume name |
+| template.spec.installImage.btrfsDefinitions.subvolume | string | | yes | Defines the btrfs sub-volume name |
+| template.spec.installImage.btrfsDefinitions.mount | string | | yes | Defines the btrfs mount path |
+| template.spec.hostSelector | object | | yes | Options to select hosts with |
+| template.spec.hostSelector.matchLabels | map[string][string] | | no | Specify labels as key-value pairs that should be there in host object to select it |
+| template.spec.hostSelector.matchExpressions | []object | | no | Requirements using Kubernetes MatchExpressions |
+| template.spec.hostSelector.matchExpressions.key | string | | yes | Key of label that should be matched in host object |
+| template.spec.hostSelector.matchExpressions.operator | string | | yes | [Selection operator](https://pkg.go.dev/k8s.io/apimachinery@v0.23.4/pkg/selection?utm_source=gopls#Operator) |
+| template.spec.hostSelector.matchExpressions.values | []string | | yes | Values whose relation to the label value in the host machine is defined by the selection operator |
+| template.spec.sshSpec | object | | yes | SSH specs |
+| template.spec.sshSpec.secretRef | object | | yes | Reference to the secret where SSH key is stored |
+| template.spec.sshSpec.secretRef.name | string | | yes | Name of the secret |
+| template.spec.sshSpec.secretRef.key | object | | yes | Details about the keys used in the data of the secret |
+| template.spec.sshSpec.secretRef.key.name | string | | yes | Name is the key in the secret's data where the SSH key's name is stored |
+| template.spec.template.spec.sshSpec.secretRef.key.publicKey | string | | yes | PublicKey is the key in the secret's data where the SSH key's public key is stored |
+| template.spec.sshSpec.secretRef.key.privateKey | string | | yes | PrivateKey is the key in the secret's data where the SSH key's private key is stored |
+| template.spec.sshSpec.portAfterInstallImage | int | 22 | no | PortAfterInstallImage specifies the port that can be used to reach the server via SSH after install image completed successfully |
+| template.spec.sshSpec.portAfterCloudInit | int | 22 (install image port) | no | PortAfterCloudInit specifies the port that can be used to reach the server via SSH after cloud init completed successfully |

--- a/docs/reference/hetzner-cluster.md
+++ b/docs/reference/hetzner-cluster.md
@@ -1,0 +1,48 @@
+## HetznerCluster
+
+In HetznerCluster you can define everything related to the general components of the cluster as well as those properties, which are valid cluster-wide.
+
+There are two different modes for the cluster. A pure HCloud cluster and a cluster that uses Hetzner dedicated (bare metal) servers, either as control planes or as workers. The HCloud cluster works with both Kubeadm and Talos and supports private networks. In a cluster that includes bare metal servers there are no private networks, as Hetzner dedicated does not support private networks. Since we rely on SSH, there is no support for Talos either. Apart from SSH, the node image has to support cloud-init, which we use to provision the bare metal machines. In cluster with bare metal servers, you need to use [this CCM](https://github.com/syself/hetzner-cloud-controller-manager), as the official one does not support bare metal.
+
+[Here](/docs/topics/managing-ssh-keys.md) you can find more information regarding the handling of SSH keys. Some of them are specified in ```HetznerCluster``` to have them cluster-wide, others are machine-scoped.
+
+
+### Overview of HetznerCluster.Spec
+| Key | Type | Default | Required | Description |
+|-----|-----|------|---------|-------------|
+| hcloudNetwork | object |  | no | Specifies details about Hetzner cloud private networks |
+| hcloudNetwork.enabled | bool |  | yes| States whether network should be enabled or disabled |
+| hcloudNetwork.cidrBlock | string | "10.0.0.0/16" | no | Defines the CIDR block |
+| hcloudNetwork.subnetCidrBlock | string | "10.0.0.0/24" | no | Defines the CIDR block of the subnet. Note that one subnet ist required |
+| hcloudNetwork.networkZone | string | "eu-central" | no | Defines the network zone. Must be eu-central or us-east |
+| controlPlaneRegions | []string | []string{fsn1} | no | This is the base for the failureDomains of the cluster |
+| sshKeys | object | | no | Cluster-wide SSH keys that serve as default for machines as well |
+| sshKeys.hcloud | []object | | no | SSH keys for hcloud |
+| sshKeys.hcloud.name | string | | yes | Name of SSH key |
+| sshKeys.hcloud.fingerprint | string | | no| Fingerprint of SSH key - used by the controller |
+| sshKeys.robotRescueSecretRef | object | | no | Reference to the secret where the SSH key for the rescue system is stored |
+| sshKeys.robotRescueSecretRef.name | string | | yes | Name of the secret |
+| sshKeys.robotRescueSecretRef.key | object | | yes | Details about the keys used in the data of the secret |
+| sshKeys.robotRescueSecretRef.key.name | string | | yes | Name is the key in the secret's data where the SSH key's name is stored |
+| template.spec.sshKeys.robotRescueSecretRef.key.publicKey | string | | yes | PublicKey is the key in the secret's data where the SSH key's public key is stored |
+| sshKeys.robotRescueSecretRef.key.privateKey | string | | yes | PrivateKey is the key in the secret's data where the SSH key's private key is stored |
+| controlPlaneEndpoint | object | | no | Set by the controller. It is the endpoint to communicate with the control plane |
+| controlPlaneEndpoint.host | string | | yes | Defines host |
+| controlPlaneEndpoint.port | int32 | | yes | Defines port |
+|controlPlaneLoadBalancer | object | | yes | Defines specs of load balancer |
+|controlPlaneLoadBalancer.name | string | | no | Name of load balancer |
+ |controlPlaneLoadBalancer.algorithm | string | round_robin | no | Type of load balancer algorithm. Either round_robin or least_connections |
+|controlPlaneLoadBalancer.type | string | lb11 | no | Type of load balancer. One of lb11, lb21, lb31 |
+|controlPlaneLoadBalancer.port| int | 6443 | no | Load balancer port. Must be in range 1-65535 |
+|controlPlaneLoadBalancer.extraServices| []object | | no | Defines extra services of load balancer |
+|controlPlaneLoadBalancer.extraServices.protocol | string | | yes | Defines protocol. Must be one of https, http, or tcp |
+|controlPlaneLoadBalancer.extraServices.listenPort | int | | yes | Defines listen port. Must be in range 1-65535 |
+|controlPlaneLoadBalancer.extraServices.destinationPort | int | | yes | Defines destination port. Must be in range 1-65535 |
+|HCloudPlacementGroup | []object | | no | List of placement groups that should be defined in Hetzner API | 
+|hcloudPlacementGroup.name | string | | yes | Name of placement group | 
+|HCloudPlacementGroup.type | string | type | no | Type of placement group. Hetzner only supports 'spread' | 
+| hetznerSecret | object |  | yes | Reference to secret where Hetzner API credentials are stored |
+| hetznerSecret.name | string |  | yes | Name of secret |
+| hetznerSecret.key | object |  | yes | Reference to the keys that are used in the secret |
+| hetznerSecret.key.hcloudToken | string |  | yes | Name of the key where the token for the Hetzner Cloud API is stored |
+

--- a/docs/topics/managing-ssh-keys.md
+++ b/docs/topics/managing-ssh-keys.md
@@ -1,0 +1,13 @@
+## Managing SSH keys
+
+### In Hetzner Cloud
+In pure HCloud clusters, without bare metal servers, there is no need for SSH keys. All keys that exist in HCloud API and are specified in ```HetznerCluster``` properties, are included when provisioning machines. Therefore, they can be used to access those machines via SSH. Note that you have to upload those keys via Hetzner UI or API beforehand. 
+
+The SSH keys can be either specified cluster-wide in the specs of the ```HetznerCluster``` object, or scoped to one machine in the specs of ```HCloudMachine```.
+
+If one SSH key is changed in the specs of the cluster, then keep in mind that the SSH key is still valid to access all servers that have been created with it. If it is a potential security vulnerability, then all of these servers should be removed and re-created with the new SSH keys.
+
+### In Hetzner Robot
+For bare metal servers, two SSH keys are required. One that is used for the rescue system, one for the actual system. The two can, under the hood, of course, be the same. These SSH keys do not have to be uploaded into Robot API, but have to be stored in two secrets (again, the same secret is also possible if the same reference is given twice). Not only the name of the SSH key, but also public and private key. The private key is necessary for provisioning the server with SSH. The SSH key for the actual system is specified in ```HetznerBareMetalMachineTemplate``` - there are no cluster-wide alternatives. The SSH key for the rescue system is defined in a cluster-wide manner in the specs of ```HetznerCluster```.
+
+The secret reference to a SSH key cannot be changed - the secret data, i.e. the SSH key, can. The host that is consumed by the ```HetznerBareMetalMachine``` object reacts in different ways on a change of the secret data of the secret that is referenced in its specs, depending on its provisioning state. If the host is already provisioned, it will emit an event warning that it is not possible for provisioned hosts to change SSH keys. The corresponding machine object should instead be deleted and recreated. When the host is provisioning, then it restarts this process again if a change of the SSH key makes it necessary. This depends on whether it is the SSH key for the rescue or the actual system and the exact provisioning state.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Add a reference for all important API objects in the /docs/reference
folder.

**TODOs**:
- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests

