### PR TITLE
:bug: Fix conditions getting ok again.

### DIFF
--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -122,8 +122,6 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 		return hcloudTokenErrorResult(ctx, err, hcloudMachine, infrav1.HCloudTokenAvailableCondition, r.Client)
 	}
 
-	conditions.MarkTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)
-
 	hcc := r.HCloudClientFactory.NewClient(hcloudToken)
 
 	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
@@ -142,6 +140,8 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %+v", err)
 	}
+
+	conditions.MarkTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 	// Always close the scope when exiting this function so we can persist any HCloudMachine changes.
 	defer func() {

--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -96,7 +96,6 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 	if err != nil {
 		return hcloudTokenErrorResult(ctx, err, machineTemplate, infrav1.HCloudTokenAvailableCondition, r.Client)
 	}
-	conditions.MarkTrue(machineTemplate, infrav1.HCloudTokenAvailableCondition)
 
 	hcc := r.HCloudClientFactory.NewClient(hcloudToken)
 
@@ -109,6 +108,8 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
+
+	conditions.MarkTrue(machineTemplate, infrav1.HCloudTokenAvailableCondition)
 
 	// Always close the scope when exiting this function so we can persist any HCloudMachine changes.
 	defer func() {

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -132,8 +132,6 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		return hcloudTokenErrorResult(ctx, err, hcloudMachine, infrav1.HCloudTokenAvailableCondition, r.Client)
 	}
 
-	conditions.MarkTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)
-
 	hcc := r.HCloudClientFactory.NewClient(hcloudToken)
 
 	remediationScope, err := scope.NewHCloudRemediationScope(scope.HCloudRemediationScopeParams{
@@ -148,6 +146,8 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
+
+	conditions.MarkTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 	// Always close the scope when exiting this function so we can persist any HCloudRemediation changes.
 	defer func() {

--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -118,8 +118,6 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 		return hcloudTokenErrorResult(ctx, err, hbmMachine, infrav1.HCloudTokenAvailableCondition, r.Client)
 	}
 
-	conditions.MarkTrue(hbmMachine, infrav1.HCloudTokenAvailableCondition)
-
 	hcc := r.HCloudClientFactory.NewClient(hcloudToken)
 
 	// Create the scope.
@@ -134,6 +132,8 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
+
+	conditions.MarkTrue(hbmMachine, infrav1.HCloudTokenAvailableCondition)
 
 	// Always close the scope when exiting this function so we can persist any HetznerBareMetalMachine changes.
 	defer func() {

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -127,7 +127,6 @@ func (r *HetznerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return hcloudTokenErrorResult(ctx, err, hetznerCluster, infrav1.HCloudTokenAvailableCondition, r.Client)
 	}
-	conditions.MarkTrue(hetznerCluster, infrav1.HCloudTokenAvailableCondition)
 	hcloudClient := r.HCloudClientFactory.NewClient(hcloudToken)
 
 	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
@@ -142,6 +141,8 @@ func (r *HetznerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
+
+	conditions.MarkTrue(hetznerCluster, infrav1.HCloudTokenAvailableCondition)
 
 	// Always close the scope when exiting this function so we can persist any HetznerCluster changes.
 	defer func() {


### PR DESCRIPTION
Every modification, which gets done before the patchHelper gets created, will not be detected as change.

We need to set MarkTrue() after the patchHelper was created.
