### PR TITLE
:bug: Fix requeue on error

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -46,6 +46,8 @@ const (
 	ImageAmbiguousReason = "ImageAmbiguous"
 	// ServerLimitExceededReason indicates that server resource rate limit is hit.
 	ServerLimitExceededReason = "ServerLimitExceeded"
+	// ServerTypeNotFoundReason indicates that server type could not be found.
+	ServerTypeNotFoundReason = "ServerTypeNotFound"
 )
 
 const (

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -227,7 +227,7 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 					return nil, nil, res, err
 				}
 
-				return nil, nil, ctrl.Result{Requeue: true}, nil
+				return nil, nil, res, nil
 			}
 			return nil, nil, res, fmt.Errorf("failed to get secret: %w", err)
 		}
@@ -251,7 +251,7 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 					return nil, nil, result, err
 				}
 
-				return nil, nil, ctrl.Result{Requeue: true}, nil
+				return nil, nil, res, nil
 			}
 			return nil, nil, res, fmt.Errorf("failed to acquire secret: %w", err)
 		}
@@ -332,7 +332,7 @@ func hetznerSecretErrorResult(
 		}
 
 		// No need to reconcile again, as it will be triggered as soon as the secret is updated.
-		return ctrl.Result{Requeue: true}, nil
+		return res, nil
 	}
 
 	credValidationErr := &bmclient.CredentialsValidationError{}

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -396,7 +396,7 @@ func hcloudTokenErrorResult(
 			clusterv1.ConditionSeverityError,
 			"could not find HetznerSecret",
 		)
-		res = ctrl.Result{Requeue: true, RequeueAfter: secretErrorRetryDelay}
+		res = ctrl.Result{RequeueAfter: secretErrorRetryDelay}
 
 	// No need to reconcile again, as it will be triggered as soon as the secret is updated.
 	case *secretutil.HCloudTokenValidationError:

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -139,7 +139,10 @@ func (s *Service) reconcileNetworkAttachement(ctx context.Context, lb *hcloud.Lo
 			clusterv1.ConditionSeverityWarning,
 			err.Error(),
 		)
-		return err
+
+		// no need to return error, as once the network is added it will be added to the status which triggers
+		// another reconcile loop
+		return nil
 	}
 
 	opts := hcloud.LoadBalancerAttachToNetworkOpts{


### PR DESCRIPTION
**What this PR does / why we need it**:
There are multiple places where the controller requeues by setting the parameter explicitly or by returning an error, where it is not necessary or even bad because it leads to a loop where the controller might run in rate limits of hcloud or hrobot APIs.

This commit introduces multiple fixes:
- if something is not correct while creating hcloud servers that needs user intervention, the controller requeues after 5 minutes and does not return an error.
- in other places where there is a requeue that is not needed it is removed
- when provisioning the host fails and there is a timeout reached due to which the controller does not expect the server to provision successfully, there is no an error set on the host as well as an exponential backoff time for requeues

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [x] add unit tests

