### PR TITLE
:bug: Update CRDs after update of controller-gen

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hcloudmachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -151,8 +151,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hcloudmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediations.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hcloudremediations.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediationtemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediationtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hcloudremediationtemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerbaremetalhosts.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerbaremetalmachines.infrastructure.cluster.x-k8s.io
 spec:
@@ -290,8 +290,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerbaremetalmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalremediations.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalremediations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerbaremetalremediations.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalremediationtemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalremediationtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerbaremetalremediationtemplates.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerclusters.infrastructure.cluster.x-k8s.io
 spec:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: hetznerclustertemplates.infrastructure.cluster.x-k8s.io
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
In the update to controller-gen v0.11.3 the CRDs where not updated accordingly.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

