### PR TITLE
:seedling: Refactor conditions of HetznerCluster

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -21,19 +21,14 @@ import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 const (
 	// LoadBalancerReadyCondition reports on whether a control plane load balancer was successfully reconciled.
 	LoadBalancerReadyCondition clusterv1.ConditionType = "LoadBalancerReady"
-	// LoadBalancerFailedReason used when an error occurs during load balancer reconciliation.
-	LoadBalancerFailedReason = "LoadBalancerFailed"
-	// LoadBalancerNotFoundReason used when a load balancer could not be found.
-	LoadBalancerNotFoundReason = "LoadBalancerNotFound"
+	// LoadBalancerCreateFailedReason used when an error occurs during load balancer create.
+	LoadBalancerCreateFailedReason = "LoadBalancerCreateFailed"
+	// LoadBalancerUpdateFailedReason used when an error occurs during load balancer update.
+	LoadBalancerUpdateFailedReason = "LoadBalancerUpdateFailed"
+	// LoadBalancerServiceSyncFailedReason used when an error occurs while syncing services of load balancer.
+	LoadBalancerServiceSyncFailedReason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnReason = "LoadBalancerFailedToOwn"
-)
-
-const (
-	// LoadBalancerAttachedToNetworkCondition reports on whether the load balancer is attached to a network.
-	LoadBalancerAttachedToNetworkCondition clusterv1.ConditionType = "LoadBalancerAttachedToNetwork"
-	// LoadBalancerNoNetworkFoundReason is used when no network could be found.
-	LoadBalancerNoNetworkFoundReason = "LoadBalancerNoNetworkFound"
 )
 
 const (
@@ -54,6 +49,9 @@ const (
 	ServerStartingReason = "ServerStarting"
 	// ServerOffReason instance is off.
 	ServerOffReason = "ServerOff"
+)
+
+const (
 	// NetworkAttachFailedReason is used when server could not be attached to network.
 	NetworkAttachFailedReason = "NetworkAttachFailed"
 	// LoadBalancerAttachFailedReason is used when server could not be attached to network.
@@ -68,17 +66,17 @@ const (
 )
 
 const (
-	// NetworkAttachedCondition reports on whether there is a network attached to the cluster.
-	NetworkAttachedCondition clusterv1.ConditionType = "NetworkAttached"
-	// NetworkUnreachableReason indicates that network is unreachable.
-	NetworkUnreachableReason = "NetworkUnreachable"
+	// NetworkReadyCondition reports on whether the network is ready.
+	NetworkReadyCondition clusterv1.ConditionType = "NetworkReady"
+	// NetworkReconcileFailedReason indicates that reconciling the network failed.
+	NetworkReconcileFailedReason = "NetworkReconcileFailed"
 )
 
 const (
 	// PlacementGroupsSyncedCondition reports on whether the placement groups are successfully synced.
 	PlacementGroupsSyncedCondition clusterv1.ConditionType = "PlacementGroupsSynced"
-	// PlacementGroupsUnreachableReason indicates that network is disabled.
-	PlacementGroupsUnreachableReason = "PlacementGroupsUnreachable"
+	// PlacementGroupsSyncFailedReason indicates that syncing the placement groups failed.
+	PlacementGroupsSyncFailedReason = "PlacementGroupsSyncFailed"
 )
 
 const (
@@ -91,12 +89,16 @@ const (
 )
 
 const (
-	// HetznerClusterTargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
-	HetznerClusterTargetClusterReadyCondition clusterv1.ConditionType = "HetznerClusterTargetClusterReady"
+	// TargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
+	TargetClusterReadyCondition clusterv1.ConditionType = "TargetClusterReady"
 	// KubeConfigNotFoundReason indicates that the Kubeconfig could not be found.
 	KubeConfigNotFoundReason = "KubeConfigNotFound"
 	// KubeAPIServerNotRespondingReason indicates that the api server cannot be reached.
 	KubeAPIServerNotRespondingReason = "KubeAPIServerNotResponding"
+	// TargetClusterCreateFailedReason indicates that the target cluster could not be created.
+	TargetClusterCreateFailedReason = "TargetClusterCreateFailed"
+	// TargetSecretSyncFailedReason indicates that the target secret could not be synced.
+	TargetSecretSyncFailedReason = "TargetSecretSyncFailed"
 )
 
 const (
@@ -149,4 +151,17 @@ const (
 const (
 	// AssociateBMHCondition reports on whether the Hetzner cluster is in ready state.
 	AssociateBMHCondition clusterv1.ConditionType = "AssociateBMHCondition"
+)
+
+// deprecated conditions.
+
+const (
+	// HetznerClusterTargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
+	HetznerClusterTargetClusterReadyCondition clusterv1.ConditionType = "HetznerClusterTargetClusterReady"
+
+	// NetworkAttachedCondition reports on whether there is a network attached to the cluster.
+	NetworkAttachedCondition clusterv1.ConditionType = "NetworkAttached"
+
+	// LoadBalancerAttachedToNetworkCondition reports on whether the load balancer is attached to a network.
+	LoadBalancerAttachedToNetworkCondition clusterv1.ConditionType = "LoadBalancerAttachedToNetwork"
 )

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	defaultPodNamespace = "caph-system"
-	timeout             = time.Second * 3
+	timeout             = time.Second * 5
 )
 
 func TestControllers(t *testing.T) {

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -463,7 +463,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 					return false
 				}
 
-				return isPresentAndFalseWithReason(key, instance, infrav1.LoadBalancerReadyCondition, infrav1.LoadBalancerNotFoundReason)
+				return isPresentAndFalseWithReason(key, instance, infrav1.LoadBalancerReadyCondition, infrav1.LoadBalancerFailedToOwnReason)
 			}, timeout, time.Second).Should(BeTrue())
 		})
 	})
@@ -803,9 +803,9 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 						return false
 					}
 					if expectedConditionState {
-						return isPresentAndTrue(key, instance, infrav1.NetworkAttachedCondition)
+						return isPresentAndTrue(key, instance, infrav1.NetworkReadyCondition)
 					}
-					return isPresentAndFalseWithReason(key, instance, infrav1.NetworkAttachedCondition, expectedReason)
+					return isPresentAndFalseWithReason(key, instance, infrav1.NetworkReadyCondition, expectedReason)
 				}, timeout).Should(BeTrue())
 			},
 			Entry("with network", getDefaultHetznerClusterSpec(), true, ""),

--- a/pkg/services/baremetal/host/utils.go
+++ b/pkg/services/baremetal/host/utils.go
@@ -54,6 +54,9 @@ SWRAIDLEVEL %v`, hostName, installImageSpec.SwraidLevel)
 PART %s %s %s`, partitions, partition.Mount, partition.FileSystem, partition.Size)
 	}
 
+	// e.g. PART / ext4 all
+	// e.g. PART /boot ext4 1024M
+
 	var lvmDefinitions string
 	for _, lvm := range installImageSpec.LVMDefinitions {
 		lvmDefinitions = fmt.Sprintf(`%s


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring conditions to improve naming and set more precise conditions.

Actively remove deprecated conditions from objects so that they are not stuck on existing objects from older versions of the operator.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

