### PR TITLE
:seedling: Improve error handling for locked servers

### DIFF
--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -159,7 +159,6 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 }
 
 func (r *HCloudMachineReconciler) reconcileDelete(ctx context.Context, machineScope *scope.MachineScope) (reconcile.Result, error) {
-	machineScope.Info("Reconciling HCloudMachine delete")
 	hcloudMachine := machineScope.HCloudMachine
 
 	// Delete servers.
@@ -178,7 +177,6 @@ func (r *HCloudMachineReconciler) reconcileDelete(ctx context.Context, machineSc
 }
 
 func (r *HCloudMachineReconciler) reconcileNormal(ctx context.Context, machineScope *scope.MachineScope) (reconcile.Result, error) {
-	machineScope.Info("Reconciling HCloudMachine")
 	hcloudMachine := machineScope.HCloudMachine
 
 	// If the HCloudMachine doesn't have our finalizer, add it.
@@ -254,17 +252,14 @@ func (r *HCloudMachineReconciler) HetznerClusterToHCloudMachines(ctx context.Con
 
 		// Don't handle deleted HetznerCluster
 		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
-			log.V(1).Info("HetznerCluster has a deletion timestamp, skipping mapping")
 			return nil
 		}
 
 		cluster, err := util.GetOwnerCluster(ctx, r.Client, c.ObjectMeta)
 		switch {
 		case apierrors.IsNotFound(err) || cluster == nil:
-			log.V(1).Info("Cluster for HetznerCluster not found, skipping mapping")
 			return result
 		case err != nil:
-			log.Error(err, "failed to get owning cluster, skipping mapping")
 			return result
 		}
 
@@ -277,15 +272,12 @@ func (r *HCloudMachineReconciler) HetznerClusterToHCloudMachines(ctx context.Con
 		for _, m := range machineList.Items {
 			log = log.WithValues("machine", m.Name)
 			if m.Spec.InfrastructureRef.GroupVersionKind().Kind != "HCloudMachine" {
-				log.V(1).Info("Machine has an InfrastructureRef for a different type, will not add to reconciliation request")
 				continue
 			}
 			if m.Spec.InfrastructureRef.Name == "" {
 				continue
 			}
 			name := client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.InfrastructureRef.Name}
-
-			log.V(1).Info("Adding HCloudMachine to reconciliation request", "hcloudMachine", name.Name)
 
 			result = append(result, reconcile.Request{NamespacedName: name})
 		}

--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -146,7 +146,6 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 }
 
 func (r *HetznerBareMetalMachineReconciler) reconcileDelete(ctx context.Context, machineScope *scope.BareMetalMachineScope) (reconcile.Result, error) {
-	machineScope.Info("Reconciling HetznerBareMetalMachine delete")
 	// delete servers
 	result, err := baremetal.NewService(machineScope).Delete(ctx)
 	if err != nil {
@@ -244,11 +243,10 @@ func (r *HetznerBareMetalMachineReconciler) HetznerClusterToBareMetalMachines(ct
 			return nil
 		}
 
-		log = log.WithValues("objectMapper", "hetznerClusterToBareMetalMachine", "namespace", c.Namespace, "hetznerCluster", c.Name)
+		log := log.WithValues("objectMapper", "hetznerClusterToBareMetalMachine", "namespace", c.Namespace, "hetznerCluster", c.Name)
 
 		// Don't handle deleted HetznerCluster
 		if !c.ObjectMeta.DeletionTimestamp.IsZero() {
-			log.V(1).Info("HetznerCluster has a deletion timestamp, skipping mapping")
 			return nil
 		}
 
@@ -269,9 +267,7 @@ func (r *HetznerBareMetalMachineReconciler) HetznerClusterToBareMetalMachines(ct
 			return nil
 		}
 		for _, m := range machineList.Items {
-			log = log.WithValues("machine", m.Name)
 			if m.Spec.InfrastructureRef.GroupVersionKind().Kind != "HetznerBareMetalMachine" {
-				log.V(1).Info("Machine has an InfrastructureRef for a different type, will not add to reconciliation request")
 				continue
 			}
 			if m.Spec.InfrastructureRef.Name == "" {
@@ -279,8 +275,6 @@ func (r *HetznerBareMetalMachineReconciler) HetznerClusterToBareMetalMachines(ct
 			}
 
 			name := client.ObjectKey{Namespace: m.Namespace, Name: m.Spec.InfrastructureRef.Name}
-
-			log.V(1).Info("Adding BareMetalMachine to reconciliation request", "bareMetalMachine", name.Name)
 
 			result = append(result, reconcile.Request{NamespacedName: name})
 		}

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -657,22 +657,17 @@ func (r *HetznerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 				panic(fmt.Sprintf("Expected a Cluster but got a %T", o))
 			}
 
-			log := log.WithValues("objectMapper", "clusterToHetznerCluster", "namespace", c.Namespace, "cluster", c.Name)
-
 			// Don't handle deleted clusters
 			if !c.ObjectMeta.DeletionTimestamp.IsZero() {
-				log.V(1).Info("Cluster has a deletion timestamp, skipping mapping.")
 				return nil
 			}
 
 			// Make sure the ref is set
 			if c.Spec.InfrastructureRef == nil {
-				log.V(1).Info("Cluster does not have an InfrastructureRef, skipping mapping.")
 				return nil
 			}
 
 			if c.Spec.InfrastructureRef.GroupVersionKind().Kind != "HetznerCluster" {
-				log.V(1).Info("Cluster has an InfrastructureRef for a different type, skipping mapping.")
 				return nil
 			}
 
@@ -684,11 +679,9 @@ func (r *HetznerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			}
 
 			if annotations.IsExternallyManaged(hetznerCluster) {
-				log.V(1).Info("HetznerCluster is externally managed, skipping mapping.")
 				return nil
 			}
 
-			log.V(1).Info("Adding request.", "hetznerCluster", c.Spec.InfrastructureRef.Name)
 			return []ctrl.Request{
 				{
 					NamespacedName: client.ObjectKey{Namespace: c.Namespace, Name: c.Spec.InfrastructureRef.Name},

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -51,8 +51,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 	log := s.scope.Logger.WithValues("reconciler", "load balancer")
 
-	log.V(1).Info("Start reconciling")
-
 	// find load balancer
 	lb, err := s.findLoadBalancer(ctx)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When a HCloud server is locked, this is because the API is doing something for a short time where no other API request for that server can go through - namely right after a server is created. We ignore these errors in the future and just trigger another reconcilement.

Additionally, some unused log statements are removed.


**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

