### PR TITLE
:bug: fix BUILDER_IMAGE_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ INFRA_PROVIDER = hetzner
 
 STAGING_IMAGE = $(INFRA_SHORT)-staging
 BUILDER_IMAGE = $(IMAGE_PREFIX)/$(INFRA_SHORT)-builder
+BUILDER_IMAGE_VERSION = $(shell cat .builder-image-version.txt)
 
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec


### PR DESCRIPTION

**What this PR does / why we need it**:

Last PR introduced an bug.

BUILDER_IMAGE_VERSION was empty.

