### PR TITLE
:sparkles: Track target cluster status through conditions 

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -80,6 +80,15 @@ const (
 )
 
 const (
+	// HetznerClusterTargetClusterReady reports on whether the kubeconfig in the target cluster is ready.
+	HetznerClusterTargetClusterReady clusterv1.ConditionType = "HetznerClusterTargetClusterReady"
+	// KubeConfigNotFound indicates that the Kubeconfig could not be found.
+	KubeConfigNotFound = "KubeConfigNotFound"
+	// KubeAPIServerNotResponding indicates that the api server cannot be reached.
+	KubeAPIServerNotResponding = "KubeAPIServerNotResponding"
+)
+
+const (
 	// RateLimitExceeded reports whether the rate limit has been reached.
 	RateLimitExceeded clusterv1.ConditionType = "RateLimitExceeded"
 	// RateLimitNotReachedReason indicates that the rate limit is not reached yet.


### PR DESCRIPTION
**What this PR does / why we need it**:
We now track the status of the target cluster (workload cluster) through conditions in HetznerCluster object.

When a cluster starts, there are multiple errors that occur temporarily, but are expected. However, they litter the log files and make it harder to debug a cluster, especially for users who are not so familiar with the code.

To reduce the error messages, we use conditions that indicate that a certain step cannot be done yet. If a rare case happens when the cluster is stuck forever in a certain state which is related to errors that we ignore at the beginning, then the user can use the conditions in HetznerCluster to find out what happens.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

