### PR TITLE
:seedling: .envrc.sample, fix hetzner-ccm, fix BM remediation.

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,3 +1,17 @@
 export TTS_TOKEN=...
 export CLUSTER_NAME=testing
 export KUBECONFIG=$PWD/.mgt-cluster-kubeconfig.yaml
+export HCLOUD_TOKEN=...
+export HCLOUD_SSH_KEY=test
+export HCLOUD_REGION=fsn1
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+export KUBERNETES_VERSION=v1.25.2
+export HCLOUD_IMAGE_NAME=1.23.4-ubuntu-20.04-containerd
+export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31
+export HCLOUD_WORKER_MACHINE_TYPE=cpx31
+export SSH_KEY=$HOME/.ssh/id_rsa.pub
+export HETZNER_SSH_PUB_PATH=$HOME/.ssh/id_rsa.pub
+export HETZNER_SSH_PRIV_PATH=$HOME/.ssh/id_rsa
+export HETZNER_ROBOT_USER=
+export HETZNER_ROBOT_PASSWORD=

--- a/Makefile
+++ b/Makefile
@@ -198,19 +198,22 @@ install-ccm-in-wl-cluster:
 	@echo 'run "kubectl --kubeconfig=$(WORKER_CLUSTER_KUBECONFIG) ..." to work with the new target cluster'
 
 add-ssh-pub-key:
-	@test $${HCLOUD_TOKEN?Please set environment variable}
-	@test $${SSH_KEY?Please set environment variable}
-	@test $${HCLOUD_SSH_KEY?Please set environment variable}
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN SSH_KEY HCLOUD_SSH_KEY
 	SSH_KEY_CONTENT=$$(cat $(SSH_KEY)) ; \
-	curl \
+	curl -sS \
 		-X POST \
 		-H "Authorization: Bearer $${HCLOUD_TOKEN}" \
 		-H "Content-Type: application/json" \
 		-d '{"labels":{},"name":"${HCLOUD_SSH_KEY}","public_key":"'"$${SSH_KEY_CONTENT}"'"}' \
 		'https://api.hetzner.cloud/v1/ssh_keys'
 
-create-workload-cluster-hcloud: $(KUSTOMIZE) $(ENVSUBST) install-crds ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+env-vars-for-wl-cluster:
+	@./hack/ensure-env-variables.sh CLUSTER_NAME CONTROL_PLANE_MACHINE_COUNT HCLOUD_CONTROL_PLANE_MACHINE_TYPE \
+	HCLOUD_REGION HCLOUD_SSH_KEY HCLOUD_WORKER_MACHINE_TYPE KUBERNETES_VERSION WORKER_MACHINE_COUNT
+
+create-workload-cluster-hcloud: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) install-crds ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN 
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/hcloud --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-hcloud.yaml
 	cat templates/cluster-templates/cluster-template-hcloud.yaml | $(ENVSUBST) - | $(KUBECTL) apply -f -
@@ -218,8 +221,9 @@ create-workload-cluster-hcloud: $(KUSTOMIZE) $(ENVSUBST) install-crds ## Creates
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=false
 
-create-workload-cluster-hcloud-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hcloud-packer: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/hcloud-packer --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-hcloud-packer.yaml
 	cat templates/cluster-templates/cluster-template-hcloud-packer.yaml | $(ENVSUBST) - | $(KUBECTL) apply -f -
@@ -227,8 +231,9 @@ create-workload-cluster-hcloud-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a wor
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=false
 
-create-workload-cluster-hcloud-talos-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hcloud-talos-packer: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/hcloud-talos-packer --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-hcloud-talos-packer.yaml
 	cat templates/cluster-templates/cluster-template-hcloud-talos-packer.yaml | $(ENVSUBST) - | $(KUBECTL) apply -f -
@@ -236,8 +241,9 @@ create-workload-cluster-hcloud-talos-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=false
 
-create-workload-cluster-hcloud-network: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hcloud-network: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/hcloud-network --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-hcloud-network.yaml
 	cat templates/cluster-templates/cluster-template-hcloud-network.yaml | $(ENVSUBST) - | $(KUBECTL) apply -f -
@@ -245,8 +251,9 @@ create-workload-cluster-hcloud-network: $(KUSTOMIZE) $(ENVSUBST) ## Creates a wo
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=true
 
-create-workload-cluster-hcloud-network-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hcloud-network-packer: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/hcloud-network-packer --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-hcloud-network-packer.yaml
 	cat templates/cluster-templates/cluster-template-hcloud-network-packer.yaml | $(ENVSUBST) - | $(KUBECTL) apply -f -
@@ -254,8 +261,9 @@ create-workload-cluster-hcloud-network-packer: $(KUSTOMIZE) $(ENVSUBST) ## Creat
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=true
 
-create-workload-cluster-hetzner-hcloud-control-plane: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hetzner-hcloud-control-plane: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN HETZNER_ROBOT_USER HETZNER_ROBOT_PASSWORD HETZNER_SSH_PRIV_PATH HETZNER_SSH_PUB_PATH
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --from-literal=robot-user=$(HETZNER_ROBOT_USER) --from-literal=robot-password=$(HETZNER_ROBOT_PASSWORD) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUBECTL) create secret generic robot-ssh --from-literal=sshkey-name=test --from-file=ssh-privatekey=${HETZNER_SSH_PRIV_PATH} --from-file=ssh-publickey=${HETZNER_SSH_PUB_PATH} --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/$(INFRA_PROVIDER)-hcloud-control-planes --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-$(INFRA_PROVIDER)-hcloud-control-planes.yaml
@@ -264,8 +272,9 @@ create-workload-cluster-hetzner-hcloud-control-plane: $(KUSTOMIZE) $(ENVSUBST) #
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=false
 
-create-workload-cluster-hetzner-baremetal-control-plane: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hetzner-baremetal-control-plane: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN HETZNER_ROBOT_USER HETZNER_ROBOT_PASSWORD HETZNER_SSH_PRIV_PATH HETZNER_SSH_PUB_PATH
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --from-literal=robot-user=$(HETZNER_ROBOT_USER) --from-literal=robot-password=$(HETZNER_ROBOT_PASSWORD) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUBECTL) create secret generic robot-ssh --from-literal=sshkey-name=test --from-file=ssh-privatekey=${HETZNER_SSH_PRIV_PATH} --from-file=ssh-publickey=${HETZNER_SSH_PUB_PATH} --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/$(INFRA_PROVIDER)-baremetal-control-planes --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-$(INFRA_PROVIDER)-baremetal-control-planes.yaml
@@ -274,8 +283,9 @@ create-workload-cluster-hetzner-baremetal-control-plane: $(KUSTOMIZE) $(ENVSUBST
 	$(MAKE) install-cilium-in-wl-cluster
 	$(MAKE) install-ccm-in-wl-cluster PRIVATE_NETWORK=false
 
-create-workload-cluster-hetzner-baremetal-control-plane-remediation: $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
+create-workload-cluster-hetzner-baremetal-control-plane-remediation: env-vars-for-wl-cluster $(KUSTOMIZE) $(ENVSUBST) ## Creates a workload-cluster. ENV Variables need to be exported or defined in the tilt-settings.json
 	# Create workload Cluster.
+	./hack/ensure-env-variables.sh HCLOUD_TOKEN HETZNER_ROBOT_USER HETZNER_ROBOT_PASSWORD HETZNER_SSH_PRIV_PATH HETZNER_SSH_PUB_PATH
 	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --from-literal=robot-user=$(HETZNER_ROBOT_USER) --from-literal=robot-password=$(HETZNER_ROBOT_PASSWORD) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUBECTL) create secret generic robot-ssh --from-literal=sshkey-name=test --from-file=ssh-privatekey=${HETZNER_SSH_PRIV_PATH} --from-file=ssh-publickey=${HETZNER_SSH_PUB_PATH} --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUSTOMIZE) build templates/cluster-templates/$(INFRA_PROVIDER)-baremetal-control-planes-remediation --load-restrictor LoadRestrictionsNone  > templates/cluster-templates/cluster-template-$(INFRA_PROVIDER)-baremetal-control-planes-remediation.yaml
@@ -291,7 +301,7 @@ move-to-workload-cluster: $(CLUSTERCTL)
 
 .PHONY: delete-workload-cluster
 delete-workload-cluster: ## Deletes the example workload Kubernetes cluster
-	@test $${CLUSTER_NAME?Please set environment variable}
+	./hack/ensure-env-variables.sh CLUSTER_NAME
 	@echo 'Your workload cluster will now be deleted, this can take up to 20 minutes'
 	$(KUBECTL) patch cluster $(CLUSTER_NAME) --type=merge -p '{"spec":{"paused": false}}'
 	$(KUBECTL) delete cluster $(CLUSTER_NAME)
@@ -300,11 +310,14 @@ delete-workload-cluster: ## Deletes the example workload Kubernetes cluster
 
 create-mgt-cluster: $(CLUSTERCTL) $(KUBECTL) cluster ## Start a mgt-cluster with the latest version of all capi components and the infra provider.
 	$(CLUSTERCTL) init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure $(INFRA_PROVIDER)
-	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN)
+	$(KUBECTL) create secret generic $(INFRA_PROVIDER) --from-literal=hcloud=$(HCLOUD_TOKEN) --save-config --dry-run=client -o yaml | $(KUBECTL) apply -f -
 	$(KUBECTL) patch secret $(INFRA_PROVIDER) -p '{"metadata":{"labels":{"clusterctl.cluster.x-k8s.io/move":""}}}'
 
 .PHONY: cluster
 cluster: $(CTLPTL) $(KUBECTL) ## Creates kind-dev Cluster
+	@# Fail early: Test if HCLOUD_TOKEN is valid. Background: After Tilt started, changing .envrc has no effect for processes
+	@# started via Tilt. That's why this should fail early.
+	@curl -fsS -H "Authorization: Bearer $$HCLOUD_TOKEN" 'https://api.hetzner.cloud/v1/ssh_keys' > /dev/null || (echo "HCLOUD_TOKEN is invalid (might help: ./hack/ci-e2e-get-token.sh and update .envrc)"; exit 1)
 	./hack/kind-dev.sh
 
 .PHONY: delete-mgt-cluster
@@ -765,7 +778,7 @@ builder-image-push: ## Build $(INFRA_SHORT)-builder to a new version. For more i
 test: test-unit ## Runs all unit and integration tests.
 
 .PHONY: tilt-up
-tilt-up: $(ENVSUBST) $(KUBECTL) $(KUSTOMIZE) $(TILT) cluster  ## Start a mgt-cluster & Tilt. Installs the CRDs and deploys the controllers
+tilt-up: env-vars-for-wl-cluster $(ENVSUBST) $(KUBECTL) $(KUSTOMIZE) $(TILT) cluster  ## Start a mgt-cluster & Tilt. Installs the CRDs and deploys the controllers
 	EXP_CLUSTER_RESOURCE_SET=true $(TILT) up --port=10351
 
 .PHONY: watch

--- a/Tiltfile
+++ b/Tiltfile
@@ -41,8 +41,6 @@ settings = {
     "talos-bootstrap": "false",
 }
 
-keys = ["HCLOUD_TOKEN", "HCLOUD_SSH_KEY"]
-
 # global settings
 settings.update(read_json(
     "tilt-settings.json",
@@ -122,12 +120,6 @@ def append_arg_for_container_in_deployment(yaml_stream, name, namespace, contain
 def fixup_yaml_empty_arrays(yaml_str):
     yaml_str = yaml_str.replace("conditions: null", "conditions: []")
     return yaml_str.replace("storedVersions: null", "storedVersions: []")
-
-def validate_needed_keys():
-    substitutions = settings.get("kustomize_substitutions", {})
-    missing = [k for k in keys if k not in substitutions]
-    if missing:
-        fail("missing kustomize_substitutions keys {} in tilt-setting.json".format(missing))
 
 def set_env_variables():
     substitutions = settings.get("kustomize_substitutions", {})
@@ -274,8 +266,6 @@ ensure_envsubst()
 ensure_kustomize()
 
 include_user_tilt_files()
-
-validate_needed_keys()
 
 load("ext://cert_manager", "deploy_cert_manager")
 

--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -63,7 +63,8 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 	// Fetch the Cluster.
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machineTemplate.ObjectMeta)
 	if err != nil {
-		log.Info("Machine is missing cluster label or cluster does not exist")
+		log.Info(fmt.Sprintf("%s is missing cluster label or cluster does not exist %s/%s",
+			machineTemplate.Kind, machineTemplate.Namespace, machineTemplate.Name))
 		return reconcile.Result{}, nil
 	}
 

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -468,13 +468,11 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 		data := make(map[string][]byte)
 		data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HCloudToken] = hetznerToken
 
-		// Save robot credentials if available
-		robotUserName, keyExists := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser]
-		if keyExists {
-			data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser] = robotUserName
-			robotPassword := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword]
-			data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword] = robotPassword
-		}
+		// Save robot credentials if available (even it empty)
+		robotUserName := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser]
+		data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotUser] = robotUserName
+		robotPassword := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword]
+		data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HetznerRobotPassword] = robotPassword
 
 		// Save network ID in secret
 		if clusterScope.HetznerCluster.Spec.HCloudNetwork.Enabled {

--- a/hack/ci-e2e-delete-token.sh
+++ b/hack/ci-e2e-delete-token.sh
@@ -2,4 +2,4 @@
 
 set -e
 token=$1
-curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"''
+curl -sS -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"''

--- a/hack/get-kubeconfig-of-workload-cluster.sh
+++ b/hack/get-kubeconfig-of-workload-cluster.sh
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cluster_name=$(jq -r .kustomize_substitutions.CLUSTER_NAME tilt-settings.json)
+if [ -z "$CLUSTER_NAME" ]; then
+    echo "env var CLUSTER_NAME is missing. Failed to get kubeconfig of workload cluster"
+    exit 1
+fi
 kubeconfig=".workload-cluster-kubeconfig.yaml"
-kubectl get secrets "$cluster_name-kubeconfig" -ojsonpath='{.data.value}' | base64 -d > "$kubeconfig"
+kubectl get secrets "${CLUSTER_NAME}-kubeconfig" -ojsonpath='{.data.value}' | base64 -d > "$kubeconfig"
 
 if [ ! -s "$kubeconfig" ]; then
     echo "failed to get kubeconfig of workload cluster"

--- a/pkg/scope/baremetalremediation.go
+++ b/pkg/scope/baremetalremediation.go
@@ -95,24 +95,6 @@ func (m *BareMetalRemediationScope) Namespace() string {
 	return m.BareMetalRemediation.Namespace
 }
 
-// PatchHost persists the host's spec and status.
-func (m *BareMetalRemediationScope) PatchHost(ctx context.Context, host *infrav1.HetznerBareMetalHost) error {
-	patchHelper, err := patch.NewHelper(host, m.Client)
-	if err != nil {
-		return fmt.Errorf("failed to init patch helper: %w", err)
-	}
-	return patchHelper.Patch(ctx, host)
-}
-
-// PatchMachine persists the capi machine's spec and status.
-func (m *BareMetalRemediationScope) PatchMachine(ctx context.Context, machine *clusterv1.Machine) error {
-	patchHelper, err := patch.NewHelper(machine, m.Client)
-	if err != nil {
-		return fmt.Errorf("failed to init patch helper: %w", err)
-	}
-	return patchHelper.Patch(ctx, machine)
-}
-
 // HasRetriesLeft returns true if the retry limit is greater than retry count.
 func (m *BareMetalRemediationScope) HasRetriesLeft() bool {
 	return m.BareMetalRemediation.Spec.Strategy.RetryLimit > 0 &&

--- a/pkg/services/baremetal/client/robot/credentials.go
+++ b/pkg/services/baremetal/client/robot/credentials.go
@@ -16,21 +16,8 @@ limitations under the License.
 
 package robotclient
 
-import "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client"
-
 // Credentials holds the information for authenticating with the Hetzner Robot API.
 type Credentials struct {
 	Username string
 	Password string
-}
-
-// Validate returns an error if the credentials are invalid.
-func (creds Credentials) Validate() error {
-	if creds.Username == "" {
-		return &client.CredentialsValidationError{Message: "Missing Hetzner robot api connection detail 'username' in credentials"}
-	}
-	if creds.Password == "" {
-		return &client.CredentialsValidationError{Message: "Missing Hetzner robot api connection detail 'password' in credentials"}
-	}
-	return nil
 }

--- a/templates/cluster-templates/bases/hcloud-hetznerCluster-network.yaml
+++ b/templates/cluster-templates/bases/hcloud-hetznerCluster-network.yaml
@@ -19,3 +19,5 @@ spec:
     name: hetzner
     key:
       hcloudToken: hcloud
+      hetznerRobotPassword: robot-password
+      hetznerRobotUser: robot-user

--- a/templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
+++ b/templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
@@ -19,3 +19,5 @@ spec:
     name: hetzner
     key:
       hcloudToken: hcloud
+      hetznerRobotPassword: robot-password
+      hetznerRobotUser: robot-user


### PR DESCRIPTION
**What this PR does / why we need it**:

* This PR extends the .envrc.sample file and adds a check for env vars in the makefile targets "create-workload-....".
* Fix for hetzner-ccm requiring "robot-user" and "robot-password" to be in the secret called "hetzner" in the wl-cluster.
* Fix for BM remediation (PatchHelper was used incorrectly).
