### PR TITLE
:seedling: Increase e2e timeout for control planes

### DIFF
--- a/test/e2e/config/hetzner-ci.yaml
+++ b/test/e2e/config/hetzner-ci.yaml
@@ -158,6 +158,6 @@ variables:
 
 intervals:
   default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
-  default/wait-control-plane: ["15m", "10s"] ## wait until first control plane is ready
+  default/wait-control-plane: ["20m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
   default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -164,6 +164,6 @@ variables:
 
 intervals:
   default/wait-cluster: ["5m", "10s"] ## wait until Infrastructure == ready and ControlPlaneEndpoint is valid
-  default/wait-control-plane: ["15m", "10s"] ## wait until first control plane is ready
+  default/wait-control-plane: ["20m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
   default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted


### PR DESCRIPTION
**What this PR does / why we need it**:
Our timeout for control planes is currently 15 minutes. This is not enough for bare metal, as it is used separately for a) the first control plane (which needs max 15m) and b) all the rest of the control planes (which need more time from the point where the first control plane is ready).

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

