### PR TITLE
:seedling: use metav1.NamespaceSystem

### DIFF
--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -433,7 +433,7 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 		return fmt.Errorf("failed to get client set: %w", err)
 	}
 
-	if _, err := clientSet.CoreV1().Secrets("kube-system").Get(
+	if _, err := clientSet.CoreV1().Secrets(metav1.NamespaceSystem).Get(
 		ctx,
 		clusterScope.HetznerCluster.Spec.HetznerSecret.Name,
 		metav1.GetOptions{},
@@ -489,12 +489,12 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 			TypeMeta:  metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterScope.HetznerCluster.Spec.HetznerSecret.Name,
-				Namespace: "kube-system",
+				Namespace: metav1.NamespaceSystem,
 			},
 		}
 
 		// create secret in cluster
-		if _, err := clientSet.CoreV1().Secrets("kube-system").Create(ctx, &newSecret, metav1.CreateOptions{}); err != nil {
+		if _, err := clientSet.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, &newSecret, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create secret: %w", err)
 		}
 	}


### PR DESCRIPTION
Don't use magic string "kube-system".

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

make code a bit cleaner by avoiding the magic string "kube-system".
