### PR TITLE
:seedling: Do not mark conditions false if no network exists

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -57,8 +57,6 @@ const (
 const (
 	// NetworkAttached reports on whether there is a network attached to the cluster.
 	NetworkAttached clusterv1.ConditionType = "NetworkAttached"
-	// NetworkDisabledReason indicates that network is disabled.
-	NetworkDisabledReason = "NetworkDisabled"
 	// NetworkUnreachableReason indicates that network is unreachable.
 	NetworkUnreachableReason = "NetworkUnreachable"
 )

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -745,8 +745,6 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 					return isPresentAndFalseWithReason(key, instance, infrav1.NetworkAttached, expectedReason)
 				}, timeout).Should(BeTrue())
 			},
-			Entry("with disabled network", hetznerClusterSpecWithDisabledNetwork, false, infrav1.NetworkDisabledReason),
-			Entry("without network", hetznerClusterSpecWithoutNetwork, false, infrav1.NetworkDisabledReason),
 			Entry("with network", getDefaultHetznerClusterSpec(), true, ""),
 		)
 	})

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -90,6 +90,11 @@ func (s *Service) reconcileNetworkAttachement(ctx context.Context, lb *hcloud.Lo
 		return nil
 	}
 
+	// nothing to do if no network is specified
+	if !s.scope.HetznerCluster.Spec.HCloudNetwork.Enabled {
+		return nil
+	}
+
 	// attach load balancer to network
 	if s.scope.HetznerCluster.Status.Network == nil {
 		conditions.MarkFalse(

--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -23,7 +23,6 @@ import (
 	"net"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/record"
 
@@ -48,13 +47,6 @@ func NewService(scope *scope.ClusterScope) *Service {
 // Reconcile implements life cycle of networks.
 func (s *Service) Reconcile(ctx context.Context) (err error) {
 	if !s.scope.HetznerCluster.Spec.HCloudNetwork.Enabled {
-		conditions.MarkFalse(
-			s.scope.HetznerCluster,
-			infrav1.NetworkAttached,
-			infrav1.NetworkDisabledReason,
-			clusterv1.ConditionSeverityInfo,
-			"network disabled",
-		)
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There are two conditions that are automatically set on false if there is no network. This can be misleading as there is no network intentionally. This commit changes the logic so that conditions are only set on false if there is a (temporary) problem

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

