### PR TITLE
:book: adding capi v1.2.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ In addition to the pure creation and operation of Kubernetes clusters, this prov
 
 This provider's versions are compatible with the following versions of Cluster API:
 
-|  | Cluster API `v1beta1` (`v1.0.x`) | Cluster API `v1beta1` (`v1.1.x`) |
+|  | Cluster API `v1beta1` (`v1.0.x`) | Cluster API `v1beta1` (`v1.1.x`)  | Cluster API `v1beta1` (`v1.2.x`) |
 |---|---|---|
-|Hetzner Provider `v1.0.x` | ✓ | ✓ |
+|Hetzner Provider `v1.0.x` | ✓ | ✓ | ✓ |
 
 This provider's versions can install and manage the following versions of Kubernetes:
 

--- a/docs/developers/tilt.md
+++ b/docs/developers/tilt.md
@@ -35,9 +35,9 @@
 | preload_images_for_kind | bool | true | no | If set to true, uses `kind load docker-image` to preload images into a kind cluster |
 | kind_cluster_name | []object | "caph" | no | The name of the kind cluster to use when preloading images |
 | capi_version | string | "v1.2.0-beta.1" | no | Version of CAPI |
-| cabpt_version | string | "v0.5.2" | no | Version of Cluster API Bootstrap Provider Talos |
-| cacppt_version | string | "v0.4.5" | no | Version of Cluster API Control Plane Provider Talos |
-| cert_manager_version | string | "v1.1.0" | no | Version of cert manager |
+| cabpt_version | string | "v0.5.4" | no | Version of Cluster API Bootstrap Provider Talos |
+| cacppt_version | string | "v0.4.6" | no | Version of Cluster API Control Plane Provider Talos |
+| cert_manager_version | string | "v1.7.2" | no | Version of cert manager |
 | kustomize_substitutions | map[string]string | {
         "HCLOUD_REGION": "fsn1",
         "CONTROL_PLANE_MACHINE_COUNT": "3",


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation  

**What this PR does / why we need it**:
The next version of caph will support the new v1.2.x capi version