### PR TITLE
:bug: Init host annotation map in remediation controller

### DIFF
--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -201,12 +201,17 @@ func (s *Service) getHost(ctx context.Context) (*infrav1.HetznerBareMetalHost, e
 // setRebootAnnotation sets reboot annotation on unhealthy host.
 func (s *Service) setRebootAnnotation(ctx context.Context, host *infrav1.HetznerBareMetalHost, helper *patch.Helper) error {
 	s.scope.Info("Adding Reboot annotation to host", "host", host.Name)
+
 	reboot := infrav1.RebootAnnotationArguments{}
 	reboot.Type = infrav1.RebootTypeHardware
-	marshalledMode, err := json.Marshal(reboot)
 
+	marshalledMode, err := json.Marshal(reboot)
 	if err != nil {
 		return err
+	}
+
+	if host.Annotations == nil {
+		host.Annotations = make(map[string]string)
 	}
 
 	host.Annotations[infrav1.RebootAnnotation] = string(marshalledMode)


### PR DESCRIPTION
**What this PR does / why we need it**:
We have to initialize a nil map. Otherwise, we get a "panic: assignment to nil map" error. The bug has been discovered in https://github.com/syself/cluster-api-provider-hetzner/issues/657. 

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

