### PR TITLE
:bug: Fix resetting bm servers

### DIFF
--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -157,6 +157,11 @@ func (s *Service) Delete(ctx context.Context) (res reconcile.Result, err error) 
 			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 
+		// remove ssh spec - this was needed for the host to fully deprovision
+		if host.Spec.Status.SSHSpec != nil {
+			host.Spec.Status.SSHSpec = nil
+		}
+
 		// deprovisiong is done - remove all references of host
 		host.Spec.ConsumerRef = nil
 		host.Spec.Status.HetznerClusterRef = ""
@@ -652,10 +657,6 @@ func removeMachineSpecsFromHost(host *infrav1.HetznerBareMetalHost) (updatedHost
 	}
 	if host.Spec.Status.UserData != nil {
 		host.Spec.Status.UserData = nil
-		updatedHost = true
-	}
-	if host.Spec.Status.SSHSpec != nil {
-		host.Spec.Status.SSHSpec = nil
 		updatedHost = true
 	}
 	emptySSHStatus := infrav1.SSHStatus{}

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -313,7 +313,7 @@ func (c *sshClient) CleanCloudInitInstances() Output {
 
 // ResetKubeadm implements the ResetKubeadm method of the SSHClient interface.
 func (c *sshClient) ResetKubeadm() Output {
-	return c.runSSH(`kubeadm reset -f`)
+	return c.runSSH(`kubeadm reset -f 2>&1 || true`)
 }
 
 // IsConnectionRefusedError checks whether the ssh error is a connection refused error.


### PR DESCRIPTION
**What this PR does / why we need it**:
The bare metal servers are supposed to be resetted when a HetznerBareMetalMachine object is deleted. At the moment, there are two problems. First, the SSH secret reference was deleted before it was used and second the SSH command didn't work.

TODO: Update SSH command

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests


Current failure:

"[preflight] Running pre-flight checks\n[reset] No etcd config found. Assuming external etcd\n[reset] Please, manually reset etcd to prevent further issues\n[reset] Stopping the kubelet service\n[reset] Unmounting mounted directories in "/var/lib/kubelet\"\n[reset] Deleting contents of directories: [/etc/kubernetes/manifests /etc/kubernetes/pki]\n[reset] Deleting files: [/etc/kubernetes/admin.conf /etc/kubernetes/kubelet.conf /etc/kubernetes/bootstrap-kubelet.conf /etc/kubernetes/controller-manager.conf /etc/kubernetes/scheduler.conf]\n[reset] Deleting contents of stateful directories: [/var/lib/kubelet]\n\nThe reset process does not clean CNI configuration. To do so, you must remove /etc/cni/net.d\n\nThe reset process does not reset or clean up iptables rules or IPVS tables.\nIf you wish to reset iptables, you must do so manually by using the \"iptables\" command.\n\nIf your cluster was setup to utilize IPVS, run ipvsadm --clear (or similar)\nto reset your system's IPVS tables.\n\nThe reset process does not clean your kubeconfig files and you must remove them manually.\nPlease, check the contents of the $HOME/.kube/config file.\n" 

"W0710 17:39:29.701352    7648 removeetcdmember.go:85] [reset] No kubeadm config, using etcd pod spec to get data directory\n" 
