### PR TITLE
:bug: Add check for empty infra ref of cluster

### DIFF
--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -68,6 +68,10 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req ctr
 
 	log = log.WithValues("Cluster", klog.KObj(cluster))
 
+	if cluster.Spec.InfrastructureRef == nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	hetznerCluster := &infrav1.HetznerCluster{}
 
 	hetznerClusterName := client.ObjectKey{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In HCloudMachineTemplate controller there is a nil pointer error due to a missing InfrastructureRef of the Cluster object when using ClusterClass. A check for missing InfrastructureRef and reconciling again solves this.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

