### PR TITLE
:sparkles: Add conditions to HetznerBareMetalHost

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -91,6 +91,14 @@ const (
 	HetznerBareMetalHostReady clusterv1.ConditionType = "HetznerBareMetalHostReady"
 	// RobotCredentialsInvalidReason indicates that credentials for Robot are invalid.
 	RobotCredentialsInvalidReason = "RobotCredentialsInvalid" // #nosec
+	// SSHCredentialsInSecretInvalid indicates that ssh credentials are invalid.
+	SSHCredentialsInSecretInvalid = "SSHCredentialsInSecretInvalid" // #nosec
+	// SSHKeyAlreadyExists indicates that the ssh key which is specified in the host spec exists already under a different name in Hetzner robot.
+	SSHKeyAlreadyExists = "SSHKeyAlreadyExists"
+	// OSSSHSecretMissing indicates that secret with the os ssh key is missing.
+	OSSSHSecretMissing = "OSSSHSecretMissing"
+	// RescueSSHSecretMissing indicates that secret with the rescue ssh key is missing.
+	RescueSSHSecretMissing = "RescueSSHSecretMissing"
 )
 
 const (

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -409,8 +409,6 @@ type HetznerBareMetalHostStatus struct{}
 // +kubebuilder:printcolumn:name="Clock speed",type="string",JSONPath=".spec.status.hardwareDetails.cpu.clockGigahertz",description="CPU clock speed"
 // +kubebuilder:printcolumn:name="RAM in GB",type="string",JSONPath=".spec.status.hardwareDetails.ramGB",description="RAM in GB"
 // +kubebuilder:printcolumn:name="Consumer",type="string",JSONPath=".spec.consumerRef.name",description="Consumer using this host"
-// +kubebuilder:printcolumn:name="ErrorType",type="string",JSONPath=".spec.status.errorType",description="Type of the most recent error"
-// +kubebuilder:printcolumn:name="ErrorMessage",type="string",JSONPath=".spec.status.errorMessage",description="Message of the most recent error"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of BaremetalHost"
 // +k8s:defaulter-gen=true
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -47,14 +47,6 @@ spec:
       jsonPath: .spec.consumerRef.name
       name: Consumer
       type: string
-    - description: Type of the most recent error
-      jsonPath: .spec.status.errorType
-      name: ErrorType
-      type: string
-    - description: Message of the most recent error
-      jsonPath: .spec.status.errorMessage
-      name: ErrorMessage
-      type: string
     - description: Time duration since creation of BaremetalHost
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -35,7 +35,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
+	"sigs.k8s.io/cluster-api/util/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -216,14 +219,22 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 		osSSHSecret, err = secretManager.ObtainSecret(ctx, osSSHSecretNamespacedName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				bmHost.SetError(infrav1.PreparationError, infrav1.ErrorMessageMissingOSSSHSecret)
+				conditions.MarkFalse(
+					bmHost,
+					infrav1.HetznerBareMetalHostReady,
+					infrav1.OSSSHSecretMissing,
+					clusterv1.ConditionSeverityError,
+					infrav1.ErrorMessageMissingOSSSHSecret,
+				)
+
+				record.Warnf(bmHost, infrav1.OSSSHSecretMissing, infrav1.ErrorMessageMissingOSSSHSecret)
 
 				result, err := host.SaveHostAndReturn(ctx, r.Client, bmHost)
 				if result != emptyResult || err != nil {
 					return nil, nil, res, err
 				}
 
-				return nil, nil, ctrl.Result{RequeueAfter: host.CalculateBackoff(bmHost.Spec.Status.ErrorCount)}, nil
+				return nil, nil, ctrl.Result{Requeue: true}, nil
 			}
 			return nil, nil, res, errors.Wrap(err, "failed to get secret")
 		}
@@ -232,14 +243,22 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 		rescueSSHSecret, err = secretManager.AcquireSecret(ctx, rescueSSHSecretNamespacedName, hetznerCluster, false, hetznerCluster.DeletionTimestamp.IsZero())
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				bmHost.SetError(infrav1.PreparationError, infrav1.ErrorMessageMissingRescueSSHSecret)
+				conditions.MarkFalse(
+					bmHost,
+					infrav1.HetznerBareMetalHostReady,
+					infrav1.RescueSSHSecretMissing,
+					clusterv1.ConditionSeverityError,
+					infrav1.ErrorMessageMissingRescueSSHSecret,
+				)
+
+				record.Warnf(bmHost, infrav1.RescueSSHSecretMissing, infrav1.ErrorMessageMissingRescueSSHSecret)
 
 				result, err := host.SaveHostAndReturn(ctx, r.Client, bmHost)
 				if result != emptyResult || err != nil {
 					return nil, nil, result, err
 				}
 
-				return nil, nil, ctrl.Result{RequeueAfter: host.CalculateBackoff(bmHost.Spec.Status.ErrorCount)}, nil
+				return nil, nil, ctrl.Result{Requeue: true}, nil
 			}
 			return nil, nil, res, errors.Wrap(err, "failed to acquire secret")
 		}
@@ -294,18 +313,33 @@ func hetznerSecretErrorResult(
 	// we requeue the host as we will not know if they create the secret
 	// at some point in the future.
 	case *secretutil.ResolveSecretRefError:
-		bmHost.SetError(infrav1.PreparationError, infrav1.ErrorMessageMissingHetznerSecret)
+		conditions.MarkFalse(
+			bmHost,
+			infrav1.HetznerBareMetalHostReady,
+			infrav1.HetznerSecretUnreachableReason,
+			clusterv1.ConditionSeverityError,
+			infrav1.ErrorMessageMissingHetznerSecret,
+		)
+
+		record.Warnf(bmHost, infrav1.HetznerSecretUnreachableReason, infrav1.ErrorMessageMissingHetznerSecret)
 
 		result, err := host.SaveHostAndReturn(ctx, client, bmHost)
 		emptyResult := reconcile.Result{}
 		if result != emptyResult || err != nil {
 			return result, err
 		}
-		backoff := host.CalculateBackoff(bmHost.Spec.Status.ErrorCount)
-		res = ctrl.Result{RequeueAfter: backoff}
+
+		res = ctrl.Result{Requeue: true}
 		// No need to reconcile again, as it will be triggered as soon as the secret is updated.
 	case *bmclient.CredentialsValidationError:
-		bmHost.SetError(infrav1.PreparationError, infrav1.ErrorMessageMissingOrInvalidSecretData)
+		conditions.MarkFalse(
+			bmHost,
+			infrav1.HetznerBareMetalHostReady,
+			infrav1.RobotCredentialsInvalidReason,
+			clusterv1.ConditionSeverityError,
+			infrav1.ErrorMessageMissingOrInvalidSecretData,
+		)
+		record.Warnf(bmHost, infrav1.SSHKeyAlreadyExists, infrav1.ErrorMessageMissingOrInvalidSecretData)
 
 		res, err = host.SaveHostAndReturn(ctx, client, bmHost)
 

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -723,7 +723,7 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 				if err := testEnv.Get(ctx, key, host); err != nil {
 					return false
 				}
-				return verifyError(host, infrav1.PreparationError, infrav1.ErrorMessageMissingRescueSSHSecret)
+				return isPresentAndFalseWithReason(key, host, infrav1.HetznerBareMetalHostReady, infrav1.RescueSSHSecretMissing)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -748,7 +748,7 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 				if err := testEnv.Get(ctx, key, host); err != nil {
 					return false
 				}
-				return verifyError(host, infrav1.PreparationError, infrav1.ErrorMessageMissingOrInvalidSecretData)
+				return isPresentAndFalseWithReason(key, host, infrav1.HetznerBareMetalHostReady, infrav1.SSHCredentialsInSecretInvalid)
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -781,7 +781,7 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 				if err := testEnv.Get(ctx, key, host); err != nil {
 					return false
 				}
-				return verifyError(host, infrav1.PreparationError, infrav1.ErrorMessageMissingOSSSHSecret)
+				return isPresentAndFalseWithReason(key, host, infrav1.HetznerBareMetalHostReady, infrav1.OSSSHSecretMissing)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -806,7 +806,7 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 				if err := testEnv.Get(ctx, key, host); err != nil {
 					return false
 				}
-				return verifyError(host, infrav1.PreparationError, infrav1.ErrorMessageMissingOrInvalidSecretData)
+				return isPresentAndFalseWithReason(key, host, infrav1.HetznerBareMetalHostReady, infrav1.SSHCredentialsInSecretInvalid)
 			}, timeout).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding conditions in case that something is wrong with secrets or credentials which the user has to specify. There are secrets for Hetzner robot and for the SSH keys used to provision the bare metal servers.

Removing the error message of spec.status from printcolumns, as it is used only internally for the controller to manage the provisioning process.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [x] add unit tests

