### PR TITLE
:bug: Fix return result for bm hosts

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -142,6 +142,8 @@ const (
 	NoStorageDeviceFoundReason = "NoStorageDeviceFound"
 	// CloudInitNotInstalledReason indicates that cloud init is not installed.
 	CloudInitNotInstalledReason = "CloudInitNotInstalled"
+	// ServerNotFoundReason indicates that a bare metal server could not be found.
+	ServerNotFoundReason = "ServerNotFound"
 )
 
 const (

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -381,7 +381,7 @@ func (r *HetznerBareMetalHostReconciler) SetupWithManager(ctx context.Context, m
 					}
 
 					// If install image changes, then we want to reconcile, as this is important when working with bm machines
-					if objectOld.Spec.Status.InstallImage != objectNew.Spec.Status.InstallImage {
+					if !reflect.DeepEqual(objectOld.Spec.Status.InstallImage, objectNew.Spec.Status.InstallImage) {
 						return true
 					}
 

--- a/pkg/services/baremetal/host/action_result.go
+++ b/pkg/services/baremetal/host/action_result.go
@@ -80,6 +80,13 @@ func (r actionError) Result() (result reconcile.Result, err error) {
 	return result, r.err
 }
 
+// actionStop is a result indicating that there is a permanent error and we have to stop reconcilement.
+type actionStop struct{}
+
+func (r actionStop) Result() (result reconcile.Result, err error) {
+	return result, err
+}
+
 // actionFailed is a result indicating that the current action has failed,
 // and that the resource should be marked as in error.
 type actionFailed struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
There were multiple issues with the return results of host objects:
- SaveHostAndReturn has overwritten the actual value in the defer statement
- We requeued after Updates of hosts always because we didn't use reflect.DeepEqual to compare pointers
- We requeuedAfter a certain time period for permanent errors which does not make sense. This is why a new actionPermanent is introduced that does not have any requeue

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

