### PR TITLE
:bug: Fix enabling IP address logic for HCloud

### DIFF
--- a/docs/reference/hcloud-machine-template.md
+++ b/docs/reference/hcloud-machine-template.md
@@ -13,6 +13,6 @@ In ```HCloudMachineTemplate``` you can define all important properties for ```HC
 | template.spec.sshKeys.hcloud.name | string | | yes | Name of SSH key |
 | template.spec.sshKeys.hcloud.fingerprint | string | | no| Fingerprint of SSH key - used by the controller |
 | template.spec.placementGroupName | string | | no | Placement group of the machine in HCloud API, must be referencing an existing placement group |
-| template.spec.publicNetwork | object | {enabledIPv4: true, enabledIPv6: true} | no | Specs about primary IP address of server. If both IPv4 and IPv6 are disabled, then the private network has to be enabled |
-| template.spec.enabledIPv4 | bool | true | no | Defines whether server has IPv4 address enabled. Note that IPv4 has to be enabled if server is supposed to be added to load balancers! Hetzner load balancers CANNOT handle IPv6. |
-| template.spec.enabledIPv6 | bool | true | no | Defines whether server has IPv6 address enabled |
+| template.spec.publicNetwork | object | {enableIPv4: true, enabledIPv6: true} | no | Specs about primary IP address of server. If both IPv4 and IPv6 are disabled, then the private network has to be enabled |
+| template.spec.enableIPv4 | bool | true | no | Defines whether server has IPv4 address enabled. As Hetzner load balancers require an IPv4 address, this setting will be ignored and set to true if there is not private net. |
+| template.spec.enableIPv6 | bool | true | no | Defines whether server has IPv6 address enabled |

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -262,6 +262,10 @@ func (s *Service) createServer(ctx context.Context, failureDomain string) (*hclo
 		Automount:        &automount,
 		StartAfterCreate: &startAfterCreate,
 		UserData:         string(userData),
+		PublicNet: &hcloud.ServerCreatePublicNet{
+			EnableIPv4: s.scope.HCloudMachine.Spec.PublicNetwork.EnableIPv4,
+			EnableIPv6: s.scope.HCloudMachine.Spec.PublicNetwork.EnableIPv6,
+		},
 	}
 
 	// set placement group if necessary
@@ -318,12 +322,9 @@ func (s *Service) createServer(ctx context.Context, failureDomain string) (*hclo
 		}}
 	}
 
-	// if no private network exists
+	// if no private network exists there must be an IPv4 for the load balancer.
 	if !s.scope.HetznerCluster.Spec.HCloudNetwork.Enabled {
-		opts.PublicNet = &hcloud.ServerCreatePublicNet{
-			EnableIPv4: s.scope.HCloudMachine.Spec.PublicNetwork.EnableIPv4,
-			EnableIPv6: s.scope.HCloudMachine.Spec.PublicNetwork.EnableIPv6,
-		}
+		opts.PublicNet.EnableIPv4 = true
 	}
 
 	// Create the server


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, the user can only enable/disable IPv4 and IPv6 if there is no private network. However, since the enabling/disabling is independent of the public/private net, we remove this if clause.

To make sure that users don't disable the IPv4 if there is no private net, we always enable it in that case. This is necessary for Hetzner load balancers, as they can only work with IPv4 of HCloud servers.

**Which issue(s) this PR fixes**:
Fixes #312

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

