### PR TITLE
🐛 Added condition so Machines do not reboot if the host is in maintenance mode

### DIFF
--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -132,13 +132,7 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
-	// Fetch the Host instance
-	hbmHost := &infrav1.HetznerBareMetalHostSpec
 
-	// Delete the machine instance if MaintenanceMode is true
-	if hbmHost.MaintenanceMode {
-		return r.reconcileDelete(ctx, machine)
-	}
 	// Always close the scope when exiting this function so we can persist any HetznerBareMetalMachine changes.
 	defer func() {
 		if reterr != nil && errors.Is(reterr, hcloudclient.ErrUnauthorized) {
@@ -301,7 +295,7 @@ func (r *HetznerBareMetalMachineReconciler) HetznerClusterToBareMetalMachines(ct
 
 // ClusterToBareMetalMachines is a handler.ToRequestsFunc to be used to enqeue
 // requests for reconciliation of BareMetalMachines.
-func (r *HetznerBareMetalMachineReconciler) ClusterTocBareMetalMachines(ctx context.Context, log logr.Logger) handler.MapFunc {
+func (r *HetznerBareMetalMachineReconciler) ClusterToBareMetalMachines(ctx context.Context, log logr.Logger) handler.MapFunc {
 	return func(_ context.Context, obj client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 		c, ok := obj.(*clusterv1.Cluster)

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -137,7 +137,7 @@ func (s *Service) remediate(ctx context.Context, host infrav1.HetznerBareMetalHo
 		return fmt.Errorf("failed to init patch helper: %s %s/%s %w", host.Kind, host.Namespace, host.Name, err)
 	}
 
-	// check if host is in maintenance mode
+	// check if host is not in maintenance mode
 	if !*host.Spec.MaintenanceMode {
 		// add annotation to host so that it reboots
 		host.Annotations, err = addRebootAnnotation(host.Annotations)

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -137,10 +137,13 @@ func (s *Service) remediate(ctx context.Context, host infrav1.HetznerBareMetalHo
 		return fmt.Errorf("failed to init patch helper: %s %s/%s %w", host.Kind, host.Namespace, host.Name, err)
 	}
 
-	// add annotation to host so that it reboots
-	host.Annotations, err = addRebootAnnotation(host.Annotations)
-	if err != nil {
-		return fmt.Errorf("failed to add reboot annotation: %w", err)
+	// check if host is in maintenance mode
+	if !*host.Spec.MaintenanceMode {
+		// add annotation to host so that it reboots
+		host.Annotations, err = addRebootAnnotation(host.Annotations)
+		if err != nil {
+			return fmt.Errorf("failed to add reboot annotation: %w", err)
+		}
 	}
 
 	if err := patchHelper.Patch(ctx, &host); err != nil {


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently the machines remediate despite the baremetal host being in maintenance mode. This PR aims at fixing that.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #930 

**Special notes for your reviewer**:
I am sorry for opening a new PR. I could not create a new branch for the last one. 
I think the PR is going in the right direction with me making progress and having a more firm grip at understanding of the issue. I still feel a little unsure about whether more things should be included in the condition that I have added in this PR, more things include the statements under the condition where the number of retry is being incremented. I think I should also include it. I am a little unsure. 
I'd love feedback. 
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._
No it does not
**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

