### PR TITLE
:seedling: Set condition in case of errors with  hcloud images

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -38,6 +38,10 @@ const (
 	InstanceHasNonExistingPlacementGroupReason = "InstanceHasNonExistingPlacementGroup"
 	// SSHKeyNotFoundReason indicates that ssh key could not be found.
 	SSHKeyNotFoundReason = "SSHKeyNotFound"
+	// ImageNotFoundReason indicates that the image could not be found.
+	ImageNotFoundReason = "ImageNotFound"
+	// ImageAmbiguousReason indicates that there are multiple images with the required properties.
+	ImageAmbiguousReason = "ImageAmbiguous"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding conditions in case of ambiguous images or in case no image is found for a hcloud server on creation

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

