### PR TITLE
✨ Add new ARM machine_types

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -37,7 +37,7 @@ type HCloudMachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// Type is the HCloud Machine Type for this machine.
-	// +kubebuilder:validation:Enum=cpx11;cx21;cpx21;cx31;cpx31;cx41;cpx41;cx51;cpx51;ccx11;ccx12;ccx21;ccx22;ccx31;ccx32;ccx41;ccx42;ccx51;ccx52;ccx62;cax11;cax21;cax31;cax41
+	// +kubebuilder:validation:Enum=cpx11;cax11;cx21;cpx21;cax21;cx31;cpx31;cax31;cx41;cpx41;cax41;cx51;cpx51;ccx11;ccx12;ccx21;ccx22;ccx31;ccx32;ccx41;ccx42;ccx51;ccx52;ccx62;cax11;cax21;cax31;cax41
 	Type HCloudMachineType `json:"type"`
 
 	// ImageName is the reference to the Machine Image from which to create the machine instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -125,12 +125,16 @@ spec:
                         description: Type is the HCloud Machine Type for this machine.
                         enum:
                         - cpx11
+                        - cax11
                         - cx21
                         - cpx21
+                        - cax21
                         - cx31
                         - cpx31
+                        - cax31
                         - cx41
                         - cpx41
+                        - cax41
                         - cx51
                         - cpx51
                         - ccx11


### PR DESCRIPTION
**What this PR does / why we need it**:
Hetzner just announced their ARM lineup for virtual hcloud servers.
They are available as "CAX" servers.

This PR adds support for those new cax machine-types by adding them to
the list of allowed values for the hcloud_server CRD.
See [htznr.li/Arm](https://htznr.li/Arm) for more info on their new
server type

**Which issue(s) this PR fixes**

fixes #772

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

/kind feature
/kind api-change
