### PR TITLE
🌱 make less api calls on up-to-date placement groups

### DIFF
--- a/pkg/services/hcloud/placementgroup/placementgroup.go
+++ b/pkg/services/hcloud/placementgroup/placementgroup.go
@@ -120,7 +120,10 @@ func (s *Service) Reconcile(ctx context.Context) (err error) {
 	}
 
 	// Update status
-	placementGroups, err = s.findPlacementGroups(ctx)
+	if len(toCreate) > 0 || len(toDelete) > 0 {
+		// No need to update status if nothing changed
+		placementGroups, err = s.findPlacementGroups(ctx)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to find placement groups: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

THe current `placementgroup.Service` lists the placement groups twice in `Reconcile()`. Once at the beginning, and another time at the end to get an up-to-date view for the status update.

The second request is only necessary in case the controller made any updates to the list (create, delete), but this happens rarely. 

In my personal cluster, this has reduced the rate of requests to `GET /v1/placementgroups` from 0.2req/s to 0.12req/s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

