### PR TITLE
:bug: Fix baremetal networking due to erroneous netplan-config / cloud-init

### DIFF
--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -17,6 +17,8 @@ spec:
             size: all
         postInstallScript: |
           #!/bin/bash
+          mkdir -p /etc/cloud/cloud.cfg.d && touch /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+          echo "network: { config: disabled }" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           apt-get update && apt-get install -y cloud-init apparmor apparmor-utils
       sshSpec:
         portAfterInstallImage: 22

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -17,6 +17,8 @@ spec:
             size: all
         postInstallScript: |
           #!/bin/bash
+          mkdir -p /etc/cloud/cloud.cfg.d && touch /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+          echo "network: { config: disabled }" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           apt-get update && apt-get install -y cloud-init apparmor apparmor-utils
       sshSpec:
         portAfterInstallImage: 22


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cloud-init generates another own DHCP entry for netplan on baremetal machines despite existing static configuration. This leads to problems and duplicate network configuration.

This fix disables cloud-inits network config through a custom config-file created before cloud-init runs.

**Which issue(s) this PR fixes:**:
Fixes #457 

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
