### PR TITLE
:seedling: added linter loggercheck

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - loggercheck
     - misspell
     - nakedret
     - nilerr


### PR DESCRIPTION
**What this PR does / why we need it**:

added linter loggercheck

**Which issue(s) this PR fixes** 

Avoid panic at runtime, if you accidentely use uneven key-value pairs for logging.

> panic: odd number of arguments passed as key-value pairs for logging