### PR TITLE
:bug: Update metadata for e2e tests and CAPI 1.4

### DIFF
--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
     minor: 3
     contract: v1beta1
   - major: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
The metadata used for e2e tests and clusterctl has to be updated as well to CAPI 1.4

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

