### PR TITLE
:seedling: corev1.NodeAddress -> clusterv1.MachineAddress

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -18,7 +18,6 @@ package v1beta1
 
 import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
@@ -64,7 +63,7 @@ type HCloudMachineStatus struct {
 	Ready bool `json:"ready"`
 
 	// Addresses contains the server's associated addresses.
-	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// Region contains the name of the HCloud location the server is running.
 	Region Region `json:"region,omitempty"`

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -241,7 +240,7 @@ type HetznerBareMetalMachineStatus struct {
 	// Addresses is a list of addresses assigned to the machine.
 	// This field is copied from the infrastructure provider reference.
 	// +optional
-	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// Ready is the state of the hetznerbaremetalmachine.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -216,7 +216,7 @@ func (in *HCloudMachineStatus) DeepCopyInto(out *HCloudMachineStatus) {
 	*out = *in
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1beta1.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.InstanceState != nil {
@@ -651,7 +651,7 @@ func (in *HetznerBareMetalMachineStatus) DeepCopyInto(out *HetznerBareMetalMachi
 	}
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
-		*out = make([]v1.NodeAddress, len(*in))
+		*out = make([]apiv1beta1.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
 	if in.Conditions != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -144,13 +144,14 @@ spec:
               addresses:
                 description: Addresses contains the server's associated addresses.
                 items:
-                  description: NodeAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
-                      description: The node address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: Node address type, one of Hostname, ExternalIP
+                      description: Machine address type, one of Hostname, ExternalIP
                         or InternalIP.
                       type: string
                   required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -283,13 +283,14 @@ spec:
                 description: Addresses is a list of addresses assigned to the machine.
                   This field is copied from the infrastructure provider reference.
                 items:
-                  description: NodeAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
-                      description: The node address.
+                      description: The machine address.
                       type: string
                     type:
-                      description: Node address type, one of Hostname, ExternalIP
+                      description: Machine address type, one of Hostname, ExternalIP
                         or InternalIP.
                       type: string
                   required:

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -27,7 +27,7 @@ import (
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/csr"
 	certificatesv1 "k8s.io/api/certificates/v1"
-	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,7 +92,7 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 
 	var isHCloudMachine bool
 	var machineName string
-	var machineAddresses []corev1.NodeAddress
+	var machineAddresses []clusterv1.MachineAddress
 
 	// find matching HCloudMachine object
 	var hcloudMachine infrav1.HCloudMachine

--- a/pkg/csr/csr.go
+++ b/pkg/csr/csr.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -37,7 +37,7 @@ const NodesPrefix = "system:node:"
 const NodesGroup = "system:nodes"
 
 // ValidateKubeletCSR validates a CSR.
-func ValidateKubeletCSR(csr *x509.CertificateRequest, machineName string, isHCloudMachine bool, addresses []corev1.NodeAddress) error {
+func ValidateKubeletCSR(csr *x509.CertificateRequest, machineName string, isHCloudMachine bool, addresses []clusterv1.MachineAddress) error {
 	// check signature and exist quickly
 	if err := csr.CheckSignature(); err != nil {
 		return err
@@ -83,7 +83,7 @@ func ValidateKubeletCSR(csr *x509.CertificateRequest, machineName string, isHClo
 	allowedIPAddresses := make(map[string]struct{})
 	for _, address := range addresses {
 		switch address.Type {
-		case corev1.NodeInternalIP, corev1.NodeExternalIP:
+		case clusterv1.MachineInternalIP, clusterv1.MachineExternalIP:
 			allowedIPAddresses[strings.Split(address.Address, "/")[0]] = struct{}{}
 		}
 	}

--- a/pkg/csr/csr_test.go
+++ b/pkg/csr/csr_test.go
@@ -24,19 +24,19 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/csr"
-	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var _ = Describe("Validate Kubelet CSR", func() {
 	var cr *x509.CertificateRequest
 	var name string
-	var addresses []corev1.NodeAddress
+	var addresses []clusterv1.MachineAddress
 	BeforeEach(func() {
 
 		name = "hcloud-testing-control-plane-vgnlc"
-		addresses = []corev1.NodeAddress{
+		addresses = []clusterv1.MachineAddress{
 			{
-				Type:    corev1.NodeExternalIP,
+				Type:    clusterv1.MachineExternalIP,
 				Address: "195.201.236.66",
 			},
 		}

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -32,6 +32,7 @@ import (
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -734,10 +735,10 @@ func (s *Service) updateMachineStatus(host *infrav1.HetznerBareMetalHost) {
 	}
 }
 
-// NodeAddresses returns a slice of corev1.NodeAddress objects for a
+// NodeAddresses returns a slice of clusterv1.MachineAddress objects for a
 // given HetznerBareMetal machine.
-func nodeAddresses(host *infrav1.HetznerBareMetalHost, bareMetalMachineName string) []corev1.NodeAddress {
-	addrs := []corev1.NodeAddress{}
+func nodeAddresses(host *infrav1.HetznerBareMetalHost, bareMetalMachineName string) []clusterv1.MachineAddress {
+	addrs := []clusterv1.MachineAddress{}
 
 	// If the host is nil or we have no hw details, return an empty address array.
 	if host == nil || host.Spec.Status.HardwareDetails == nil {
@@ -745,19 +746,19 @@ func nodeAddresses(host *infrav1.HetznerBareMetalHost, bareMetalMachineName stri
 	}
 
 	for _, nic := range host.Spec.Status.HardwareDetails.NIC {
-		address := corev1.NodeAddress{
-			Type:    corev1.NodeInternalIP,
+		address := clusterv1.MachineAddress{
+			Type:    clusterv1.MachineInternalIP,
 			Address: nic.IP,
 		}
 		addrs = append(addrs, address)
 	}
 
 	// Add hostname == bareMetalMachineName as well
-	addrs = append(addrs, corev1.NodeAddress{
-		Type:    corev1.NodeHostName,
+	addrs = append(addrs, clusterv1.MachineAddress{
+		Type:    clusterv1.MachineHostName,
 		Address: bareMetalMachineName,
-	}, corev1.NodeAddress{
-		Type:    corev1.NodeInternalDNS,
+	}, clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalDNS,
 		Address: bareMetalMachineName,
 	})
 

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -31,6 +31,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 )
 
 var _ = Describe("chooseHost", func() {
@@ -277,23 +278,23 @@ var _ = Describe("Test NodeAddresses", func() {
 		IP: "172.0.20.2",
 	}
 
-	addr1 := corev1.NodeAddress{
-		Type:    corev1.NodeInternalIP,
+	addr1 := clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalIP,
 		Address: "192.168.1.1",
 	}
 
-	addr2 := corev1.NodeAddress{
-		Type:    corev1.NodeInternalIP,
+	addr2 := clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalIP,
 		Address: "172.0.20.2",
 	}
 
-	addr3 := corev1.NodeAddress{
-		Type:    corev1.NodeHostName,
+	addr3 := clusterv1.MachineAddress{
+		Type:    clusterv1.MachineHostName,
 		Address: "bm-machine",
 	}
 
-	addr4 := corev1.NodeAddress{
-		Type:    corev1.NodeInternalDNS,
+	addr4 := clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalDNS,
 		Address: "bm-machine",
 	}
 
@@ -301,7 +302,7 @@ var _ = Describe("Test NodeAddresses", func() {
 		Machine               clusterv1.Machine
 		BareMetalMachine      infrav1.HetznerBareMetalMachine
 		Host                  *infrav1.HetznerBareMetalHost
-		ExpectedNodeAddresses []corev1.NodeAddress
+		ExpectedNodeAddresses []clusterv1.MachineAddress
 	}
 
 	DescribeTable("Test NodeAddress",
@@ -321,7 +322,7 @@ var _ = Describe("Test NodeAddresses", func() {
 					},
 				},
 			},
-			ExpectedNodeAddresses: []corev1.NodeAddress{addr1, addr3, addr4},
+			ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1, addr3, addr4},
 		}),
 		Entry("Two NICs", testCaseNodeAddress{
 			Host: &infrav1.HetznerBareMetalHost{
@@ -333,7 +334,7 @@ var _ = Describe("Test NodeAddresses", func() {
 					},
 				},
 			},
-			ExpectedNodeAddresses: []corev1.NodeAddress{addr1, addr2, addr3, addr4},
+			ExpectedNodeAddresses: []clusterv1.MachineAddress{addr1, addr2, addr3, addr4},
 		}),
 		Entry("No host", testCaseNodeAddress{
 			Host:                  nil,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -532,13 +532,13 @@ func setStatusFromAPI(server *hcloud.Server) infrav1.HCloudMachineStatus {
 	var status infrav1.HCloudMachineStatus
 	s := server.Status
 	status.InstanceState = &s
-	status.Addresses = []corev1.NodeAddress{}
+	status.Addresses = []clusterv1.MachineAddress{}
 
 	if ip := server.PublicNet.IPv4.IP.String(); ip != "" {
 		status.Addresses = append(
 			status.Addresses,
-			corev1.NodeAddress{
-				Type:    corev1.NodeExternalIP,
+			clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalIP,
 				Address: ip,
 			},
 		)
@@ -548,8 +548,8 @@ func setStatusFromAPI(server *hcloud.Server) infrav1.HCloudMachineStatus {
 		ip[15]++
 		status.Addresses = append(
 			status.Addresses,
-			corev1.NodeAddress{
-				Type:    corev1.NodeExternalIP,
+			clusterv1.MachineAddress{
+				Type:    clusterv1.MachineExternalIP,
 				Address: ip.String(),
 			},
 		)
@@ -558,8 +558,8 @@ func setStatusFromAPI(server *hcloud.Server) infrav1.HCloudMachineStatus {
 	for _, net := range server.PrivateNet {
 		status.Addresses = append(
 			status.Addresses,
-			corev1.NodeAddress{
-				Type:    corev1.NodeInternalIP,
+			clusterv1.MachineAddress{
+				Type:    clusterv1.MachineInternalIP,
 				Address: net.IP.String(),
 			},
 		)

--- a/pkg/services/hcloud/server/server_suite_test.go
+++ b/pkg/services/hcloud/server/server_suite_test.go
@@ -28,7 +28,7 @@ import (
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
-	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const serverJSON = `
@@ -192,7 +192,7 @@ var server *hcloud.Server
 const instanceState = hcloud.ServerStatusRunning
 
 var ips = []string{"1.2.3.4", "2001:db8::3", "10.0.0.2"}
-var addressTypes = []corev1.NodeAddressType{corev1.NodeExternalIP, corev1.NodeExternalIP, corev1.NodeInternalIP}
+var addressTypes = []clusterv1.MachineAddressType{clusterv1.MachineExternalIP, clusterv1.MachineExternalIP, clusterv1.MachineInternalIP}
 
 func TestServer(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Change corev1.NodeAddress to clusterv1.MachineAddress.

Related Slack conversation: https://kubernetes.slack.com/archives/C8TSNPY4T/p1677234946342759

According to the cluster-api documentation, the Status should be a MachineAdress (api from cluster-api)

https://cluster-api.sigs.k8s.io/developer/architecture/controllers/machine.html#optional-status-fields-1


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

