### PR TITLE
🐛 Wait for LoadBalancer IP

### DIFF
--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -194,26 +194,27 @@ func (r *HetznerClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	}
 	conditions.MarkTrue(hetznerCluster, infrav1.PlacementGroupsSynced)
 
-	if hetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled &&
-		hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4 != "<nil>" {
-		var defaultHost = hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4
-		var defaultPort = int32(hetznerCluster.Spec.ControlPlaneLoadBalancer.Port)
+	if hetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled {
+		if hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4 != "<nil>" {
+			var defaultHost = hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4
+			var defaultPort = int32(hetznerCluster.Spec.ControlPlaneLoadBalancer.Port)
 
-		if hetznerCluster.Spec.ControlPlaneEndpoint == nil {
-			hetznerCluster.Spec.ControlPlaneEndpoint = &clusterv1.APIEndpoint{
-				Host: defaultHost,
-				Port: defaultPort,
+			if hetznerCluster.Spec.ControlPlaneEndpoint == nil {
+				hetznerCluster.Spec.ControlPlaneEndpoint = &clusterv1.APIEndpoint{
+					Host: defaultHost,
+					Port: defaultPort,
+				}
+			} else {
+				if hetznerCluster.Spec.ControlPlaneEndpoint.Host == "" {
+					hetznerCluster.Spec.ControlPlaneEndpoint.Host = defaultHost
+				}
+				if hetznerCluster.Spec.ControlPlaneEndpoint.Port == 0 {
+					hetznerCluster.Spec.ControlPlaneEndpoint.Port = defaultPort
+				}
 			}
-		} else {
-			if hetznerCluster.Spec.ControlPlaneEndpoint.Host == "" {
-				hetznerCluster.Spec.ControlPlaneEndpoint.Host = defaultHost
-			}
-			if hetznerCluster.Spec.ControlPlaneEndpoint.Port == 0 {
-				hetznerCluster.Spec.ControlPlaneEndpoint.Port = defaultPort
-			}
+
+			hetznerCluster.Status.Ready = true
 		}
-
-		hetznerCluster.Status.Ready = true
 	} else if hetznerCluster.Spec.ControlPlaneEndpoint != nil {
 		hetznerCluster.Status.Ready = true
 	}


### PR DESCRIPTION
Don't mark the cluster as ready when the LB is enabled but has no IP address yet.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently, if the LB is enabled but doesn't have an IP address yet, but an (incomplete) controlPlaneEndpoint is configured in the HetznerCluster resource, the infrastructure is marked as ready leading to wrong endpoint data being used by the bootstrap provider.

**Which issue(s) this PR fixes**:

Fixes #454

**TODOs**:
- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

