### PR TITLE
:sparkles: Add logging to hetzner robot API client.

### DIFF
--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -140,7 +140,6 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// check whether rate limit has been reached and if so, then wait.
 	if wait := reconcileRateLimit(bmHost, r.RateLimitWaitTime); wait {
-		log.Info("Rate limit exceeded - requeue in 30 seconds")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,9 @@ require (
 	github.com/hetznercloud/hcloud-go/v2 v2.2.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
+	github.com/prometheus/client_golang v1.16.0
 	github.com/stretchr/testify v1.8.4
-	github.com/syself/hrobot-go v0.2.4
+	github.com/syself/hrobot-go v0.2.5
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.11.0
 	golang.org/x/mod v0.11.0
@@ -94,7 +95,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
-github.com/syself/hrobot-go v0.2.4 h1:/XjtE7UjXPfp4NCM3NNjfKrex0biKBUVgHRNPp7kmXg=
-github.com/syself/hrobot-go v0.2.4/go.mod h1:Oy47yZs+fJKcSh38S3OiNJdY34MXb0pkk796UnpYBnc=
+github.com/syself/hrobot-go v0.2.5 h1:Zs7GDFRd6fDn4YHYE9e5CGtRm6KYmMZwMMnm7OC/09g=
+github.com/syself/hrobot-go v0.2.5/go.mod h1:Oy47yZs+fJKcSh38S3OiNJdY34MXb0pkk796UnpYBnc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func main() {
 	if err = (&controllers.HCloudMachineReconciler{
 		Client:              mgr.GetClient(),
 		APIReader:           mgr.GetAPIReader(),
+		RateLimitWaitTime:   rateLimitWaitTime,
 		HCloudClientFactory: hcloudClientFactory,
 		WatchFilterValue:    watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: hcloudMachineConcurrency}); err != nil {
@@ -149,6 +150,7 @@ func main() {
 	if err = (&controllers.HCloudMachineTemplateReconciler{
 		Client:              mgr.GetClient(),
 		APIReader:           mgr.GetAPIReader(),
+		RateLimitWaitTime:   rateLimitWaitTime,
 		HCloudClientFactory: hcloudClientFactory,
 		WatchFilterValue:    watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
@@ -161,6 +163,7 @@ func main() {
 		RobotClientFactory: robotclient.NewFactory(),
 		SSHClientFactory:   sshclient.NewFactory(),
 		APIReader:          mgr.GetAPIReader(),
+		RateLimitWaitTime:  rateLimitWaitTime,
 		WatchFilterValue:   watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: hetznerBareMetalHostConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HetznerBareMetalHost")
@@ -170,6 +173,7 @@ func main() {
 	if err = (&controllers.HetznerBareMetalMachineReconciler{
 		Client:              mgr.GetClient(),
 		APIReader:           mgr.GetAPIReader(),
+		RateLimitWaitTime:   rateLimitWaitTime,
 		HCloudClientFactory: hcloudClientFactory,
 		WatchFilterValue:    watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: hetznerBareMetalMachineConcurrency}); err != nil {
@@ -188,6 +192,7 @@ func main() {
 	if err = (&controllers.HCloudRemediationReconciler{
 		Client:              mgr.GetClient(),
 		APIReader:           mgr.GetAPIReader(),
+		RateLimitWaitTime:   rateLimitWaitTime,
 		HCloudClientFactory: hcloudClientFactory,
 		WatchFilterValue:    watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -140,7 +140,7 @@ func (s *Service) actionPreparing() actionResult {
 	if err != nil {
 		s.handleRateLimitExceeded(err, "GetBMServer")
 		if models.IsError(err, models.ErrorCodeServerNotFound) {
-			return s.recordActionFailure(infrav1.RegistrationError, fmt.Sprintf("bare metal host with id %d not found", s.scope.HetznerBareMetalHost.Spec.ServerID))
+			return s.recordActionFailure(infrav1.FatalError, fmt.Sprintf("bare metal host with id %d not found", s.scope.HetznerBareMetalHost.Spec.ServerID))
 		}
 		return actionError{err: fmt.Errorf("failed to get bare metal server: %w", err)}
 	}

--- a/vendor/github.com/syself/hrobot-go/README.md
+++ b/vendor/github.com/syself/hrobot-go/README.md
@@ -10,6 +10,7 @@ the public API documentation is available at [robot.your-server.de](https://robo
 This fork is based on the repo of nl2go. The original repo implemented the important parts of Hetzner Robot API, but has not been updated since 2019. This work has the goal to keep up with API changes on Hetzner side and to implement additional functions that Hetzner Robot offers. 
 
 Contributions and feature requests are very welcome!
+
 ## Example
 
 ```go
@@ -33,3 +34,6 @@ func main() {
     fmt.Println(servers)
 }
 ```
+
+If you want to add instrumentation (for example to debug why you hit rate-limits of the Hetzner API) 
+you can use `NewBasicAuthClientWithCustomHttpClient()` to use your own httpClient.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -379,7 +379,7 @@ github.com/stretchr/testify/mock
 # github.com/subosito/gotenv v1.4.2
 ## explicit; go 1.18
 github.com/subosito/gotenv
-# github.com/syself/hrobot-go v0.2.4
+# github.com/syself/hrobot-go v0.2.5
 ## explicit; go 1.17
 github.com/syself/hrobot-go
 github.com/syself/hrobot-go/models


### PR DESCRIPTION
**What this PR does / why we need it**:

Add logging to hetzner robot client, so that we have a better understanding why the rate-limit get reached.
