### PR TITLE
:seedling: update caph latest version and capi

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -77,7 +77,7 @@ runs:
         HETZNER_SSH_PUB: ${{ inputs.e2e_ssh_pub }}
         HETZNER_SSH_PRIV: ${{ inputs.e2e_ssh_priv }}
         SKIP_IMAGE_BUILD: "1"
-        CAPH_LATEST_VERSION: "v1.0.0-beta.1"
+        CAPH_LATEST_VERSION: "v1.0.0-beta.22"
       run: make ${{ inputs.e2e_make_target }}
     - name: Upload artifact
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3

--- a/test/e2e/config/hetzner-ci.yaml
+++ b/test/e2e/config/hetzner-ci.yaml
@@ -13,8 +13,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/core-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -30,8 +30,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/bootstrap-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -47,8 +47,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/control-plane-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -13,8 +13,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/core-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -30,8 +30,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/bootstrap-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -47,8 +47,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.5.0
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/control-plane-components.yaml"
+      - name: v1.5.2
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.2/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the latest caph version to v1.0.0-beta.22 and updates capi to v1.5.2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

