### PR TITLE
:seedling: fix constant log "... is missing cluster label"

### DIFF
--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -61,11 +61,11 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 	log = log.WithValues("HCloudMachineTemplate", klog.KObj(machineTemplate))
 
 	// Fetch the Cluster.
-	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machineTemplate.ObjectMeta)
-	if err != nil {
-		log.Info(fmt.Sprintf("%s is missing cluster label or cluster does not exist %s/%s",
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, machineTemplate.ObjectMeta)
+	if err != nil || cluster == nil {
+		log.Info(fmt.Sprintf("%s is missing ownerRef to cluster or cluster does not exist %s/%s",
 			machineTemplate.Kind, machineTemplate.Namespace, machineTemplate.Name))
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	log = log.WithValues("Cluster", klog.KObj(cluster))

--- a/controllers/hcloudmachinetemplate_controller_test.go
+++ b/controllers/hcloudmachinetemplate_controller_test.go
@@ -91,11 +91,9 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 		machineTemplate = &infrav1.HCloudMachineTemplate{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "hcloud-machine-template-",
-				Namespace:    testNs.Name,
-				Labels: map[string]string{
-					clusterv1.ClusterNameLabel: capiCluster.Name,
-				},
+				GenerateName:    "hcloud-machine-template-",
+				Namespace:       testNs.Name,
+				OwnerReferences: infraCluster.OwnerReferences,
 			},
 			Spec: infrav1.HCloudMachineTemplateSpec{
 				Template: infrav1.HCloudMachineTemplateResource{


### PR DESCRIPTION
**What this PR does / why we need it**:

remove constant logging

> HCloudMachineTemplate is missing cluster label or cluster does not exist

```
❯ tilt logs --port 10351  | grep 'HCloudMachineTemplate is missing cluster label' | wc -l 

469 (in 38 minutes, with --sync-period=3s)
```
