### PR TITLE
:seedling: rename Condition of loadbalancer

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -19,10 +19,10 @@ package v1beta1
 import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 const (
-	// LoadBalancerAttached reports on whether the load balancer is attached.
-	LoadBalancerAttached clusterv1.ConditionType = "LoadBalancerAttached"
-	// LoadBalancerUnreachableReason is used when load balancer is unreachable.
-	LoadBalancerUnreachableReason = "LoadBalancerUnreachable"
+	// LoadBalancerReadyCondition reports on whether a control plane load balancer was successfully reconciled.
+	LoadBalancerReadyCondition clusterv1.ConditionType = "LoadBalancerReady"
+	// LoadBalancerFailedReason used when an error occurs during load balancer reconciliation.
+	LoadBalancerFailedReason = "LoadBalancerFailed"
 )
 
 const (

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -184,10 +184,10 @@ func (r *HetznerClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 
 	// reconcile the load balancers
 	if err := loadbalancer.NewService(clusterScope).Reconcile(ctx); err != nil {
-		conditions.MarkFalse(hetznerCluster, infrav1.LoadBalancerAttached, infrav1.LoadBalancerUnreachableReason, clusterv1.ConditionSeverityError, err.Error())
+		conditions.MarkFalse(hetznerCluster, infrav1.LoadBalancerReadyCondition, infrav1.LoadBalancerFailedReason, clusterv1.ConditionSeverityError, err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile load balancers for HetznerCluster %s/%s: %w", hetznerCluster.Namespace, hetznerCluster.Name, err)
 	}
-	conditions.MarkTrue(hetznerCluster, infrav1.LoadBalancerAttached)
+	conditions.MarkTrue(hetznerCluster, infrav1.LoadBalancerReadyCondition)
 
 	// reconcile the placement groups
 	if err := placementgroup.NewService(clusterScope).Reconcile(ctx); err != nil {

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 				if err := testEnv.Get(ctx, key, instance); err != nil {
 					return false
 				}
-				return isPresentAndTrue(key, instance, infrav1.LoadBalancerAttached)
+				return isPresentAndTrue(key, instance, infrav1.LoadBalancerReadyCondition)
 			}, timeout).Should(BeTrue())
 
 			By("updating load balancer specs")


### PR DESCRIPTION
**What this PR does / why we need it**:

We took the naming of the aws provider:

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/cdbaf654af78585d507ba333c10ce3e678944616/api/v1beta2/conditions_consts.go#L116
