### PR TITLE
:seedling: clean-up of e2e tests

### DIFF
--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Run e2e Test
-        id: e2e
+        id: e2e-bm
         uses: ./.github/actions/e2e
         with:
           e2e_name: hetzner-basic

--- a/test/e2e/feature_test.go
+++ b/test/e2e/feature_test.go
@@ -70,18 +70,19 @@ var _ = Describe("[Feature] Testing Cluster Flavor with 3x control-planes 1x wor
 		})
 	})
 
-	Context("Testing deactivated loadbalancer", func() {
-		CaphClusterDeploymentSpec(ctx, func() CaphClusterDeploymentSpecInput {
-			return CaphClusterDeploymentSpecInput{
-				E2EConfig:                e2eConfig,
-				ClusterctlConfigPath:     clusterctlConfigPath,
-				BootstrapClusterProxy:    bootstrapClusterProxy,
-				ArtifactFolder:           artifactFolder,
-				SkipCleanup:              skipCleanup,
-				ControlPlaneMachineCount: 3,
-				WorkerMachineCount:       1,
-				Flavor:                   "hcloud-feature-loadbalancer-off",
-			}
-		})
-	})
+	// TODO: If deactivated it's necessary to set a domain name. Currently this is not supported on the CI
+	// Context("Testing deactivated loadbalancer", func() {
+	// 	CaphClusterDeploymentSpec(ctx, func() CaphClusterDeploymentSpecInput {
+	// 		return CaphClusterDeploymentSpecInput{
+	// 			E2EConfig:                e2eConfig,
+	// 			ClusterctlConfigPath:     clusterctlConfigPath,
+	// 			BootstrapClusterProxy:    bootstrapClusterProxy,
+	// 			ArtifactFolder:           artifactFolder,
+	// 			SkipCleanup:              skipCleanup,
+	// 			ControlPlaneMachineCount: 3,
+	// 			WorkerMachineCount:       1,
+	// 			Flavor:                   "hcloud-feature-loadbalancer-off",
+	// 		}
+	// 	})
+	// })
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup          

**What this PR does / why we need it**:
* disables e2e loadbalancer disabled test, because we do not support setting a host in the CI

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

