### PR TITLE
:bug: Remove cluster label from existing lb on delete

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -25,6 +25,8 @@ const (
 	LoadBalancerCreateFailedReason = "LoadBalancerCreateFailed"
 	// LoadBalancerUpdateFailedReason used when an error occurs during load balancer update.
 	LoadBalancerUpdateFailedReason = "LoadBalancerUpdateFailed"
+	// LoadBalancerDeleteFailedReason used when an error occurs during load balancer delete.
+	LoadBalancerDeleteFailedReason = "LoadBalancerDeleteFailed"
 	// LoadBalancerServiceSyncFailedReason used when an error occurs while syncing services of load balancer.
 	LoadBalancerServiceSyncFailedReason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -281,7 +281,15 @@ func (c *cacheHCloudClient) UpdateLoadBalancer(_ context.Context, lb *hcloud.Loa
 	}
 
 	// Update it
-	c.loadBalancerCache.idMap[lb.ID].Name = opts.Name
+	if opts.Name != "" {
+		c.loadBalancerCache.idMap[lb.ID].Name = opts.Name
+	}
+
+	// Update it
+	if opts.Labels != nil {
+		c.loadBalancerCache.idMap[lb.ID].Labels = opts.Labels
+	}
+
 	return c.loadBalancerCache.idMap[lb.ID], nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When a cluster is deleted, the load balancer is usually deleted. However, if the user specified the name of an existing load balancer in the spec, the expectated behavior would be that the load balancer of the user is not deleted when a cluster is deleted.

This commit implements that behavior and also removes the cluster label from the load balancer.

It also improves the conditions and events for load balancer deletion.

A problem with pointers is fixed which caused an issue in the fake hcloud client, where we implicitly updated the load balancers with the pointer, instead of using the actual API call.

In order to fix this, the API fake behavior is fixed and labels are also updated, according to the behavior of the actual hcloud-go client

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

