### PR TITLE
:book: Documentation update (baremetalhost)

### DIFF
--- a/docs/reference/hetzner-bare-metal-host.md
+++ b/docs/reference/hetzner-bare-metal-host.md
@@ -1,27 +1,54 @@
 ## HetznerBareMetalHost
 
-The ```HetznerBareMetalHost``` object has a one-to-one relationship to a Hetzner dedicated server. Its ID is specified in the specs. The host object does not belong to a certain ```HetznerCluster```, but can be used by multiple clusters. This is useful, as one host object per server is enough and you can easily see whether a host is used by one of your clusters or not.
+The `HetznerBareMetalHost` object has a one-to-one relationship to a Hetzner dedicated server. Its ID is specified in the specs. The host object does not belong to a certain `HetznerCluster`, but can be used by multiple clusters. This is useful, as one host object per server is enough and you can easily see whether a host is used by one of your clusters or not.
 
- There are not many properties that are relevant for the host object. The WWN of the storage device that should be used for provisioning has to be specified in ```rootDeviceHints``` - but not right from the start. This property can be updated after the host started the provisioning phase and wrote all ```hardwareDetails``` in the host's status. From there, you can copy the WWN of the storage device that suits your needs. 
+There are not many properties that are relevant for the host object. The WWN of the storage device that should be used for provisioning has to be specified in `rootDeviceHints` - but not right from the start. This property can be updated after the host started the provisioning phase and wrote all `hardwareDetails` in the host's status. From there, you can copy the WWN of the storage device that suits your needs and add it to your `HetznerBareMetalHost` object.
+
+#### Find the WWN
+
+After you have started the provisioning, run the following on your management cluster to find the `hardwareDetails` of all of your bare metal hosts.
+
+```shell
+kubectl describe hetznerbaremetalhost
+```
 
 ### Lifecycle of a HetznerBareMetalHost
 
-A host object is available for consumption right after it has been created. When a ```HetznerBareMetalMachine``` chooses the host, it updates the host's status. This triggers the provisioning of the host. When the ```HetznerBareMetalMachine``` gets deleted, then the host deprovisions and returns to the state where it is available for new consumers.
+A host object is available for consumption right after it has been created. When a `HetznerBareMetalMachine` chooses the host, it updates the host's status. This triggers the provisioning of the host. When the `HetznerBareMetalMachine` gets deleted, then the host deprovisions and returns to the state where it is available for new consumers.
 
-```HetznerBareMetalHosts``` can only be deleted when they are in the neutral state. In order to delete them, they should be first set to maintenance mode, so that no ```HetznerBareMetalMachine``` consumes it.
+`HetznerBareMetalHosts` can only be deleted when they are in the neutral state. In order to delete them, they should be first set to maintenance mode, so that no `HetznerBareMetalMachine` consumes it.
 
-Host objects cannot be updated and have to be deleted and re-created if some of the properties change. 
+Host objects cannot be updated and have to be deleted and re-created if some of the properties change.
 
 #### Maintenance mode
-Maintenance mode means that the host will not be consumed by any ```HetznerBareMetalMachine```. If it is already consumed, then the corresponding ```HetznerBareMetalMachine``` will be deleted and the ```HetznerBareMetalHost``` deprovisioned. 
+
+Maintenance mode means that the host will not be consumed by any `HetznerBareMetalMachine`. If it is already consumed, then the corresponding `HetznerBareMetalMachine` will be deleted and the `HetznerBareMetalHost` deprovisioned.
 
 ### Overview of HetznerBareMetalHost.Spec
-| Key | Type | Default | Required | Description |
-|-----|-----|------|---------|-------------|
-| serverID | int | | yes | Server ID of the Hetzner dedicated server |
-| rootDeviceHints | object | | no | Important to find the correct root device. If none are specified, the host will stop provisioning in between to wait for the details to be specified. HardwareDetails in the host's status can be used to find the correct device. Currently, only WWN is supported |
-| rootDeviceHints.wwn | string | | yes | Unique storage identifier |
-| consumerRef | object | | no | Used by the controller and references the bare metal machine that consumes this host |
-| maintenanceMode | bool | | no | If set to true, the host deprovisions and will not be consumed by any bare metal machine |
-| description | string | | no | Description can be used to store some valuable information about this host |
-| status | object | | no | The controller writes this status. As there are some that cannot be regenerated during any reconcilement, the status is in the specs of the object - not the actual status. DO NOT EDIT!!! |
+
+| Key                 | Type   | Default | Required | Description                                                                                                                                                                                                                                                         |
+| ------------------- | ------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| serverID            | int    |         | yes      | Server ID of the Hetzner dedicated server, you can find it on your Hetzner robot dashboard                                                                                                                                                                          |
+| rootDeviceHints     | object |         | no       | Important to find the correct root device. If none are specified, the host will stop provisioning in between to wait for the details to be specified. HardwareDetails in the host's status can be used to find the correct device. Currently, only WWN is supported |
+| rootDeviceHints.wwn | string |         | yes      | Unique storage identifier                                                                                                                                                                                                                                           |
+| consumerRef         | object |         | no       | Used by the controller and references the bare metal machine that consumes this host                                                                                                                                                                                |
+| maintenanceMode     | bool   |         | no       | If set to true, the host deprovisions and will not be consumed by any bare metal machine                                                                                                                                                                            |
+| description         | string |         | no       | Description can be used to store some valuable information about this host                                                                                                                                                                                          |
+| status              | object |         | no       | The controller writes this status. As there are some that cannot be regenerated during any reconcilement, the status is in the specs of the object - not the actual status. DO NOT EDIT!!!                                                                          |
+
+### Example of the HetznerBareMetalHost object
+
+You should create one of these objects for each of your bare metal servers that you want to use for your deployment.
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-0" #example
+spec:
+  serverID: 1682566 #change
+  rootDeviceHints:
+    wwn: "eui.0068475201b4egh2" #change
+  maintenanceMode: false
+  description: Test Machine 0 #example
+```

--- a/docs/reference/hetzner-bare-metal-machine-template.md
+++ b/docs/reference/hetzner-bare-metal-machine-template.md
@@ -1,68 +1,75 @@
 ## HetznerBareMetalMachineTemplate
 
-In ```HetznerBareMetalMachineTemplate``` you can define all important properties for the ```HetznerBareMetalMachines```. ```HetznerBareMetalMachines``` are reconciled by the ```HetznerBareMetalMachineController```, which DOES NOT create or delete Hetzner dedicated machines. Instead, it uses the inventory of ```HetznerBareMetalHosts```. These hosts correspond to already existing bare metal servers, which get provisioned when selected by a ```HetznerBareMetalMachine```.
+In `HetznerBareMetalMachineTemplate` you can define all important properties for the `HetznerBareMetalMachines`. `HetznerBareMetalMachines` are reconciled by the `HetznerBareMetalMachineController`, which DOES NOT create or delete Hetzner dedicated machines. Instead, it uses the inventory of `HetznerBareMetalHosts`. These hosts correspond to already existing bare metal servers, which get provisioned when selected by a `HetznerBareMetalMachine`.
 
 ### Lifecycle of a HetznerBareMetalMachine
 
 #### Creating of a HetznerBareMetalMachine
-Simply put, the specs of a ```HetznerBareMetalMachine``` consist of two parts. First, there is information about how the bare metal server is supposed to be provisioned. Second, there are properties where you can specify which host to select. If these selectors correspond to a host that is not consumed yet, then the ```HetznerBareMetalMachine``` transfers important information to the host object. This information is used to provision the host according to what you specified in the specs of ```HetznerBareMetalMachineTemplate```. If a host has provisioned successfully, then the ```HetznerBareMetalMachine``` is considered to be ready. 
+
+Simply put, the specs of a `HetznerBareMetalMachine` consist of two parts. First, there is information about how the bare metal server is supposed to be provisioned. Second, there are properties where you can specify which host to select. If these selectors correspond to a host that is not consumed yet, then the `HetznerBareMetalMachine` transfers important information to the host object. This information is used to provision the host according to what you specified in the specs of `HetznerBareMetalMachineTemplate`. If a host has provisioned successfully, then the `HetznerBareMetalMachine` is considered to be ready.
 
 #### Deleting of a HetznerBareMetalMachine
-When the ```HetznerBareMetalMachine``` object gets deleted, it removes the information from the host that the latter used for provisioning. The host then triggers the deprovisioning. As soon as this has completed, the ```HetznerBareMetalMachineController``` removes the owner and consumer reference of the host and deletes the finalizer of the machine, so that it can be finally deleted. 
+
+When the `HetznerBareMetalMachine` object gets deleted, it removes the information from the host that the latter used for provisioning. The host then triggers the deprovisioning. As soon as this has completed, the `HetznerBareMetalMachineController` removes the owner and consumer reference of the host and deletes the finalizer of the machine, so that it can be finally deleted.
 
 #### Updating a HetznerBareMetalMachine
-Updating a ```HetznerBareMetalMachineTemplate``` is not possible. Instead, a new template should be created.
+
+Updating a `HetznerBareMetalMachineTemplate` is not possible. Instead, a new template should be created.
 
 ## cloud-init and install-image
+
 Both in install-image and cloud-init the ports used for SSH can be changed, e.g. with the following code snippet:
+
 ```
 sed -i -e '/^\(#\|\)Port/s/^.*$/Port 2223/' /etc/ssh/sshd_config
 ```
-As the controller needs to know this to be able to successfully provision the server, these ports can be specified in ```SSHSpec``` of ```HetznerBareMetalMachineTemplate```.
 
-When the port is changed in cloud-init, then we additionally need to use the following command to make sure that the change of ports takes immediate effect: 
-```systemctl restart sshd``` 
+As the controller needs to know this to be able to successfully provision the server, these ports can be specified in `SSHSpec` of `HetznerBareMetalMachineTemplate`.
+
+When the port is changed in cloud-init, then we additionally need to use the following command to make sure that the change of ports takes immediate effect:
+`systemctl restart sshd`
 
 ## Choosing the right host
 
 Via MatchLabels you can specify a certain label (key and value) that identifies the host. You get more flexibility with MatchExpressions. This allows decisions like "take any host that has the key "mykey" and let this key have either one of the values "val1", "val2", and "val3".
 
 ### Overview of HetznerBareMetalMachineTemplate.Spec
-| Key | Type | Default | Required | Description |
-|-----|-----|------|---------|-------------|
-| template.spec.providerID | string |  | no | Provider ID set by controller |
-| template.spec.installImage | object | | yes | Configuration used in autosetup |
-| template.spec.installImage.image | object | | yes | Defines image for bm machine. Must specify either name and url, or a (local) path |
-| template.spec.installImage.image.url | string | | no | Remote URL of image. Can be tar, tar.gz, tar.bz, tar.bz2, tar.xz, tgz, tbz, txz |
-| template.spec.installImage.image.name | string | | no | Name of the image |
-| template.spec.installImage.image.path | string | | no | Local path of a pre-installed image |
-| template.spec.installImage.postInstallScript | string | | no | PostInstallScript that is used for commands that will be executed after install image |
-| template.spec.installImage.partitions | []object | | yes | Partitions that should be created in installimage |
-| template.spec.installImage.partitions.mount | string | | yes | Mount defines the mount path of the filesystem |
-| template.spec.installImage.partitions.fileSystem | string | | yes | Filesystem that should  be used. Can be ext2, ext3, ext4, btrfs, reiserfs, xfs, swap, or the name of the LVM volume group, if the partition is a VG|
-| template.spec.installImage.partitions.size | string | | yes | Size of the partition. Use 'all' to use all remaining space of the drive. M/G/T can be used as unit specifications for MiB, GiB, TiB |
-| template.spec.installImage.logicalVolumeDefinitions | []object | | no | Defines the logical volume definitions that should be created |
-| template.spec.installImage.logicalVolumeDefinitions.vg | string | | yes | Defines the vg name |
-| template.spec.installImage.logicalVolumeDefinitions.name | string | | yes | Defines the volume name |
-| template.spec.installImage.logicalVolumeDefinitions.mount | string | | yes | Defines the mount path |
-| template.spec.installImage.logicalVolumeDefinitions.fileSystem | string | | yes | Defines the file system |
-| template.spec.installImage.logicalVolumeDefinitions.size | string | | yes | Defines size with unit M/G/T or MiB/GiB/TiB |
-| template.spec.installImage.btrfsDefinitions | []object | | no | Defines the btrfs sub-volume definitions that should be created |
-| template.spec.installImage.btrfsDefinitions.volume | string | | yes | Defines the btrfs volume name |
-| template.spec.installImage.btrfsDefinitions.subvolume | string | | yes | Defines the btrfs sub-volume name |
-| template.spec.installImage.btrfsDefinitions.mount | string | | yes | Defines the btrfs mount path |
-| template.spec.hostSelector | object | | yes | Options to select hosts with |
-| template.spec.hostSelector.matchLabels | map[string][string] | | no | Specify labels as key-value pairs that should be there in host object to select it |
-| template.spec.hostSelector.matchExpressions | []object | | no | Requirements using Kubernetes MatchExpressions |
-| template.spec.hostSelector.matchExpressions.key | string | | yes | Key of label that should be matched in host object |
-| template.spec.hostSelector.matchExpressions.operator | string | | yes | [Selection operator](https://pkg.go.dev/k8s.io/apimachinery@v0.23.4/pkg/selection?utm_source=gopls#Operator) |
-| template.spec.hostSelector.matchExpressions.values | []string | | yes | Values whose relation to the label value in the host machine is defined by the selection operator |
-| template.spec.sshSpec | object | | yes | SSH specs |
-| template.spec.sshSpec.secretRef | object | | yes | Reference to the secret where SSH key is stored |
-| template.spec.sshSpec.secretRef.name | string | | yes | Name of the secret |
-| template.spec.sshSpec.secretRef.key | object | | yes | Details about the keys used in the data of the secret |
-| template.spec.sshSpec.secretRef.key.name | string | | yes | Name is the key in the secret's data where the SSH key's name is stored |
-| template.spec.template.spec.sshSpec.secretRef.key.publicKey | string | | yes | PublicKey is the key in the secret's data where the SSH key's public key is stored |
-| template.spec.sshSpec.secretRef.key.privateKey | string | | yes | PrivateKey is the key in the secret's data where the SSH key's private key is stored |
-| template.spec.sshSpec.portAfterInstallImage | int | 22 | no | PortAfterInstallImage specifies the port that can be used to reach the server via SSH after install image completed successfully |
-| template.spec.sshSpec.portAfterCloudInit | int | 22 (install image port) | no | PortAfterCloudInit specifies the port that can be used to reach the server via SSH after cloud init completed successfully |
+
+| Key                                                            | Type                | Default                 | Required | Description                                                                                                                                        |
+| -------------------------------------------------------------- | ------------------- | ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| template.spec.providerID                                       | string              |                         | no       | Provider ID set by controller                                                                                                                      |
+| template.spec.installImage                                     | object              |                         | yes      | Configuration used in autosetup                                                                                                                    |
+| template.spec.installImage.image                               | object              |                         | yes      | Defines image for bm machine. Must specify either name and url, or a (local) path                                                                  |
+| template.spec.installImage.image.url                           | string              |                         | no       | Remote URL of image. Can be tar, tar.gz, tar.bz, tar.bz2, tar.xz, tgz, tbz, txz                                                                    |
+| template.spec.installImage.image.name                          | string              |                         | no       | Name of the image                                                                                                                                  |
+| template.spec.installImage.image.path                          | string              |                         | no       | Local path of a pre-installed image                                                                                                                |
+| template.spec.installImage.postInstallScript                   | string              |                         | no       | PostInstallScript that is used for commands that will be executed after install image                                                              |
+| template.spec.installImage.partitions                          | []object            |                         | yes      | Partitions that should be created in installimage                                                                                                  |
+| template.spec.installImage.partitions.mount                    | string              |                         | yes      | Mount defines the mount path of the filesystem                                                                                                     |
+| template.spec.installImage.partitions.fileSystem               | string              |                         | yes      | Filesystem that should be used. Can be ext2, ext3, ext4, btrfs, reiserfs, xfs, swap, or the name of the LVM volume group, if the partition is a VG |
+| template.spec.installImage.partitions.size                     | string              |                         | yes      | Size of the partition. Use 'all' to use all remaining space of the drive. M/G/T can be used as unit specifications for MiB, GiB, TiB               |
+| template.spec.installImage.logicalVolumeDefinitions            | []object            |                         | no       | Defines the logical volume definitions that should be created                                                                                      |
+| template.spec.installImage.logicalVolumeDefinitions.vg         | string              |                         | yes      | Defines the vg name                                                                                                                                |
+| template.spec.installImage.logicalVolumeDefinitions.name       | string              |                         | yes      | Defines the volume name                                                                                                                            |
+| template.spec.installImage.logicalVolumeDefinitions.mount      | string              |                         | yes      | Defines the mount path                                                                                                                             |
+| template.spec.installImage.logicalVolumeDefinitions.fileSystem | string              |                         | yes      | Defines the file system                                                                                                                            |
+| template.spec.installImage.logicalVolumeDefinitions.size       | string              |                         | yes      | Defines size with unit M/G/T or MiB/GiB/TiB                                                                                                        |
+| template.spec.installImage.btrfsDefinitions                    | []object            |                         | no       | Defines the btrfs sub-volume definitions that should be created                                                                                    |
+| template.spec.installImage.btrfsDefinitions.volume             | string              |                         | yes      | Defines the btrfs volume name                                                                                                                      |
+| template.spec.installImage.btrfsDefinitions.subvolume          | string              |                         | yes      | Defines the btrfs sub-volume name                                                                                                                  |
+| template.spec.installImage.btrfsDefinitions.mount              | string              |                         | yes      | Defines the btrfs mount path                                                                                                                       |
+| template.spec.hostSelector                                     | object              |                         | no       | Options to select hosts with                                                                                                                       |
+| template.spec.hostSelector.matchLabels                         | map[string][string] |                         | no       | Specify labels as key-value pairs that should be there in host object to select it                                                                 |
+| template.spec.hostSelector.matchExpressions                    | []object            |                         | no       | Requirements using Kubernetes MatchExpressions                                                                                                     |
+| template.spec.hostSelector.matchExpressions.key                | string              |                         | yes      | Key of label that should be matched in host object                                                                                                 |
+| template.spec.hostSelector.matchExpressions.operator           | string              |                         | yes      | [Selection operator](https://pkg.go.dev/k8s.io/apimachinery@v0.23.4/pkg/selection?utm_source=gopls#Operator)                                       |
+| template.spec.hostSelector.matchExpressions.values             | []string            |                         | yes      | Values whose relation to the label value in the host machine is defined by the selection operator                                                  |
+| template.spec.sshSpec                                          | object              |                         | yes      | SSH specs                                                                                                                                          |
+| template.spec.sshSpec.secretRef                                | object              |                         | yes      | Reference to the secret where SSH key is stored                                                                                                    |
+| template.spec.sshSpec.secretRef.name                           | string              |                         | yes      | Name of the secret                                                                                                                                 |
+| template.spec.sshSpec.secretRef.key                            | object              |                         | yes      | Details about the keys used in the data of the secret                                                                                              |
+| template.spec.sshSpec.secretRef.key.name                       | string              |                         | yes      | Name is the key in the secret's data where the SSH key's name is stored                                                                            |
+| template.spec.template.spec.sshSpec.secretRef.key.publicKey    | string              |                         | yes      | PublicKey is the key in the secret's data where the SSH key's public key is stored                                                                 |
+| template.spec.sshSpec.secretRef.key.privateKey                 | string              |                         | yes      | PrivateKey is the key in the secret's data where the SSH key's private key is stored                                                               |
+| template.spec.sshSpec.portAfterInstallImage                    | int                 | 22                      | no       | PortAfterInstallImage specifies the port that can be used to reach the server via SSH after install image completed successfully                   |
+| template.spec.sshSpec.portAfterCloudInit                       | int                 | 22 (install image port) | no       | PortAfterCloudInit specifies the port that can be used to reach the server via SSH after cloud init completed successfully                         |

--- a/docs/topics/quickstart.md
+++ b/docs/topics/quickstart.md
@@ -35,8 +35,17 @@ All pre-configured flavors can be found on the [release page](https://github.com
 
 ## Hetzner Dedicated / Bare Metal Server
 
-If you want to create a cluster with bare metal servers, you need to additionally set up the robot credentials in the preparation step. As described in the [reference](/docs/reference/hetzner-bare-metal-machine-template.md), you need to manually buy bare metal servers before-hand.
-Then you need to create a `HetznerBareMetalHost` object for each bare metal server that you bought and specify its server ID in the specs. If you already know the WWN of the storage device you want to choose for booting, then specify it in `rootDeviceHints`. If not, then you can wait for the host to start provisioning. It will show you an error that you did not specify the WWN. If you reach this point, have a look at the status of `HetznerBareMetalHost`. There you find `hardwareDetails`, in which you can see a list of all relevant storage devices as well as their properties. You can just copy+paste the WWN of your favorite storage device into `rootDeviceHints`.  ....
+If you want to create a cluster with bare metal servers, you need to additionally set up the robot credentials in the preparation step. As described in the [reference](/docs/reference/hetzner-bare-metal-machine-template.md), you need to manually buy bare metal servers before-hand. To use bare metal servers for your deployment, you should choose one of the following flavors:
+
+| Flavor                                       | What it does                                                                                                                                 |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| hetzner-baremetal-control-planes-remediation | Uses bare metal servers for the control plane nodes - with custom remediation (try to reboot machines first)  |
+| hetzner-baremetal-control-planes             | Uses bare metal servers for the control plane nodes - with normal remediation (unprovision/recreate machines) |
+| hetzner-hcloud-control-planes                | Uses the hcloud servers for the control plane nodes and the bare metal servers for the worker nodes                                          |
+
+Then you need to create a `HetznerBareMetalHost` object for each bare metal server that you bought and specify its server ID in the specs. See an [example](/docs/reference/hetzner-bare-metal-host.md). Add the created objects to your my-cluster.yaml file. If you already know the WWN of the storage device you want to choose for booting, then specify it in `rootDeviceHints` of the object. If not, you can apply the workload cluster and start the provisioning without specifying the WWN and then wait for the bare metal hosts to show an error.
+
+Then have a look at the status of `HetznerBareMetalHost` by running `kubectl describe hetznerbaremetalhost` in your management cluster. There you will find `hardwareDetails` of all of your bare metal hosts, in which you can see a list of all the relevant storage devices as well as their properties. You can just copy+paste the WWN:s of your desired storage device into the `rootDeviceHints` of your `HetznerBareMetalHost` objects.
 
 ## Apply the workload cluster
 
@@ -89,7 +98,7 @@ You can, of course, also install an alternative CNI, e.g. calico.
 
 ## Deploy the CCM
 
-### Deploy HCloud Cloud Controller Manager - *hcloud only*
+### Deploy HCloud Cloud Controller Manager - _hcloud only_
 
 This make command will install the CCM in your workload cluster.
 
@@ -117,7 +126,7 @@ KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install ccm syself/ccm
 helm repo add syself https://charts.syself.com
 helm repo update syself
 
-KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG)helm upgrade --install ccm syself/ccm-hetzner --version 1.1.2 \
+KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install ccm syself/ccm-hetzner --version 1.1.2 \
 --namespace kube-system \
 --set image.tag=latest \
 --set privateNetwork.enabled=false
@@ -188,8 +197,8 @@ Clusterctl Flags:
 
 | Flag                      | Description                                                                                                                   |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| _--namespace_             | The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used. |
-| _--kubeconfig_            | Path to the kubeconfig file for the source management cluster. If unspecified, default discovery rules apply. |
-| _--kubeconfig-context_    | Context to be used within the kubeconfig file for the source management cluster. If empty, current context will be used. |
-| _--to-kubeconfig_         | Path to the kubeconfig file to use for the destination management cluster. |
+| _--namespace_             | The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used.                  |
+| _--kubeconfig_            | Path to the kubeconfig file for the source management cluster. If unspecified, default discovery rules apply.                 |
+| _--kubeconfig-context_    | Context to be used within the kubeconfig file for the source management cluster. If empty, current context will be used.      |
+| _--to-kubeconfig_         | Path to the kubeconfig file to use for the destination management cluster.                                                    |
 | _--to-kubeconfig-context_ | Context to be used within the kubeconfig file for the destination management cluster. If empty, current context will be used. |


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:
Adds more info about the HetznerBareMetalHost object to make it clearer how to use Hetzner bare metal servers with the cluster-api. Also adds some more info about the baremetal deployment to the quickstart.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #209

**Special notes for your reviewer**:
-

**TODOs**:
- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests

