### PR TITLE
🐛 Missing cilium networkd configuration on Ubuntu 22.04

### DIFF
--- a/templates/node-image/1.25.2-ubuntu-22-04-containerd/scripts/cilium-requirements.sh
+++ b/templates/node-image/1.25.2-ubuntu-22-04-containerd/scripts/cilium-requirements.sh
@@ -46,5 +46,10 @@ cat > /etc/sysctl.d/99-cilium.conf <<EOF
 net.ipv4.conf.lxc*.rp_filter = 0
 EOF
 
-
-
+# Cilium 1.13 Requirements
+# https://docs.cilium.io/en/v1.13/operations/system_requirements/#systemd-based-distributions
+cat > /etc/systemd/networkd.conf <<EOF
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:

The added configuration is required on Ubuntu 22.04 according to the [cilium-docs].

In my personal cluster, not setting these values would cause the Host networking to break after "[unattended-upgrades]" were executed and core system services restarted. This happened roughly once per day and had the potential to take down the whole cluster.

[cilium-docs]: https://docs.cilium.io/en/v1.13/operations/system_requirements/#systemd-based-distributions
[unattended-upgrades]: https://help.ubuntu.com/community/AutomaticSecurityUpdates

**Which issue(s) this PR fixes**:

/

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

