### PR TITLE
:seedling: Bump latest released version for e2e

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -73,7 +73,7 @@ runs:
         MANIFEST_PATH: "../../../out"
         HCLOUD_TOKEN: ${{ env.HCLOUD_TOKEN }}
         SKIP_IMAGE_BUILD: "1"
-        CAPH_LATEST_VERSION: "v1.0.0-alpha.18"
+        CAPH_LATEST_VERSION: "v1.0.0-alpha.19"
       run: make ${{ inputs.e2e_make_target }}
     - name: Upload artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
**What type of PR is this?**

/kind other        

**What this PR does / why we need it**:
Follow-up for caph upgrade e2e test. Bumps to v1.0.0-alpha.19 


