### PR TITLE
:sparkles: Notify user when robot ssh key already exists

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -307,6 +307,11 @@ func (s *Service) ensureSSHKey(sshSecretRef infrav1.SSHSecretRef, sshSecret *cor
 				)
 				return infrav1.SSHKey{}, actionContinue{}
 			}
+			if models.IsError(err, models.ErrorCodeKeyAlreadyExists) {
+				record.Warnf(s.scope.HetznerBareMetalHost, "SSHKeyAlreadyExists",
+					"failed to upload ssh key %s - it already exists under a different name", string(sshSecret.Data[sshSecretRef.Key.Name]))
+				return infrav1.SSHKey{}, s.recordActionFailure(infrav1.FatalError, "cannot upload ssh key - exists already under a different name")
+			}
 			return infrav1.SSHKey{}, actionError{err: fmt.Errorf("failed to set ssh key: %w", err)}
 		}
 		sshKey.Name = hetznerSSHKey.Name


### PR DESCRIPTION
**What this PR does / why we need it**:
There is currently a case where a bare metal server cannot start due to a wrong ssh key, but the user is not notified except for log messages.

Now an event is published and the host machine sets a fatal error, so that it is obvious to the user that something is wrong.

The use case is when the user uses an ssh key for bare metal which has been already uploaded to Hetzner robot under a different name. As the keys are compared via name, the controller does not figure out that the key exists in reality and uploads it again. This is when Hetzner Robot returns an error.

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

