### PR TITLE
:seedling: Use errors in host package

### DIFF
--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -176,7 +176,7 @@ func (r *HetznerBareMetalHostReconciler) reconcileSelectedStates(ctx context.Con
 		if needsUpdate {
 			err := r.Update(ctx, bmHost)
 			if err != nil {
-				return &ctrl.Result{}, errors.Wrap(err, "failed to add finalizer")
+				return nil, errors.Wrap(err, "failed to add finalizer")
 			}
 		}
 
@@ -188,15 +188,15 @@ func (r *HetznerBareMetalHostReconciler) reconcileSelectedStates(ctx context.Con
 
 		if !utils.StringInList(bmHost.Finalizers, infrav1.BareMetalHostFinalizer) {
 			log.Info("Ready to be deleted")
-			return &ctrl.Result{}, nil
+			return nil, nil
 		}
 
 		bmHost.Finalizers = utils.FilterStringFromList(bmHost.Finalizers, infrav1.BareMetalHostFinalizer)
 		if err := r.Update(context.Background(), bmHost); err != nil {
-			return &ctrl.Result{}, errors.Wrap(err, "failed to remove finalizer")
+			return nil, errors.Wrap(err, "failed to remove finalizer")
 		}
 		log.Info("Cleanup complete. Removed finalizer", "remaining", bmHost.Finalizers)
-		return &ctrl.Result{}, nil
+		return nil, nil
 	}
 	return nil, nil
 }
@@ -226,7 +226,7 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 
 				return nil, nil, &ctrl.Result{RequeueAfter: host.CalculateBackoff(bmHost.Spec.Status.ErrorCount)}, nil
 			}
-			return nil, nil, &ctrl.Result{}, errors.Wrap(err, "failed to get secret")
+			return nil, nil, nil, errors.Wrap(err, "failed to get secret")
 		}
 
 		rescueSSHSecretNamespacedName := types.NamespacedName{Namespace: bmHost.Namespace, Name: hetznerCluster.Spec.SSHKeys.RobotRescueSecretRef.Name}
@@ -241,7 +241,7 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 
 				return nil, nil, &ctrl.Result{RequeueAfter: host.CalculateBackoff(bmHost.Spec.Status.ErrorCount)}, nil
 			}
-			return nil, nil, &ctrl.Result{}, errors.Wrap(err, "failed to acquire secret")
+			return nil, nil, nil, errors.Wrap(err, "failed to acquire secret")
 		}
 	}
 	return osSSHSecret, rescueSSHSecret, nil, nil

--- a/pkg/services/baremetal/host/host_suite_test.go
+++ b/pkg/services/baremetal/host/host_suite_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package host
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	robotclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/robot"

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package host
 
 import (
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	bmmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks"

--- a/pkg/services/baremetal/host/state_machine.go
+++ b/pkg/services/baremetal/host/state_machine.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/record"
 )
@@ -116,7 +115,7 @@ func (hsm *hostStateMachine) updateSSHKey() actionResult {
 	// Get ssh key secrets from secret
 	osSSHSecret, rescueSSHSecret, err := hsm.reconciler.getSSHKeysAndUpdateStatus()
 	if err != nil {
-		return actionError{err: errors.Wrap(err, "failed to get ssh keys and update status")}
+		return actionError{err: fmt.Errorf("failed to get ssh keys and update status: %w", err)}
 	}
 
 	// Check whether os secret has been updated if it exists already
@@ -133,7 +132,7 @@ func (hsm *hostStateMachine) updateSSHKey() actionResult {
 				return hsm.reconciler.recordActionFailure(infrav1.RegistrationError, errMessage)
 			}
 			if err := hsm.host.UpdateOSSSHStatus(*osSSHSecret); err != nil {
-				return actionError{err: errors.Wrap(err, "failed to update status of OS SSH secret")}
+				return actionError{err: fmt.Errorf("failed to update status of OS SSH secret: %w", err)}
 			}
 		}
 		actResult := hsm.reconciler.validateSSHKey(osSSHSecret, "os")
@@ -152,7 +151,7 @@ func (hsm *hostStateMachine) updateSSHKey() actionResult {
 				hsm.nextState = infrav1.StateNone
 			}
 			if err := hsm.host.UpdateRescueSSHStatus(*rescueSSHSecret); err != nil {
-				return actionError{err: errors.Wrap(err, "failed to update status of rescue SSH secret")}
+				return actionError{err: fmt.Errorf("failed to update status of rescue SSH secret: %w", err)}
 			}
 		}
 		actResult := hsm.reconciler.validateSSHKey(rescueSSHSecret, "rescue")

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -59,7 +59,7 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 	host, helper, err := s.getUnhealthyHost(ctx)
 	if err != nil {
 		s.scope.Error(err, "unable to find a host for unhealthy machine")
-		return &ctrl.Result{}, errors.Wrapf(err, "unable to find a host for unhealthy machine")
+		return nil, errors.Wrapf(err, "unable to find a host for unhealthy machine")
 	}
 
 	// If host is not in state provisioned, then remediate immediately
@@ -67,7 +67,7 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 		log.Info("Deleting host without remediation", "provisioningState", host.Spec.Status.ProvisioningState)
 		if err := s.setOwnerRemediatedConditionNew(ctx); err != nil {
 			s.scope.Error(err, "error setting cluster api conditions")
-			return &ctrl.Result{}, errors.Wrapf(err, "error setting cluster api conditions")
+			return nil, errors.Wrapf(err, "error setting cluster api conditions")
 		}
 	}
 
@@ -75,7 +75,7 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 
 	if remediationType != infrav1.RebootRemediationStrategy {
 		s.scope.Info("unsupported remediation strategy")
-		return &ctrl.Result{}, nil
+		return nil, nil
 	}
 
 	if remediationType == infrav1.RebootRemediationStrategy {
@@ -92,7 +92,7 @@ func (s *Service) Reconcile(ctx context.Context) (_ *ctrl.Result, err error) {
 		default:
 		}
 	}
-	return &ctrl.Result{}, nil
+	return nil, nil
 }
 
 func (s *Service) handlePhaseRunning(ctx context.Context, host *infrav1.HetznerBareMetalHost, helper *patch.Helper) (*ctrl.Result, error) {
@@ -102,7 +102,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, host *infrav1.HetznerB
 		err := s.setRebootAnnotation(ctx, host, helper)
 		if err != nil {
 			s.scope.Error(err, "error setting reboot annotation")
-			return &ctrl.Result{}, errors.Wrap(err, "error setting reboot annotation")
+			return nil, errors.Wrap(err, "error setting reboot annotation")
 		}
 		now := metav1.Now()
 		s.scope.BareMetalRemediation.Status.LastRemediated = &now
@@ -117,7 +117,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, host *infrav1.HetznerB
 			err := s.setRebootAnnotation(ctx, host, helper)
 			if err != nil {
 				s.scope.Error(err, "error setting reboot annotation")
-				return &ctrl.Result{}, errors.Wrapf(err, "error setting reboot annotation")
+				return nil, errors.Wrapf(err, "error setting reboot annotation")
 			}
 			now := metav1.Now()
 			s.scope.BareMetalRemediation.Status.LastRemediated = &now
@@ -146,7 +146,7 @@ func (s *Service) handlePhaseWaiting(ctx context.Context) (*ctrl.Result, error) 
 		err := s.setOwnerRemediatedConditionNew(ctx)
 		if err != nil {
 			s.scope.Error(err, "error setting cluster api conditions")
-			return &ctrl.Result{}, errors.Wrapf(err, "error setting cluster api conditions")
+			return nil, errors.Wrapf(err, "error setting cluster api conditions")
 		}
 	}
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -157,7 +157,7 @@ func (s *Service) Delete(ctx context.Context) (_ *reconcile.Result, err error) {
 
 	if s.scope.IsControlPlane() && s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled {
 		if err := s.deleteServerOfLoadBalancer(ctx, server); err != nil {
-			return &reconcile.Result{}, fmt.Errorf("failed to delete attached server of loadbalancer: %w", err)
+			return nil, fmt.Errorf("failed to delete attached server of loadbalancer: %w", err)
 		}
 	}
 
@@ -518,7 +518,7 @@ func (s *Service) handleDeleteServerStatusRunning(ctx context.Context, server *h
 					"exceeded rate limit with calling hcloud function ShutdownServer",
 				)
 			}
-			return &reconcile.Result{}, fmt.Errorf("failed to shutdown server: %w", err)
+			return nil, fmt.Errorf("failed to shutdown server: %w", err)
 		}
 		conditions.MarkFalse(s.scope.HCloudMachine,
 			infrav1.InstanceReadyCondition,
@@ -536,7 +536,7 @@ func (s *Service) handleDeleteServerStatusRunning(ctx context.Context, server *h
 			)
 		}
 		record.Warnf(s.scope.HCloudMachine, "FailedDeleteHCloudServer", "Failed to delete HCloud server %s", s.scope.Name())
-		return &reconcile.Result{}, fmt.Errorf("failed to delete server: %w", err)
+		return nil, fmt.Errorf("failed to delete server: %w", err)
 	}
 
 	record.Eventf(
@@ -558,7 +558,7 @@ func (s *Service) handleDeleteServerStatusOff(ctx context.Context, server *hclou
 			)
 		}
 		record.Warnf(s.scope.HCloudMachine, "FailedDeleteHCloudServer", "Failed to delete HCloud server %s", s.scope.Name())
-		return &reconcile.Result{}, fmt.Errorf("failed to delete server: %w", err)
+		return nil, fmt.Errorf("failed to delete server: %w", err)
 	}
 
 	record.Eventf(


### PR DESCRIPTION
**What this PR does / why we need it**:
github.com/pkg/errors is included in the standard library for some time now. We should use the standard lib everywhere

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

