### PR TITLE
:seedling: adding cache to image build

### DIFF
--- a/.github/actions/manager-image/action.yaml
+++ b/.github/actions/manager-image/action.yaml
@@ -24,6 +24,35 @@ runs:
         metadata_flavor: ${{ env.metadata_flavor }}
         metadata_tags: ${{ env.metadata_tags }}
 
+    # Load Golang cache build from GitHub
+    - name: Load Caph Golang cache build from GitHub
+      uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
+      id: cache
+      with:
+        path: /tmp/.cache/caph
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+          ${{ runner.os }}-go-
+
+    - name: Create Caph cache directory
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        mkdir -p /tmp/.cache/caph
+
+    # Import GitHub's cache build to docker cache
+    - name: Copy Caph Golang cache to docker cache
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+      with:
+        provenance: false
+        context: /tmp/.cache/caph
+        file: ./images/cache/Dockerfile
+        push: false
+        platforms: linux/amd64
+        target: import-cache
+
     - name: Build and push manager image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
       with:
@@ -34,5 +63,3 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64
-        cache-from: type=gha, scope=${{ github.workflow }}
-        cache-to: type=gha, mode=max, scope=${{ github.workflow }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,35 @@ jobs:
           echo $DOCKER_BUILD_LDFLAGS >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
+      # Load Golang cache build from GitHub
+      - name: Load Caph Golang cache build from GitHub
+        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
+        id: cache
+        with:
+          path: /tmp/.cache/caph
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-
+
+      - name: Create Caph cache directory
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/caph
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy Caph Golang cache to docker cache
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          provenance: false
+          context: /tmp/.cache/caph
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
       - name: Build and push manager image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4
         id: docker_build_release
@@ -74,8 +103,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, mode=max, scope=${{ github.workflow }}
 
       - name: Sign Container Images
         env:
@@ -96,6 +123,32 @@ jobs:
           name: image-digest caph
           path: image-digest
           retention-days: 90
+
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store Caph Golang cache build locally
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
+        with:
+          provenance: false
+          context: .
+          file: ./images/cache/Dockerfile
+          push: false
+          outputs: type=local,dest=/tmp/docker-cache-caph
+          platforms: linux/amd64
+          target: export-cache
+
+      # Store docker's golang's cache build locally only on the main branch
+      - name: Store Caph Golang cache in GitHub cache path
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/caph/
+          if [ -f /tmp/docker-cache-caph/tmp/go-build-cache.tar.gz ]; then
+          cp /tmp/docker-cache-caph/tmp/go-build-cache.tar.gz /tmp/.cache/caph/
+          fi
+          if [ -f /tmp/docker-cache-caph/tmp/go-pkg-cache.tar.gz ]; then
+          cp /tmp/docker-cache-caph/tmp/go-pkg-cache.tar.gz /tmp/.cache/caph/
+          fi
 
       - name: Image Digests Output
         shell: bash

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -13,6 +13,7 @@ on:
       - ".github/actions/**/*"
       - ".github/workflows/e2e-*"
       - ".github/workflows/pr-*"
+      - "images/caph/**"
       - "!**/vendor/**"
 env:
   IMAGE_NAME: caph-staging
@@ -43,6 +44,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Test Release
         id: manager-image
         uses: ./.github/actions/test-release
@@ -58,6 +61,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run e2e Test
         id: e2e
         uses: ./.github/actions/e2e
@@ -78,6 +83,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run e2e Test
         id: e2e-bm
         uses: ./.github/actions/e2e

--- a/.github/workflows/schedule-cache-cleaner-caph-image.yml
+++ b/.github/workflows/schedule-cache-cleaner-caph-image.yml
@@ -1,0 +1,41 @@
+name: Caph Image Cache Cleaner
+# yamllint disable rule:line-length
+on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  schedule:
+    # Run the GC on the first day in the month at 6am
+    - cron: "0 6 1 * *"
+permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+jobs:
+  cache-cleaner:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - name: symin
+    steps:
+      # Load Golang cache build from GitHub
+      - name: Load Caph Golang cache build from GitHub
+        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
+        id: cache
+        with:
+          path: /tmp/.cache/caph
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-caph-
+            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-
+      - name: Create Caph cache directory
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/caph
+      # Clean docker's golang's cache
+      - name: Clean Caph Golang cache from GitHub
+        shell: bash
+        run: |
+          rm -f /tmp/.cache/caph/go-build-cache.tar.gz
+          rm -f /tmp/.cache/caph/go-pkg-cache.tar.gz


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a cache to the image build. Every time a PR is opened, the e2e triggers an image build of caph. We could speed up this process by using the cache. The cache is only updated during a nightly build in the main branch. Since we expect the changes in a PR to be minor, it makes sense to use the main branch cache. Release builds will not use a cache.  
Since using a Golang cache in Github actions is not natively supported, we use a fake Dockerfile to import and export the cache to the local Docker cache, and use Buildkit's mount directives.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

