### PR TITLE
:seedling: replace deprecated TTS for getting temp hetzner cloud tokens

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -7,9 +7,6 @@ inputs:
   e2e_make_target:
     description: "e2e_make_target"
     required: true
-  e2e_tts_token:
-    description: "e2e_tts_token"
-    required: false
   e2e_hcloud_token:
     description: "e2e_hcloud_token"
     required: false
@@ -61,22 +58,9 @@ runs:
         TAG: ${{ steps.meta.outputs.version }}
 
     - name: HCLOUD_TOKEN
-      env:
-        TTS_TOKEN: ${{ inputs.e2e_tts_token }}
-        HCLOUD_TOKEN: ${{ inputs.e2e_hcloud_token }}
-      shell: bash
-      run: |
-        set -ueo pipefail
-        if [[ "${HCLOUD_TOKEN:-}" != "" ]]; then
-          echo "HCLOUD_TOKEN=$HCLOUD_TOKEN" >> "$GITHUB_ENV"
-        elif [[ "${TTS_TOKEN:-}" != "" ]]; then
-                  token="$(./hack/ci-e2e-get-token.sh)"
-                  echo "::add-mask::$token"
-                  echo "HCLOUD_TOKEN=$token" >> "$GITHUB_ENV"
-        else
-          echo "::error ::Couldn't determine HCLOUD_TOKEN. Check that repository secrets are setup correctly."
-          exit 1
-        fi
+      uses: hetznercloud/tps-action@8a445ac40beed1e27ce8ef016fb0314342ff8d64 # main
+      with:
+        token: ${{ inputs.e2e_hcloud_token }}
 
     - name: "e2e-${{ inputs.e2e_name }}"
       shell: bash
@@ -101,16 +85,3 @@ runs:
       with:
         name: e2e-${{ inputs.e2e_name }}
         path: _artifacts
-
-    - name: Clean Up
-      if: always()
-      shell: bash
-      env:
-        TTS_TOKEN: ${{ inputs.e2e_tts_token }}
-        HCLOUD_TOKEN: ${{ env.HCLOUD_TOKEN }}
-        HETZNER_ROBOT_USER: ${{ inputs.e2e_robot_user }}
-        HETZNER_ROBOT_PASSWORD: ${{ inputs.e2e_robot_password }}
-        HETZNER_SSH_PUB: ${{ inputs.e2e_ssh_pub }}
-        HETZNER_SSH_PRIV: ${{ inputs.e2e_ssh_priv }}
-      run: |
-        ./hack/ci-e2e-delete-token.sh $HCLOUD_TOKEN $HETZNER_ROBOT_USER $HETZNER_ROBOT_PASSWORD $HETZNER_SSH_PUB $HETZNER_SSH_PRIV

--- a/.github/workflows/e2e-basic-baremetal.yaml
+++ b/.github/workflows/e2e-basic-baremetal.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hetzner Basic
     concurrency: ci-${{ github.ref }}-e2e-baremetal-hetzner
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,7 +47,6 @@ jobs:
         with:
           e2e_name: hetzner-basic
           e2e_make_target: test-e2e-baremetal
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           e2e_robot_user: ${{ secrets.HETZNER_ROBOT_USER }}
           e2e_robot_password: ${{ secrets.HETZNER_ROBOT_PASSWORD }}

--- a/.github/workflows/e2e-basic-packer.yaml
+++ b/.github/workflows/e2e-basic-packer.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hcloud Basic Packer Image
     concurrency: ci-${{ github.ref }}-e2e-basic-packer
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,5 +47,4 @@ jobs:
         with:
           e2e_name: hcloud-basic-packer
           e2e_make_target: test-e2e-feature-packer
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/e2e-basic.yaml
+++ b/.github/workflows/e2e-basic.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hcloud Basic
     concurrency: ci-${{ github.ref }}-e2e-basic
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,5 +47,4 @@ jobs:
         with:
           e2e_name: hcloud-basic
           e2e_make_target: test-e2e
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/e2e-feature-baremetal.yaml
+++ b/.github/workflows/e2e-feature-baremetal.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hetzner Baremetal Features
     concurrency: ci-${{ github.ref }}-e2e-baremetal-hetzner
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,7 +47,6 @@ jobs:
         with:
           e2e_name: hetzner-baremetal-feature
           e2e_make_target: test-e2e-baremetal-feature
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           e2e_robot_user: ${{ secrets.HETZNER_ROBOT_USER }}
           e2e_robot_password: ${{ secrets.HETZNER_ROBOT_PASSWORD }}

--- a/.github/workflows/e2e-feature.yaml
+++ b/.github/workflows/e2e-feature.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hcloud Features
     concurrency: ci-${{ github.ref }}-e2e-feature
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,5 +47,4 @@ jobs:
         with:
           e2e_name: hcloud-feature
           e2e_make_target: test-e2e-feature
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/e2e-periodic.yaml
+++ b/.github/workflows/e2e-periodic.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Hcloud Basic
     concurrency: ci-${{ github.ref }}-e2e-basic-periodic
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,13 +47,15 @@ jobs:
         with:
           e2e_name: hcloud-basic
           e2e_make_target: test-e2e
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   e2e-hcloud-feature:
     name: Test Hcloud Features
     concurrency: ci-${{ github.ref }}-e2e-feature
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -63,13 +68,15 @@ jobs:
         with:
           e2e_name: hcloud-feature
           e2e_make_target: test-e2e-feature
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   e2e-hcloud-feature-packer:
     name: Test Hcloud Feature Packer Image
     concurrency: ci-${{ github.ref }}-e2e-feature-packer
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -82,13 +89,15 @@ jobs:
         with:
           e2e_name: hcloud-feature-packer
           e2e_make_target: test-e2e-feature-packer
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   e2e-hcloud-lifecycle:
     name: Test Hcloud Lifecycle
     concurrency: ci-${{ github.ref }}-e2e-lifecycle
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -101,13 +110,15 @@ jobs:
         with:
           e2e_name: hcloud-lifecycle
           e2e_make_target: test-e2e-lifecycle
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   e2e-hcloud-conformance:
     name: Test Hcloud Conformance
     concurrency: ci-${{ github.ref }}-e2e-conformance
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -120,5 +131,4 @@ jobs:
         with:
           e2e_name: hcloud-conformance
           e2e_make_target: test-e2e-conformance
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/e2e-upgrade-caph.yaml
+++ b/.github/workflows/e2e-upgrade-caph.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test upgrade CAPH
     concurrency: ci-${{ github.ref }}-e2e-upgrade-caph
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,7 +47,6 @@ jobs:
         with:
           e2e_name: upgrade-caph
           e2e_make_target: test-e2e-upgrade-caph
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           e2e_robot_user: ${{ secrets.HETZNER_ROBOT_USER }}
           e2e_robot_password: ${{ secrets.HETZNER_ROBOT_PASSWORD }}

--- a/.github/workflows/e2e-upgrade-kubernetes.yaml
+++ b/.github/workflows/e2e-upgrade-kubernetes.yaml
@@ -32,6 +32,9 @@ jobs:
     name: Test Kubernetes Upgrade
     concurrency: ci-${{ github.ref }}-e2e-upgrade-kubernetes
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -44,5 +47,4 @@ jobs:
         with:
           e2e_name: upgrade-kubernetes
           e2e_make_target: test-e2e-upgrade-kubernetes
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -55,6 +55,9 @@ jobs:
     if: github.event_name != 'pull_request_target' || !github.event.pull_request.draft
     concurrency: ci-${{ github.ref }}-e2e-basic
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -69,7 +72,6 @@ jobs:
         with:
           e2e_name: hcloud-basic
           e2e_make_target: test-e2e
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
 
   e2e-hetzner-basic:
@@ -77,6 +79,9 @@ jobs:
     if: github.event_name != 'pull_request_target' || !github.event.pull_request.draft
     concurrency: ci-${{ github.ref }}-e2e-basic-hetzner
     runs-on: ubuntu-latest
+    permissions:
+      # Required for hcloud TPS
+      id-token: write
     needs:
       - manager-image
       - test-release
@@ -91,7 +96,6 @@ jobs:
         with:
           e2e_name: hetzner-basic
           e2e_make_target: test-e2e-baremetal
-          e2e_tts_token: ${{ secrets.TTS_TOKEN }}
           e2e_hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
           e2e_robot_user: ${{ secrets.HETZNER_ROBOT_USER }}
           e2e_robot_password: ${{ secrets.HETZNER_ROBOT_PASSWORD }}

--- a/hack/ci-e2e-delete-token.sh
+++ b/hack/ci-e2e-delete-token.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-token=$1
-curl -sS -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"''

--- a/hack/ci-e2e-get-token.sh
+++ b/hack/ci-e2e-get-token.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-set -e
-resp=$(curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
-if grep -q token "resp.json"
-then
-    token=$(cat resp.json | jq -r '.token')
-    echo $token
-else
-    exit 1
-fi
+set -eu
+
+curl \
+    --fail-with-body \
+    --retry 2 \
+    --silent \
+    -A "github.com/syself/cluster-api-provider-hetzner" \
+    --header "Authorization: Bearer $TPS_TOKEN" \
+    -X POST \
+    https://tps.hc-integrations.de/


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

TTS is being replaced by TPS. TPS now uses (primarily) GitHub Actions OIDC tokens and has a reusable GitHub Action to get the token.

This does require additional permissions for the jobs that need to talk to TPS, to generate the OIDC tokens.

Right now, there is no way (and no need) to cleanup these tokens, they will be deleted at the end of their configured lifetime.

TPS creates temporary projects instead of tokens for one project.

You can remove the `TTS_TOKEN` from the repository settings once you have merged & validated this PR.



