### PR TITLE
🌱 Update HCloud instance types

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -37,7 +37,7 @@ type HCloudMachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// Type is the HCloud Machine Type for this machine.
-	// +kubebuilder:validation:Enum=cpx11;cx21;cpx21;cx31;cpx31;cx41;cpx41;cx51;cpx51;ccx11;ccx12;ccx21;ccx22;ccx31;ccx32;ccx41;ccx42;ccx51;ccx52;ccx62;cax11;cax21;cax31;cax41
+	// +kubebuilder:validation:Enum=cpx11;cx21;cpx21;cx31;cpx31;cx41;cpx41;cx51;cpx51;ccx11;ccx12;ccx13;ccx21;ccx22;ccx23;ccx31;ccx32;ccx33;ccx41;ccx42;ccx43;ccx51;ccx52;ccx53;ccx62;ccx63;cax11;cax21;cax31;cax41
 	Type HCloudMachineType `json:"type"`
 
 	// ImageName is the reference to the Machine Image from which to create the machine instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -124,15 +124,21 @@ spec:
                 - cpx51
                 - ccx11
                 - ccx12
+                - ccx13
                 - ccx21
                 - ccx22
+                - ccx23
                 - ccx31
                 - ccx32
+                - ccx33
                 - ccx41
                 - ccx42
+                - ccx43
                 - ccx51
                 - ccx52
+                - ccx53
                 - ccx62
+                - ccx63
                 - cax11
                 - cax21
                 - cax31

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -135,15 +135,21 @@ spec:
                         - cpx51
                         - ccx11
                         - ccx12
+                        - ccx13
                         - ccx21
                         - ccx22
+                        - ccx23
                         - ccx31
                         - ccx32
+                        - ccx33
                         - ccx41
                         - ccx42
+                        - ccx43
                         - ccx51
                         - ccx52
+                        - ccx53
                         - ccx62
+                        - ccx63
                         - cax11
                         - cax21
                         - cax31


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

https://www.hetzner.com/news/new-dedicated-vcpu-cloud-server

Hetzner has recently introduced new AMD EPYC instances. This makes them usable with CAPH.


