### PR TITLE
:seedling: fix `kubectl patch` in delete-workload-cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ move-to-workload-cluster: $(CLUSTERCTL)
 delete-workload-cluster: ## Deletes the example workload Kubernetes cluster
 	@test $${CLUSTER_NAME?Please set environment variable}
 	@echo 'Your Hetzner resources will now be deleted, this can take up to 20 minutes'
-	kubectl patch cluster $(CLUSTER_NAME) --type=merge -p '{"spec":{"paused": "false"}}' || true
+	kubectl patch cluster $(CLUSTER_NAME) --type=merge -p '{"spec":{"paused": false}}'
 	kubectl delete cluster $(CLUSTER_NAME)
 	${TIMEOUT} 15m bash -c "while kubectl get cluster | grep $(NAME); do sleep 1; done"
 	@echo 'Cluster deleted'


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

fix `kubectl patch` in delete-workload-cluster

Up to now the command always failed.

`paused` is a boolean:

```
❯ k explain cluster.spec.paused
KIND:     Cluster
VERSION:  cluster.x-k8s.io/v1beta1

FIELD:    paused <boolean>

DESCRIPTION:
     Paused can be used to prevent controllers from processing the Cluster and
     all its associated objects.

```
