### PR TITLE
:seedling: Replace pkg/errors with std lib errors

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -324,7 +324,7 @@ func GetImageSuffix(url string) (string, error) {
 		}
 	}
 
-	return "", errors.Wrapf(errUnknownSuffix, "unknown suffix in URL %s", url)
+	return "", fmt.Errorf("unknown suffix in URL %s: %w", url, errUnknownSuffix)
 }
 
 // HasHostAnnotation checks whether the annotation that references a host exists.

--- a/api/v1beta1/hetznerbaremetalmachine_types_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
@@ -199,7 +198,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 					},
 				})
 				if err != nil {
-					return errors.Wrap(err, "error while listing load balancers")
+					return fmt.Errorf("failed to list load balancers: %w", err)
 				}
 				if len(loadBalancers) > 1 {
 					return fmt.Errorf("there are multiple load balancers found: %v", loadBalancers)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/hetznercloud/hcloud-go v1.41.0
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
 	github.com/syself/hrobot-go v0.2.4
 	go.uber.org/zap v1.24.0
@@ -100,6 +99,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/pkg/scope/baremetalhost.go
+++ b/pkg/scope/baremetalhost.go
@@ -19,10 +19,10 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	robotclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/robot"
@@ -117,7 +117,7 @@ func (s *BareMetalHostScope) GetRawBootstrapData(ctx context.Context) ([]byte, e
 	key := types.NamespacedName{Namespace: s.HetznerBareMetalHost.Spec.Status.UserData.Namespace, Name: s.HetznerBareMetalHost.Spec.Status.UserData.Name}
 	secret, err := s.SecretManager.AcquireSecret(ctx, key, s.HetznerBareMetalHost, false, false)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to acquire secret")
+		return nil, fmt.Errorf("failed to acquire secret: %w", err)
 	}
 
 	value, ok := secret.Data["value"]

--- a/pkg/scope/baremetalmachine.go
+++ b/pkg/scope/baremetalmachine.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -66,7 +65,7 @@ func NewBareMetalMachineScope(ctx context.Context, params BareMetalMachineScopeP
 
 	patchHelper, err := patch.NewHelper(params.BareMetalMachine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	return &BareMetalMachineScope{

--- a/pkg/scope/baremetalremediation.go
+++ b/pkg/scope/baremetalremediation.go
@@ -18,9 +18,10 @@ package scope
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -55,7 +56,7 @@ func NewBareMetalRemediationScope(ctx context.Context, params BareMetalRemediati
 
 	patchHelper, err := patch.NewHelper(params.BareMetalRemediation, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	return &BareMetalRemediationScope{

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -19,10 +19,10 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
@@ -69,7 +69,7 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 
 	helper, err := patch.NewHelper(params.HetznerCluster, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	return &ClusterScope{
@@ -153,11 +153,11 @@ func (s *ClusterScope) ClientConfig(ctx context.Context) (clientcmd.ClientConfig
 	secretManager := secretutil.NewSecretManager(s.Logger, s.Client, s.APIReader)
 	kubeconfigSecret, err := secretManager.AcquireSecret(ctx, cluster, s.HetznerCluster, false, false)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to acquire secret")
+		return nil, fmt.Errorf("failed to acquire secret: %w", err)
 	}
 	kubeconfigBytes, ok := kubeconfigSecret.Data[secret.KubeconfigDataName]
 	if !ok {
-		return nil, errors.Errorf("missing key %q in secret data", secret.KubeconfigDataName)
+		return nil, fmt.Errorf("missing key %q in secret data", secret.KubeconfigDataName)
 	}
 	return clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
 }
@@ -171,7 +171,7 @@ func (s *ClusterScope) ClientConfigWithAPIEndpoint(ctx context.Context, endpoint
 
 	raw, err := c.RawConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving rawConfig from clientConfig")
+		return nil, fmt.Errorf("error retrieving rawConfig from clientConfig: %w", err)
 	}
 	// update cluster endpint in config
 	for key := range raw.Clusters {

--- a/pkg/scope/hcloudmachinetemplate.go
+++ b/pkg/scope/hcloudmachinetemplate.go
@@ -19,9 +19,10 @@ package scope
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"k8s.io/klog/v2/klogr"
@@ -51,7 +52,7 @@ func NewHCloudMachineTemplateScope(ctx context.Context, params HCloudMachineTemp
 
 	helper, err := patch.NewHelper(params.HCloudMachineTemplate, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	return &HCloudMachineTemplateScope{

--- a/pkg/scope/hcloudremediation.go
+++ b/pkg/scope/hcloudremediation.go
@@ -18,9 +18,10 @@ package scope
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
@@ -66,12 +67,12 @@ func NewHCloudRemediationScope(ctx context.Context, params HCloudRemediationScop
 
 	patchHelper, err := patch.NewHelper(params.HCloudRemediation, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	machinePatchHelper, err := patch.NewHelper(params.Machine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init machine patch helper")
+		return nil, fmt.Errorf("failed to init machine patch helper: %w", err)
 	}
 
 	return &HCloudRemediationScope{

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -18,10 +18,11 @@ package scope
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"hash/crc32"
 	"sort"
 
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,12 +57,12 @@ func NewMachineScope(ctx context.Context, params MachineScopeParams) (*MachineSc
 
 	cs, err := NewClusterScope(ctx, params.ClusterScopeParams)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed create new cluster scope: %w", err)
 	}
 
 	cs.patchHelper, err = patch.NewHelper(params.HCloudMachine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	return &MachineScope{
@@ -172,7 +173,7 @@ func (m *MachineScope) GetRawBootstrapData(ctx context.Context) ([]byte, error) 
 	secretManager := secretutil.NewSecretManager(m.Logger, m.Client, m.APIReader)
 	secret, err := secretManager.AcquireSecret(ctx, key, m.HCloudMachine, false, false)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to acquire secret")
+		return nil, fmt.Errorf("failed to acquire secret: %w", err)
 	}
 
 	value, ok := secret.Data["value"]

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -19,12 +19,12 @@ package sshclient
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -341,7 +341,7 @@ func (c *sshClient) runSSH(command string) Output {
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey([]byte(c.privateSSHKey))
 	if err != nil {
-		return Output{Err: errors.Errorf("unable to parse private key: %v", err)}
+		return Output{Err: fmt.Errorf("unable to parse private key: %w", err)}
 	}
 
 	config := &ssh.ClientConfig{
@@ -364,7 +364,7 @@ func (c *sshClient) runSSH(command string) Output {
 
 	sess, err := client.NewSession()
 	if err != nil {
-		return Output{Err: errors.Wrap(err, "unable to create new ssh session")}
+		return Output{Err: fmt.Errorf("unable to create new ssh session: %w", err)}
 	}
 	defer sess.Close()
 

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -23,7 +23,6 @@ import (
 	"net"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	"github.com/pkg/errors"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
@@ -182,7 +181,7 @@ func (c *cacheHCloudClient) ListLoadBalancers(ctx context.Context, opts hcloud.L
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert label selector to labels")
+		return nil, fmt.Errorf("failed to convert label selector to labels: %w", err)
 	}
 
 	for _, lb := range c.loadBalancerCache.idMap {
@@ -446,7 +445,7 @@ func (c *cacheHCloudClient) ListServers(ctx context.Context, opts hcloud.ServerL
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert label selector to labels")
+		return nil, fmt.Errorf("failed to convert label selector to labels: %w", err)
 	}
 
 	for _, s := range c.serverCache.idMap {
@@ -545,7 +544,7 @@ func (c *cacheHCloudClient) ListNetworks(ctx context.Context, opts hcloud.Networ
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert label selector to labels")
+		return nil, fmt.Errorf("failed to convert label selector to labels: %w", err)
 	}
 
 	for _, network := range c.networkCache.idMap {
@@ -615,7 +614,7 @@ func (c *cacheHCloudClient) ListPlacementGroups(ctx context.Context, opts hcloud
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert label selector to labels")
+		return nil, fmt.Errorf("failed to convert label selector to labels: %w", err)
 	}
 
 	for _, pg := range c.placementGroupCache.idMap {

--- a/pkg/services/hcloud/placementgroup/placementgroup.go
+++ b/pkg/services/hcloud/placementgroup/placementgroup.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	"github.com/pkg/errors"
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
@@ -53,7 +52,7 @@ func (s *Service) Reconcile(ctx context.Context) (err error) {
 	// find placement groups
 	placementGroups, err := s.findPlacementGroups(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to find placement group")
+		return fmt.Errorf("failed to find placement group: %w", err)
 	}
 
 	s.scope.HetznerCluster.Status.HCloudPlacementGroup = apiToStatus(placementGroups, s.scope.HetznerCluster.Name)
@@ -104,13 +103,13 @@ func (s *Service) Reconcile(ctx context.Context) (err error) {
 	}
 
 	if err := kerrors.NewAggregate(multierr); err != nil {
-		return errors.Wrap(err, "aggregate error - creating/deleting placement groups")
+		return fmt.Errorf("aggregate error - creating/deleting placement groups: %w", err)
 	}
 
 	// Update status
 	placementGroups, err = s.findPlacementGroups(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to find placement group")
+		return fmt.Errorf("failed to find placement group: %w", err)
 	}
 
 	s.scope.HetznerCluster.Status.HCloudPlacementGroup = apiToStatus(placementGroups, s.scope.HetznerCluster.Name)
@@ -152,7 +151,7 @@ func (s *Service) findPlacementGroups(ctx context.Context) ([]*hcloud.PlacementG
 	placementGroups, err := s.scope.HCloudClient.ListPlacementGroups(ctx, opts)
 	if err != nil {
 		hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "ListPlacementGroups")
-		return nil, errors.Wrap(err, "failed to list placement groups")
+		return nil, fmt.Errorf("failed to list placement groups: %w", err)
 	}
 	return placementGroups, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -56,7 +55,7 @@ func LabelSelectorToLabels(str string) (map[string]string, error) {
 	input = fmt.Sprintf(`{"%s"}`, input) //nolint:gocritic
 
 	if err := json.Unmarshal([]byte(input), &labels); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal")
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
 	return labels, nil
 }

--- a/test/helpers/mod.go
+++ b/test/helpers/mod.go
@@ -30,9 +30,9 @@ limitations under the License.
 package helpers
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"golang.org/x/mod/modfile"
 )
 
@@ -67,7 +67,7 @@ func (m mod) FindDependencyVersion(dependency string) (string, error) {
 		}
 	}
 	if version == "" {
-		return version, errors.Errorf("could not find required package: %s", dependency)
+		return version, fmt.Errorf("could not find required package: %s", dependency)
 	}
 
 	for _, entry := range f.Replace {


### PR DESCRIPTION
**What this PR does / why we need it**:
Replacing the outdated pkg/errors library with the standard Go library which contains everything from the pkg/errors library.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

