### PR TITLE
:sparkles: Bump Go to 1.19

### DIFF
--- a/.github/workflows/pr-unit-test.yml
+++ b/.github/workflows/pr-unit-test.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: Test
         run: make test-verbose

--- a/.github/workflows/pr-verify-code.yml
+++ b/.github/workflows/pr-verify-code.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
       - name: Verify Boilerplate
         run: make verify-boilerplate
       - name: Verify Modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
       - name: install kustomize
         run: |
           make kustomize

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,9 +68,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.18"
+    go: "1.19"
   stylecheck:
-    go: "1.18"
+    go: "1.19"
   gosec:
     excludes:
       - G307 # Deferring unsafe method "Close" on type "\*os.File"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ HELM_DIFF_VERSION=3.4.1									# https://github.com/databus23/helm-diff/release
 #
 # Go.
 #
-GO_VERSION ?= 1.18.2
+GO_VERSION ?= 1.19.1
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syself/cluster-api-provider-hetzner
 
-go 1.18
+go 1.19
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.0-beta.1
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/syself/cluster-api-provider-hetzner/hack/tools
 
-go 1.18
+go 1.19
 
 replace github.com/syself/cluster-api-provider-hetzner => ../../
 


### PR DESCRIPTION
**What type of PR is this?**
/kind other

**What this PR does / why we need it**:
Latest Go version, needed for upcoming CAPI 1.25 release

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

