### PR TITLE
:sparkles: printcolumns alignement.

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -94,17 +94,12 @@ type HCloudMachineStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this HCloudMachine belongs"
-// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.imageName",description="Image name"
-// +kubebuilder:printcolumn:name="Placement group",type="string",JSONPath=".spec.placementGroupName",description="Placement group name"
-// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="Server type"
-// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="HCloud instance state"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
-// +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="HCloud instance ID"
 // +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this HCloudMachine"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="HCloud instance state"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of hcloudmachine"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
 // +k8s:defaulter-gen=true
-
 // HCloudMachine is the Schema for the hcloudmachines API.
 type HCloudMachine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -408,11 +408,13 @@ type HetznerBareMetalHostStatus struct{}
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".spec.status.provisioningState",description="Provisioning status"
 // +kubebuilder:printcolumn:name="IPv4",type="string",JSONPath=".spec.status.ipv4",description="IPv4 of the host"
 // +kubebuilder:printcolumn:name="IPv6",type="string",JSONPath=".spec.status.ipv6",description="IPv6 of the host"
-// +kubebuilder:printcolumn:name="Threads",type="string",JSONPath=".spec.status.hardwareDetails.cpu.threads",description="CPU threads"
-// +kubebuilder:printcolumn:name="Clock speed",type="string",JSONPath=".spec.status.hardwareDetails.cpu.clockGigahertz",description="CPU clock speed"
-// +kubebuilder:printcolumn:name="RAM in GB",type="string",JSONPath=".spec.status.hardwareDetails.ramGB",description="RAM in GB"
+// +kubebuilder:printcolumn:name="Maintenance",type="boolean",JSONPath=".spec.maintenanceMode",description="Maintenance Mode"
+// +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.status.hardwareDetails.cpu.threads",description="CPU threads"
+// +kubebuilder:printcolumn:name="RAM",type="string",JSONPath=".spec.status.hardwareDetails.ramGB",description="RAM in GB"
 // +kubebuilder:printcolumn:name="Consumer",type="string",JSONPath=".spec.consumerRef.name",description="Consumer using this host"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of BaremetalHost"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".spec.status.conditions[?(@.type=='Ready')].reason"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".spec.status.conditions[?(@.type=='Ready')].message"
 // +k8s:defaulter-gen=true
 
 // HetznerBareMetalHost is the Schema for the hetznerbaremetalhosts API.

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -277,17 +277,17 @@ type HetznerBareMetalMachineStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=hbmm
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=hetznerbaremetalmachines,scope=Namespaced,categories=cluster-api,shortName=hbm;hbmachine;hbmachines;hetznerbaremetalm;hetznerbaremetalmachine
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of hetznerbaremetalmachine"
-// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="hetznerbaremetalmachine is Ready"
-// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this M3Machine belongs"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this HetznerBareMetalMachine belongs"
+// +kubebuilder:printcolumn:name="Host",type="string",JSONPath=".metadata.annotations.infrastructure\\.cluster\\.x-k8s\\.io/HetznerBareMetalHost",description="HetznerBareMetalHost"
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this HetznerBareMetalMachine"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="HetznerBareMetalMachine status such as Pending/Provisioning/Running etc"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of HetznerBareMetalMachine"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].message"
-
 // HetznerBareMetalMachine is the Schema for the hetznerbaremetalmachines API.
 type HetznerBareMetalMachine struct {
 	metav1.TypeMeta `json:",inline"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -23,34 +23,18 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
-    - description: Image name
-      jsonPath: .spec.imageName
-      name: Image
-      type: string
-    - description: Placement group name
-      jsonPath: .spec.placementGroupName
-      name: Placement group
-      type: string
-    - description: Server type
-      jsonPath: .spec.type
-      name: Type
+    - description: Machine object which owns with this HCloudMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
       type: string
     - description: HCloud instance state
       jsonPath: .status.instanceState
       name: State
       type: string
-    - description: Machine ready status
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: HCloud instance ID
-      jsonPath: .spec.providerID
-      name: InstanceID
-      type: string
-    - description: Machine object which owns with this HCloudMachine
-      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
-      name: Machine
-      type: string
+    - description: Time duration since creation of hcloudmachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=='Ready')].reason
       name: Reason
       type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -30,17 +30,17 @@ spec:
       jsonPath: .spec.status.ipv6
       name: IPv6
       type: string
+    - description: Maintenance Mode
+      jsonPath: .spec.maintenanceMode
+      name: Maintenance
+      type: boolean
     - description: CPU threads
       jsonPath: .spec.status.hardwareDetails.cpu.threads
-      name: Threads
-      type: string
-    - description: CPU clock speed
-      jsonPath: .spec.status.hardwareDetails.cpu.clockGigahertz
-      name: Clock speed
+      name: CPU
       type: string
     - description: RAM in GB
       jsonPath: .spec.status.hardwareDetails.ramGB
-      name: RAM in GB
+      name: RAM
       type: string
     - description: Consumer using this host
       jsonPath: .spec.consumerRef.name
@@ -50,6 +50,12 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
+    - jsonPath: .spec.status.conditions[?(@.type=='Ready')].message
+      name: Message
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -23,27 +23,27 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Time duration since creation of hetznerbaremetalmachine
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Provider ID
-      jsonPath: .spec.providerID
-      name: ProviderID
-      type: string
-    - description: hetznerbaremetalmachine is Ready
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: Cluster to which this M3Machine belongs
+    - description: Cluster to which this HetznerBareMetalMachine belongs
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
+      type: string
+    - description: HetznerBareMetalHost
+      jsonPath: .metadata.annotations.infrastructure\.cluster\.x-k8s\.io/HetznerBareMetalHost
+      name: Host
+      type: string
+    - description: Machine object which owns with this HetznerBareMetalMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
       type: string
     - description: HetznerBareMetalMachine status such as Pending/Provisioning/Running
         etc
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: Time duration since creation of HetznerBareMetalMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=='Ready')].reason
       name: Reason
       type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

Align printcolumns of several CRDs.

Current result:

```
❯ k get hcloudmachine
NAME                               CLUSTER        MACHINE                                    STATE     AGE     REASON   MESSAGE
caph-guettli-control-plane-24hhs   caph-guettli   caph-guettli-control-plane-t9w8q           running   6h45m            
caph-guettli-md-0-8xtnv            caph-guettli   caph-guettli-md-0-54bf746bc6xwzz5s-mk7rj   running   6h46m            
```
```
❯ k get hetznerbaremetalmachine ; k get hetznerbaremetalhosts

NAME                      CLUSTER        HOST                  MACHINE                                   PHASE          AGE   REASON              MESSAGE
caph-guettli-md-1-7d6rm   caph-guettli   default/test-bm-gpu   caph-guettli-md-1-85fcf5b65xk9wz9-xnrsn   Provisioning   50s   StillProvisioning   still provisioning - current state "registering"

NAME          STATE         IPV4            IPV6                 MAINTENANCE   CPU   RAM   CONSUMER                  AGE    REASON              MESSAGE
test-bm-gpu   registering   95.216.111.98   2a01:4f9:2b:dc8::1   false         8     64    caph-guettli-md-1-7d6rm   7h4m   StillProvisioning   host is provisioning - current state: "registering"
```