### PR TITLE
:sparkles: Reuse existing load balancer

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -23,6 +23,10 @@ const (
 	LoadBalancerReadyCondition clusterv1.ConditionType = "LoadBalancerReady"
 	// LoadBalancerFailedReason used when an error occurs during load balancer reconciliation.
 	LoadBalancerFailedReason = "LoadBalancerFailed"
+	// LoadBalancerNotFoundReason used when a load balancer could not be found.
+	LoadBalancerNotFoundReason = "LoadBalancerNotFound"
+	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.
+	LoadBalancerFailedToOwnReason = "LoadBalancerFailedToOwn"
 )
 
 const (

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -185,7 +185,13 @@ func (c *cacheHCloudClient) ListLoadBalancers(_ context.Context, opts hcloud.Loa
 		return nil, fmt.Errorf("failed to convert label selector to labels: %w", err)
 	}
 
-	for _, lb := range c.loadBalancerCache.idMap {
+	for key, lb := range c.loadBalancerCache.idMap {
+		// if name is set and is not correct, continue
+		if opts.Name != "" && lb.Name != opts.Name {
+			continue
+		}
+
+		// check for labels
 		allLabelsFound := true
 		for key, label := range labels {
 			if val, found := lb.Labels[key]; !found || val != label {
@@ -193,8 +199,9 @@ func (c *cacheHCloudClient) ListLoadBalancers(_ context.Context, opts hcloud.Loa
 				break
 			}
 		}
+
 		if allLabelsFound {
-			lbs = append(lbs, lb)
+			lbs = append(lbs, c.loadBalancerCache.idMap[key])
 		}
 	}
 	return lbs, nil

--- a/pkg/services/hcloud/client/fake/hcloud_client_test.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client_test.go
@@ -100,6 +100,12 @@ var _ = Describe("Load balancer", func() {
 		Expect(lb.ID).ToNot(Equal(0))
 	})
 
+	It("lists a load balancer by name", func() {
+		resp, err := client.ListLoadBalancers(ctx, hcloud.LoadBalancerListOpts{Name: lb.Name})
+		Expect(err).To(BeNil())
+		Expect(resp).To(HaveLen(1))
+	})
+
 	It("gives an error when load balancer is created twice", func() {
 		_, err := client.CreateLoadBalancer(ctx, opts)
 		Expect(err).ToNot(Succeed())

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -73,7 +73,6 @@ var _ = Describe("createOptsFromSpec", func() {
 	var hetznerCluster *infrav1.HetznerCluster
 	var wantCreateOpts hcloud.LoadBalancerCreateOpts
 	BeforeEach(func() {
-		lbName := "lb-name"
 		lbType := "lb11"
 		lbRegion := "fsn1"
 		controlPlaneEndpointPort := 22
@@ -83,7 +82,7 @@ var _ = Describe("createOptsFromSpec", func() {
 		hetznerCluster = &infrav1.HetznerCluster{
 			Spec: infrav1.HetznerClusterSpec{
 				ControlPlaneLoadBalancer: infrav1.LoadBalancerSpec{
-					Name:      &lbName,
+					Name:      nil,
 					Algorithm: infrav1.LoadBalancerAlgorithmTypeLeastConnections,
 					Type:      lbType,
 					Region:    infrav1.Region(lbRegion),
@@ -102,7 +101,7 @@ var _ = Describe("createOptsFromSpec", func() {
 
 		wantCreateOpts = hcloud.LoadBalancerCreateOpts{
 			LoadBalancerType: &hcloud.LoadBalancerType{Name: lbType},
-			Name:             lbName,
+			Name:             "",
 			Algorithm:        &hcloud.LoadBalancerAlgorithm{Type: hcloud.LoadBalancerAlgorithmTypeLeastConnections},
 			Location:         &hcloud.Location{Name: lbRegion},
 			Network:          &hcloud.Network{ID: networkID},
@@ -123,11 +122,21 @@ var _ = Describe("createOptsFromSpec", func() {
 		hetznerCluster.Status.Network = nil
 		wantCreateOpts.Network = nil
 
-		Expect(createOptsFromSpec(hetznerCluster)).To(Equal(wantCreateOpts))
+		createOpts := createOptsFromSpec(hetznerCluster)
+
+		// ignore random name
+		createOpts.Name = ""
+
+		Expect(createOpts).To(Equal(wantCreateOpts))
 	})
 
 	It("creates specs for cluster with network", func() {
-		Expect(createOptsFromSpec(hetznerCluster)).To(Equal(wantCreateOpts))
+		createOpts := createOptsFromSpec(hetznerCluster)
+
+		// ignore random name
+		createOpts.Name = ""
+
+		Expect(createOpts).To(Equal(wantCreateOpts))
 	})
 
 	It("creates specs for cluster without load balancer name set", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-using existing load balancer if name of load balancer is set in spec

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [x] add unit tests

