### PR TITLE
:bug: Fix ssh call to wrong port in actionEnsureProvisioned

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1338,9 +1338,13 @@ func (s *Service) actionEnsureProvisioned() actionResult {
 	}
 
 	// Check whether cloud init did not run successfully even though it shows "done"
-	actResult = s.handleCloudInitNotStarted()
-	if _, complete := actResult.(actionComplete); !complete {
-		return actResult
+	// Check this only when the port did not change. Because if it did, then we can already confirm at this point
+	// that the change worked and the new port is usable. This is a strong enough indication for us to assume cloud init worked.
+	if s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage == s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterCloudInit {
+		actResult = s.handleCloudInitNotStarted()
+		if _, complete := actResult.(actionComplete); !complete {
+			return actResult
+		}
 	}
 
 	s.scope.SetErrorCount(0)

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1584,6 +1584,25 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			},
 		),
 		Entry(
+			"correct hostname, cloud init done, no SIGTERM, ports different",
+			ensureProvisionedInputs{
+				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
+				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
+				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				samePorts:                              false,
+				expectedActionResult:                   actionComplete{},
+				expectedErrorType:                      infrav1.ErrorType(""),
+				expectsSSHClientCallCloudInitStatus:    true,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		Entry(
 			"timeout of sshclient",
 			ensureProvisionedInputs{
 				outSSHClientGetHostName:                sshclient.Output{Err: timeout},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In actionEnsureProvisioned we check whether cloud init actually ran successfully: Sometimes it happens that it shows success, but has a SIGTERM in the logs.

However, if we change ssh ports in cloud init, then we have to call the new port after cloud init finished. If this works, we can already conclude that cloud init did something right. This is enough reason for us to assume that everything went well.

If this is a wrong assumption, we can include in the future an additional if statement that makes ssh statements to both ports to check the current cloud init status.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

