### PR TITLE
:seedling: use SetSummary, extend printcolumns.

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -101,6 +101,8 @@ type HCloudMachineStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
 // +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="HCloud instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this HCloudMachine"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 // +k8s:defaulter-gen=true
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta1/hcloudmachinetemplate_types.go
+++ b/api/v1beta1/hcloudmachinetemplate_types.go
@@ -46,6 +46,8 @@ type HCloudMachineTemplateStatus struct {
 // +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.template.spec.imageName",description="Image name"
 // +kubebuilder:printcolumn:name="Placement group",type="string",JSONPath=".spec.template.spec.placementGroupName",description="Placement group name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.template.spec.type",description="Server type"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 // +kubebuilder:storageversion
 // +k8s:defaulter-gen=true
 

--- a/api/v1beta1/hcloudremediation_types.go
+++ b/api/v1beta1/hcloudremediation_types.go
@@ -67,6 +67,8 @@ type HCloudRemediationStatus struct {
 // +kubebuilder:printcolumn:name="Last Remediated",type=string,JSONPath=".status.lastRemediated",description="Timestamp of the last remediation attempt"
 // +kubebuilder:printcolumn:name="Retry count",type=string,JSONPath=".status.retryCount",description="How many times remediation controller has tried to remediate the node"
 // +kubebuilder:printcolumn:name="Retry limit",type=string,JSONPath=".spec.strategy.retryLimit",description="How many times remediation controller should attempt to remediate the node"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 
 // HCloudRemediation is the Schema for the hcloudremediations API.
 type HCloudRemediation struct {

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -279,6 +279,8 @@ type HetznerBareMetalMachineStatus struct {
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="hetznerbaremetalmachine is Ready"
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this M3Machine belongs"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 
 // HetznerBareMetalMachine is the Schema for the hetznerbaremetalmachines API.
 type HetznerBareMetalMachine struct {

--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -80,6 +80,8 @@ type HetznerClusterStatus struct {
 // +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint",priority=1
 // +kubebuilder:printcolumn:name="Regions",type="string",JSONPath=".spec.controlPlaneRegions",description="Control plane regions"
 // +kubebuilder:printcolumn:name="Network enabled",type="boolean",JSONPath=".spec.hcloudNetwork.enabled",description="Indicates if private network is enabled."
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 // +k8s:defaulter-gen=true
 
 // HetznerCluster is the Schema for the hetznercluster API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -51,6 +51,12 @@ spec:
       jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
       name: Machine
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -31,6 +31,12 @@ spec:
       jsonPath: .spec.template.spec.type
       name: Type
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediations.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudremediations.yaml
@@ -42,6 +42,12 @@ spec:
       jsonPath: .spec.strategy.retryLimit
       name: Retry limit
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -39,6 +39,12 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -40,6 +40,12 @@ spec:
       jsonPath: .spec.hcloudNetwork.enabled
       name: Network enabled
       type: boolean
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -395,7 +395,7 @@ func hcloudTokenErrorResult(
 	default:
 		return ctrl.Result{}, fmt.Errorf("an unhandled failure occurred with the Hetzner secret: %w", err)
 	}
-
+	conditions.SetSummary(setter)
 	if err := client.Status().Update(ctx, setter); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update: %w", err)
 	}

--- a/pkg/scope/baremetalmachine.go
+++ b/pkg/scope/baremetalmachine.go
@@ -23,7 +23,9 @@ import (
 	"github.com/go-logr/logr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -94,6 +96,7 @@ type BareMetalMachineScope struct {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (m *BareMetalMachineScope) Close(ctx context.Context) error {
+	conditions.SetSummary(m.BareMetalMachine)
 	return m.patchHelper.Patch(ctx, m.BareMetalMachine)
 }
 

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -116,6 +118,7 @@ func (s *ClusterScope) HetznerSecret() *corev1.Secret {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *ClusterScope) Close(ctx context.Context) error {
+	conditions.SetSummary(s.HetznerCluster)
 	return s.patchHelper.Patch(ctx, s.HetznerCluster)
 }
 

--- a/pkg/scope/hcloudmachinetemplate.go
+++ b/pkg/scope/hcloudmachinetemplate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -87,6 +88,7 @@ func (s *HCloudMachineTemplateScope) Namespace() string {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (s *HCloudMachineTemplateScope) Close(ctx context.Context) error {
+	conditions.SetSummary(s.HCloudMachineTemplate)
 	return s.patchHelper.Patch(ctx, s.HCloudMachineTemplate)
 }
 

--- a/pkg/scope/hcloudremediation.go
+++ b/pkg/scope/hcloudremediation.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -102,6 +103,7 @@ type HCloudRemediationScope struct {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (m *HCloudRemediationScope) Close(ctx context.Context, opts ...patch.Option) error {
+	conditions.SetSummary(m.HCloudRemediation)
 	return m.patchHelper.Patch(ctx, m.HCloudRemediation, opts...)
 }
 

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -95,6 +95,7 @@ type MachineScope struct {
 
 // Close closes the current scope persisting the cluster configuration and status.
 func (m *MachineScope) Close(ctx context.Context) error {
+	conditions.SetSummary(m.HCloudMachine)
 	return m.patchHelper.Patch(ctx, m.HCloudMachine)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

use SetSummary, extend printcolumns.


Related: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20200506-conditions.md#data-model-changes


CRDs of CAPH:
```
❯ find config/crd/bases/ -name '*.yaml' | xargs grep -l 'kind: CustomRe' | xargs grep -hoP 'plural: \K\S+'
```

* hetznerclusters: changed
* hcloudmachines: changed
* hcloudremediationtemplates: changed
* hcloudremediations: changed
* hetznerbaremetalhosts:  not changed, has not defer up to now. Unclear where to put SetSummary()
* hetznerbaremetalmachines: changed
* hetznerbaremetalmachinetemplates: not changed, has no status
* hcloudmachinetemplates: changed
* hetznerclustertemplates: not changed, has no status
* hetznerbaremetalremediationtemplates: not changed, not controller/reconcile found
* hetznerbaremetalremediations: not changed. Does not have status.conditions.

"changed" means: 
* added print-columns to type definition
* added conditions.SetSummary() in the method called via `defer` (in most cases a Scope.Close() method).
