### PR TITLE
:seedling: Upgrade Go to 1.20.2

### DIFF
--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -4,7 +4,7 @@
   },
   // https://docs.renovatebot.com/configuration-options/#constraints
   "constraints": {
-    "go": "1.19"
+    "go": "1.20"
   },
   packageRules: [
     {

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,9 +75,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.19"
+    go: "1.20"
   stylecheck:
-    go: "1.19"
+    go: "1.20"
   gosec:
     excludes:
       - G307 # Deferring unsafe method "Close" on type "\*os.File"
@@ -105,7 +105,7 @@ linters-settings:
       - rangeValCopy
       - hugeParam
   unused:
-    go: "1.19"
+    go: "1.20"
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syself/cluster-api-provider-hetzner
 
-go 1.19
+go 1.20
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.3.5
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/syself/cluster-api-provider-hetzner/hack/tools
 
-go 1.19
+go 1.20
 
 replace github.com/syself/cluster-api-provider-hetzner => ../../
 

--- a/images/caph/Dockerfile
+++ b/images/caph/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.19.7@sha256:7a8fb82f707b04e934ce1dea380924422b4942bb06f27ad4710fd63d711316ff as build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.20.2@sha256:f7099345b8e4a93c62dc5102e7eb19a9cdbad12e7e322644eeaba355d70e616d as build
 ARG TARGETOS TARGETARCH
 
 COPY . /src/cluster-api-provider-hetzner


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add a icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR upgrades Go to 1.20. This is needed to use `errors.Join()` or multiple `%w` entries in `fmt.Errorf()`.

