### PR TITLE
:bug: Fix add server to lb with only private IP

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -579,8 +579,8 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 		return nil
 	}
 
-	// Only if server has IPv4, otherwise Hetzner cannot handle it
-	if server.PublicNet.IPv4.IP != nil {
+	// Only if server has private IP or public IPv4, otherwise Hetzner cannot handle it
+	if server.PublicNet.IPv4.IP != nil || hasPrivateIP {
 		loadBalancerAddServerTargetOpts := hcloud.LoadBalancerAddServerTargetOpts{
 			Server:       server,
 			UsePrivateIP: &hasPrivateIP,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In one of the last PRs we added support for Hetzner's new feature of
disabling IPv4 and IPv6 addresses. This required to prevent servers from
being added to load balancer in case they only have IPv6 addresses - as
no IPv6 addresses can be added to a Hetzner load balancer. This only
applies to public network though. This is why we also need to add
servers in case that private networks are there - independent whether
there is a public IPv4 or not.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

