### PR TITLE
🌱 reduce reconciles by sorting hetznerCluster.status.networkStatus.attachedServers

### DIFF
--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -182,6 +183,9 @@ func statusFromHCloudNetwork(network *hcloud.Network) *infrav1.NetworkStatus {
 	for _, s := range network.Servers {
 		attachedServerIDs = append(attachedServerIDs, s.ID)
 	}
+	// The server IDs are not sorted by the API, but we want to have a
+	// deterministic order to avoid unnecessary updates to the HetznerCluster resource.
+	slices.Sort(attachedServerIDs)
 
 	return &infrav1.NetworkStatus{
 		ID:              network.ID,


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The list of servers returned by the API is not consistently sorted. As the IDs from this list are written into
HetznerCluster.Status.NetworkStatus.AttachedServers in this random order, this causes uncesseary patches to the HetznerCluster object.

By sorting the IDs before writing, only actual changes causes the object to be patched.

As other controllers have a watch on HetznerCluster, this reduces the general amount of reconciles happening in CAPH.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #926

Closes #926

**Special notes for your reviewer**:

This depends on #905, as Go 1.21 introduce a nice new way to sort `int64` slices.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

