### PR TITLE
🌱 Set Application Name in hcloud-go client

### DIFF
--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -80,6 +80,7 @@ type Factory interface {
 func (f *factory) NewClient(hcloudToken string) Client {
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(hcloudToken),
+		hcloud.WithApplication("cluster-api-provider-hetzner", ""),
 	}
 
 	// controller-runtime hides their default prometheus registry it uses (and exposes via HTTP) behind a custom


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the ["Application"](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/hcloud#WithApplication) in the hcloud-go client adds that information to the "User-Agent" of all outgoing http requests to the Hetzner Cloud API. This data helps Hetzner Cloud find potentially misbehaving API clients.

I saw that you have a [script to include version information](https://github.com/syself/cluster-api-provider-hetzner/blob/271d7452c427b11217910e281e5150888dac2096/hack/version.sh#L72-L93) in the built binaries, but I could not find the referenced go package, and left the version parameter empty.

**Which issue(s) this PR fixes**:
/

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

