### PR TITLE
:seedling: Refactor hcloudcontroller tests

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -43,11 +43,6 @@ const (
 	timeout             = time.Second * 5
 )
 
-func TestControllers(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller Suite")
-}
-
 var (
 	testEnv      *helpers.TestEnvironment
 	hcloudClient hcloudclient.Client
@@ -57,6 +52,11 @@ var (
 	defaultPlacementGroupName = "caph-placement-group"
 	defaultFailureDomain      = "fsn1"
 )
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}
 
 var _ = BeforeSuite(func() {
 	utilruntime.Must(infrav1.AddToScheme(scheme.Scheme))
@@ -71,7 +71,6 @@ var _ = BeforeSuite(func() {
 		Client:                         testEnv.Manager.GetClient(),
 		APIReader:                      testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory:            testEnv.HCloudClientFactory,
-		WatchFilterValue:               "",
 		TargetClusterManagersWaitGroup: &wg,
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
@@ -79,14 +78,12 @@ var _ = BeforeSuite(func() {
 		Client:              testEnv.Manager.GetClient(),
 		APIReader:           testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory: testEnv.HCloudClientFactory,
-		WatchFilterValue:    "",
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
 	Expect((&HCloudMachineTemplateReconciler{
 		Client:              testEnv.Manager.GetClient(),
 		APIReader:           testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory: testEnv.HCloudClientFactory,
-		WatchFilterValue:    "",
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
 	Expect((&HetznerBareMetalHostReconciler{
@@ -94,14 +91,12 @@ var _ = BeforeSuite(func() {
 		APIReader:          testEnv.Manager.GetAPIReader(),
 		RobotClientFactory: testEnv.RobotClientFactory,
 		SSHClientFactory:   testEnv.SSHClientFactory,
-		WatchFilterValue:   "",
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
 	Expect((&HetznerBareMetalMachineReconciler{
 		Client:              testEnv.Manager.GetClient(),
 		APIReader:           testEnv.Manager.GetAPIReader(),
 		HCloudClientFactory: testEnv.HCloudClientFactory,
-		WatchFilterValue:    "",
 	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{})).To(Succeed())
 
 	go func() {

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,11 +70,10 @@ type HetznerClusterReconciler struct {
 	client.Client
 	APIReader                      client.Reader
 	HCloudClientFactory            hcloudclient.Factory
-	Log                            logr.Logger
-	WatchFilterValue               string
 	targetClusterManagersStopCh    map[types.NamespacedName]chan struct{}
 	targetClusterManagersLock      sync.Mutex
 	TargetClusterManagersWaitGroup *sync.WaitGroup
+	WatchFilterValue               string
 }
 
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -362,8 +362,6 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 				Expect(testEnv.Delete(ctx, bootstrapSecret)).To(Succeed())
 			}()
 
-			hcloudClient := testEnv.HCloudClientFactory.NewClient("")
-
 			By("creating load balancer manually")
 
 			opts := hcloud.LoadBalancerCreateOpts{
@@ -409,8 +407,6 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			defer func() {
 				Expect(testEnv.Delete(ctx, bootstrapSecret)).To(Succeed())
 			}()
-
-			hcloudClient := testEnv.HCloudClientFactory.NewClient("")
 
 			By("creating load balancer manually")
 			labelsOwnedByOtherCluster := map[string]string{instance.ClusterTagKey() + "s": string(infrav1.ResourceLifecycleOwned)}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring tests of hcloud controller to better re-use objects, add useful comments, remove unnecessary code and improve naming

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

