### PR TITLE
:seedling: Update timeouts for E2E tests

### DIFF
--- a/test/e2e/config/hetzner-ci.yaml
+++ b/test/e2e/config/hetzner-ci.yaml
@@ -157,18 +157,7 @@ variables:
   REDACT_LOG_SCRIPT: "../../hack/log/redact.sh"
 
 intervals:
-  default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["30m", "10s"]
-  default/wait-worker-nodes: ["15m", "10s"]
-  default/wait-controllers: ["5m", "10s"]
-  default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["20m", "10s"]
-  default/wait-machine-status: ["20m", "10s"]
-  default/wait-failed-machine-status: ["2m", "10s"]
-  default/wait-machine-remediation: ["15m", "10s"]
-  default/wait-deployment: ["5m", "10s"]
-  default/wait-job: ["5m", "10s"]
-  default/wait-nodes-ready: ["15m", "10s"]
-  default/wait-service: ["3m", "10s"]
-  node-drain/wait-deployment-available: ["3m", "10s"]
-  node-drain/wait-machine-deleted: ["15m", "10s"]
+  default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
+  default/wait-control-plane: ["8m", "10s"] ## wait until first control plane is ready
+  default/wait-worker-nodes: ["15m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
+  default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -163,18 +163,7 @@ variables:
   REDACT_LOG_SCRIPT: "../../hack/log/redact.sh"
 
 intervals:
-  default/wait-cluster: ["20m", "10s"]
-  default/wait-control-plane: ["30m", "10s"]
-  default/wait-worker-nodes: ["15m", "10s"]
-  default/wait-controllers: ["5m", "10s"]
-  default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["20m", "10s"]
-  default/wait-machine-status: ["20m", "10s"]
-  default/wait-failed-machine-status: ["2m", "10s"]
-  default/wait-machine-remediation: ["15m", "10s"]
-  default/wait-deployment: ["5m", "10s"]
-  default/wait-job: ["5m", "10s"]
-  default/wait-nodes-ready: ["15m", "10s"]
-  default/wait-service: ["3m", "10s"]
-  node-drain/wait-deployment-available: ["3m", "10s"]
-  node-drain/wait-machine-deleted: ["15m", "10s"]
+  default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
+  default/wait-control-plane: ["8m", "10s"] ## wait until first control plane is ready
+  default/wait-worker-nodes: ["15m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
+  default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted


### PR DESCRIPTION
**What this PR does / why we need it**:
The timeouts were too high in most of the cases. To make it more understandable, comments are describing what the interval is meant to be used for. Most intervals are not used at all.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

