### PR TITLE
:sparkles: Introducing permanent error for host objects

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -136,6 +136,12 @@ const (
 	SSHConnectionRefusedReason = "SSHConnectionRefused"
 	// RescueSystemUnavailableReason indicates that the server has no rescue system.
 	RescueSystemUnavailableReason = "RescueSystemUnavailable"
+	// ImageSpecInvalidReason indicates that the information specified about the image of the host are invalid.
+	ImageSpecInvalidReason = "ImageSpecInvalid"
+	// NoStorageDeviceFoundReason indicates that no suitable storage device could be found.
+	NoStorageDeviceFoundReason = "NoStorageDeviceFound"
+	// CloudInitNotInstalledReason indicates that cloud init is not installed.
+	CloudInitNotInstalledReason = "CloudInitNotInstalled"
 )
 
 const (

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -100,6 +100,9 @@ const (
 
 	// FatalError is a fatal error that triggers a failureMessage in the bm machine.
 	FatalError ErrorType = "fatal error"
+
+	// PermanentError is like fatal error but stays on host machine.
+	PermanentError ErrorType = "permanent error"
 )
 
 const (

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -215,7 +215,8 @@ func (s *Service) update(ctx context.Context) error {
 	}
 
 	// if host has a fatal error, then it should be set on the machine object as well
-	if host.Spec.Status.ErrorType == infrav1.FatalError && s.scope.BareMetalMachine.Status.FailureReason == nil {
+	if (host.Spec.Status.ErrorType == infrav1.FatalError || host.Spec.Status.ErrorType == infrav1.PermanentError) &&
+		s.scope.BareMetalMachine.Status.FailureReason == nil {
 		s.scope.BareMetalMachine.SetFailure(capierrors.UpdateMachineError, host.Spec.Status.ErrorMessage)
 		record.Eventf(s.scope.BareMetalMachine, "BareMetalMachineSetFailure", host.Spec.Status.ErrorMessage)
 		return nil

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -503,7 +503,7 @@ var _ = Describe("handleIncompleteBoot", func() {
 var _ = Describe("ensureSSHKey", func() {
 	defaultFingerPrint := "my-fingerprint"
 
-	It("sets a fatal error if a key that exists under another name is uploaded", func() {
+	It("sets an error error if a key that exists under another name is uploaded", func() {
 		secret := helpers.GetDefaultSSHSecret("ssh-secret", "default")
 		robotMock := robotmock.Client{}
 		sshSecretKeyRef := infrav1.SSHSecretKeyRef{
@@ -537,7 +537,7 @@ var _ = Describe("ensureSSHKey", func() {
 		emptySSHKey := infrav1.SSHKey{}
 		Expect(sshKey).To(Equal(emptySSHKey))
 		Expect(actResult).To(BeAssignableToTypeOf(actionFailed{}))
-		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.FatalError))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.PreparationError))
 	})
 
 	type testCaseEnsureSSHKey struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Introducing the permanent error on host objects to leverage the fact that there are some errors that occur during provisioning of a host that cannot be fixed, namely that the Hetzner robot device does not exist with that respective serverID, or that there is no rescue mode for the server.

In cases where there are errors that cannot be recovered without provisioning another time, the FatalError is used which leads to a FailureMessage on the bm machine.

In cases where there is a configuration problem or a failure of the scripts that the user provided, there is an error that stays on the host as well as a condition that shows a user-facing error, e.g. that there is no cloud-init installed, or that an ssh key already exists under a different name and cannot be uploaded

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

