### PR TITLE
:bug: fixed: install matching golangci version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ golangci-lint: $(GOLANGCI_LINT) ## Build a local copy of golangci-lint. After ru
 $(GOLANGCI_LINT): images/builder/Dockerfile # Download golanci-lint using hack script into tools folder.
 	hack/ensure-golangci-lint.sh \
 		-b $(TOOLS_DIR)/$(BIN_DIR) \
-		$(shell cat images/builder/Dockerfile | grep "GOLANGCI_VERSION=" | sed 's/.*GOLANGCI_VERSION=//' | sed 's/\s.*$//')
+		$(shell cat images/builder/Dockerfile | grep "GOLANGCI_VERSION=" | sed 's/.*GOLANGCI_VERSION=//' | sed 's/\s.*$$//')
 
 TILT := $(abspath $(TOOLS_BIN_DIR)/tilt)
 tilt: $(TILT) ## Build a local copy of tilt


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

There was a typo in the Makefile, so that the version of golangci-lint was not updated.


