### PR TITLE
:seedling: Refactor conditions of provider machine objects

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -32,32 +32,39 @@ const (
 const (
 	// LoadBalancerAttachedToNetworkCondition reports on whether the load balancer is attached to a network.
 	LoadBalancerAttachedToNetworkCondition clusterv1.ConditionType = "LoadBalancerAttachedToNetwork"
-	// LoadBalancerAttachFailedReason is used when load balancer could not be attached to network.
-	LoadBalancerAttachFailedReason = "LoadBalancerAttachFailed"
 	// LoadBalancerNoNetworkFoundReason is used when no network could be found.
 	LoadBalancerNoNetworkFoundReason = "LoadBalancerNoNetworkFound"
 )
 
 const (
-	// InstanceReadyCondition reports on current status of the instance. Ready indicates the instance is in a Running state.
-	InstanceReadyCondition clusterv1.ConditionType = "InstanceReady"
-	// InstanceTerminatedReason instance is in a terminated state.
-	InstanceTerminatedReason = "InstanceTerminated"
+	// ServerCreateSucceededCondition reports on current status of the instance. Ready indicates the instance is in a Running state.
+	ServerCreateSucceededCondition clusterv1.ConditionType = "ServerCreateSucceeded"
 	// InstanceHasNonExistingPlacementGroupReason instance has a placement group name that does not exist.
 	InstanceHasNonExistingPlacementGroupReason = "InstanceHasNonExistingPlacementGroup"
-	// ServerOffReason instance is off.
-	ServerOffReason = "ServerOff"
-	// InstanceAsControlPlaneUnreachableReason control plane is (not yet) reachable.
-	InstanceAsControlPlaneUnreachableReason = "InstanceAsControlPlaneUnreachable"
 	// SSHKeyNotFoundReason indicates that ssh key could not be found.
 	SSHKeyNotFoundReason = "SSHKeyNotFound"
 )
 
 const (
-	// InstanceBootstrapReadyCondition reports on current status of the instance. BootstrapReady indicates the bootstrap is ready.
-	InstanceBootstrapReadyCondition clusterv1.ConditionType = "InstanceBootstrapReady"
-	// InstanceBootstrapNotReadyReason bootstrap not ready yet.
-	InstanceBootstrapNotReadyReason = "InstanceBootstrapNotReady"
+	// ServerAvailableCondition indicates the instance is in a Running state.
+	ServerAvailableCondition clusterv1.ConditionType = "ServerAvailable"
+	// ServerTerminatingReason instance is in a terminated state.
+	ServerTerminatingReason = "InstanceTerminated"
+	// ServerStartingReason instance is in a terminated state.
+	ServerStartingReason = "ServerStarting"
+	// ServerOffReason instance is off.
+	ServerOffReason = "ServerOff"
+	// NetworkAttachFailedReason is used when server could not be attached to network.
+	NetworkAttachFailedReason = "NetworkAttachFailed"
+	// LoadBalancerAttachFailedReason is used when server could not be attached to network.
+	LoadBalancerAttachFailedReason = "LoadBalancerAttachFailed"
+)
+
+const (
+	// BootstrapReadyCondition  indicates that bootstrap is ready.
+	BootstrapReadyCondition clusterv1.ConditionType = "BootstrapReady"
+	// BootstrapNotReadyReason bootstrap not ready yet.
+	BootstrapNotReadyReason = "BootstrapNotReady"
 )
 
 const (
@@ -112,6 +119,31 @@ const (
 	OSSSHSecretMissingReason = "OSSSHSecretMissing"
 	// RescueSSHSecretMissingReason indicates that secret with the rescue ssh key is missing.
 	RescueSSHSecretMissingReason = "RescueSSHSecretMissing"
+)
+
+const (
+	// HostAssociateSucceededCondition indicates that a host has been associated.
+	HostAssociateSucceededCondition clusterv1.ConditionType = "HostAssociateSucceeded"
+	// NoAvailableHostReason indicates that there is no available host.
+	NoAvailableHostReason = "NoAvailableHost"
+	// HostAssociateFailedReason indicates that asssociating a host failed.
+	HostAssociateFailedReason = "HostAssociateFailed"
+)
+
+const (
+	// HostProvisionSucceededCondition indicates that a host has been provisioned.
+	HostProvisionSucceededCondition clusterv1.ConditionType = "HostProvisionSucceeded"
+	// StillProvisioningReason indicates that asssociating a host is still provisioning.
+	StillProvisioningReason = "StillProvisioning"
+)
+
+// deprecated .
+
+const (
+	// InstanceReadyCondition reports on current status of the instance. Ready indicates the instance is in a Running state.
+	InstanceReadyCondition clusterv1.ConditionType = "InstanceReady"
+	// InstanceBootstrapReadyCondition reports on current status of the instance. BootstrapReady indicates the bootstrap is ready.
+	InstanceBootstrapReadyCondition clusterv1.ConditionType = "InstanceBootstrapReady"
 )
 
 const (

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	defaultPodNamespace = "caph-system"
-	timeout             = time.Second * 25
+	timeout             = time.Second * 3
 )
 
 func TestControllers(t *testing.T) {

--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -141,6 +141,8 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 			conditions.MarkTrue(hbmMachine, infrav1.HCloudTokenAvailableCondition)
 		}
 
+		conditions.SetSummary(hbmMachine)
+
 		if err := machineScope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			lbName string
 		)
 		BeforeEach(func() {
-			testNs, err = testEnv.CreateNamespace(ctx, "lb-attachement")
+			testNs, err = testEnv.CreateNamespace(ctx, "lb-attachment")
 			Expect(err).NotTo(HaveOccurred())
 			namespace = testNs.Name
 

--- a/pkg/scope/baremetalmachine.go
+++ b/pkg/scope/baremetalmachine.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
-
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -160,20 +160,20 @@ func (m *MachineScope) SetReady(ready bool) {
 	m.HCloudMachine.Status.Ready = ready
 }
 
-// HasInstanceReadyCondition checks whether InstanceReady condition is set on true.
-func (m *MachineScope) HasInstanceReadyCondition() bool {
-	return conditions.IsTrue(m.HCloudMachine, infrav1.InstanceReadyCondition)
+// HasServerAvailableCondition checks whether ServerAvailable condition is set on true.
+func (m *MachineScope) HasServerAvailableCondition() bool {
+	return conditions.IsTrue(m.HCloudMachine, infrav1.ServerAvailableCondition)
 }
 
-// HasInstanceTerminatedCondition checks the whether InstanceReady condition is false with reason "terminated".
-func (m *MachineScope) HasInstanceTerminatedCondition() bool {
-	return conditions.IsFalse(m.HCloudMachine, infrav1.InstanceReadyCondition) &&
-		conditions.GetReason(m.HCloudMachine, infrav1.InstanceReadyCondition) == infrav1.InstanceTerminatedReason
+// HasServerTerminatedCondition checks the whether ServerAvailable condition is false with reason "terminated".
+func (m *MachineScope) HasServerTerminatedCondition() bool {
+	return conditions.IsFalse(m.HCloudMachine, infrav1.ServerAvailableCondition) &&
+		conditions.GetReason(m.HCloudMachine, infrav1.ServerAvailableCondition) == infrav1.ServerTerminatingReason
 }
 
 // HasShutdownTimedOut checks the whether the HCloud server is terminated.
 func (m *MachineScope) HasShutdownTimedOut() bool {
-	return time.Now().After(conditions.GetLastTransitionTime(m.HCloudMachine, infrav1.InstanceReadyCondition).Time.Add(maxShutDownTime))
+	return time.Now().After(conditions.GetLastTransitionTime(m.HCloudMachine, infrav1.ServerAvailableCondition).Time.Add(maxShutDownTime))
 }
 
 // IsBootstrapDataReady checks the readiness of a capi machine's bootstrap data.

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -90,7 +90,7 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	}
 
 	if err := s.reconcileNetworkAttachement(ctx, lb); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to reconcile network attachement: %w", err)
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile network attachment: %w", err)
 	}
 
 	if err := s.reconcileServices(ctx, lb); err != nil {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -216,26 +216,26 @@ var _ = Describe("handleServerStatusOff", func() {
 		res, err := service.handleServerStatusOff(context.Background(), server)
 		Expect(err).To(Succeed())
 		Expect(res).Should(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
-		Expect(conditions.GetReason(hcloudMachine, infrav1.InstanceReadyCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
 	})
 
 	It("tries to power on server again if it is not timed out", func() {
-		conditions.MarkFalse(hcloudMachine, infrav1.InstanceReadyCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
+		conditions.MarkFalse(hcloudMachine, infrav1.ServerAvailableCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
 		service := newTestService(hcloudMachine, client)
 		res, err := service.handleServerStatusOff(context.Background(), server)
 		Expect(err).To(Succeed())
 		Expect(res).Should(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
-		Expect(conditions.GetReason(hcloudMachine, infrav1.InstanceReadyCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
 	})
 
 	It("sets a failure message if it timed out", func() {
-		conditions.MarkFalse(hcloudMachine, infrav1.InstanceReadyCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
+		conditions.MarkFalse(hcloudMachine, infrav1.ServerAvailableCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
 		// manipulate lastTransitionTime
 		conditionsList := hcloudMachine.GetConditions()
 		for i, c := range conditionsList {
-			if c.Type == infrav1.InstanceReadyCondition {
+			if c.Type == infrav1.ServerAvailableCondition {
 				conditionsList[i].LastTransitionTime = metav1.NewTime(time.Now().Add(-time.Hour))
 			}
 		}
@@ -249,12 +249,12 @@ var _ = Describe("handleServerStatusOff", func() {
 	})
 
 	It("tries to power on server and sets new condition if different one is set", func() {
-		conditions.MarkTrue(hcloudMachine, infrav1.InstanceReadyCondition)
+		conditions.MarkTrue(hcloudMachine, infrav1.ServerAvailableCondition)
 		service := newTestService(hcloudMachine, client)
 		res, err := service.handleServerStatusOff(context.Background(), server)
 		Expect(err).To(Succeed())
 		Expect(res).Should(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
-		Expect(conditions.GetReason(hcloudMachine, infrav1.InstanceReadyCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring conditions of HetznerBareMetalMachine and HCloudMachine to make them more readable and more expressive.

Actively deleting deprecated conditions from objects

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

