### PR TITLE
:sparkles: Add condition for bootstrap ready

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -48,6 +48,13 @@ const (
 )
 
 const (
+	// InstanceBootstrapReadyCondition reports on current status of the instance. BootstrapReady indicates the bootstrap is ready.
+	InstanceBootstrapReadyCondition clusterv1.ConditionType = "InstanceBootstrapReady"
+	// InstanceBootstrapNotReadyReason bootstrap not ready yet.
+	InstanceBootstrapNotReadyReason = "InstanceBootstrapNotReady"
+)
+
+const (
 	// NetworkAttached reports on whether there is a network attached to the cluster.
 	NetworkAttached clusterv1.ConditionType = "NetworkAttached"
 	// NetworkDisabledReason indicates that network is disabled.

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -93,8 +93,21 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 	// Make sure bootstrap data is available and populated. If not, return, we
 	// will get an event from the machine update when the flag is set to true.
 	if !s.scope.IsBootstrapReady(ctx) {
+		s.scope.V(1).Info("Bootstrap not ready - requeuing")
+		conditions.MarkFalse(
+			s.scope.BareMetalMachine,
+			infrav1.InstanceBootstrapReadyCondition,
+			infrav1.InstanceBootstrapNotReadyReason,
+			capi.ConditionSeverityInfo,
+			"bootstrap not ready yet",
+		)
 		return &ctrl.Result{}, nil
 	}
+
+	conditions.MarkTrue(
+		s.scope.BareMetalMachine,
+		infrav1.InstanceBootstrapReadyCondition,
+	)
 
 	errType := capierrors.CreateMachineError
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It is not very clear, without looking at logs, that a machine is
currently waiting for its bootstrap data. In order to facilitate the
operator's job, we include this as a condition into the machine's
status.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

