### PR TITLE
🌱 test: add missing webhooks to envtest

### DIFF
--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -162,6 +162,12 @@ func NewTestEnvironment() *TestEnvironment {
 	if err := (&infrav1.HetznerBareMetalHost{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("failed to set up webhook with manager for HetznerBareMetalHost: %s", err)
 	}
+	if err := (&infrav1.HetznerBareMetalRemediation{}).SetupWebhookWithManager(mgr); err != nil {
+		klog.Fatalf("failed to set up webhook with manager for HetznerBareMetalRemediation: %s", err)
+	}
+	if err := (&infrav1.HetznerBareMetalRemediationTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		klog.Fatalf("failed to set up webhook with manager for HetznerBareMetalRemediationTemplate: %s", err)
+	}
 	// Create a fake HCloudClientFactory
 	hcloudClientFactory := fakeclient.NewHCloudClientFactory()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Starts the webhooks for `HetznerBareMetalRemediation` and `HetznerBareMetalRemediationTemplate` in `envtest` used by the unit tests (`make test`). At the moment these webhooks are not doing anything, but to be consistent and to avoid future confusion they should still be started.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #105

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

