### PR TITLE
:seedling: handle deprovision of bare metal.

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1426,9 +1426,11 @@ func (s *Service) actionDeprovisioning() actionResult {
 			IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
 		})
 		out := sshClient.ResetKubeadm()
-		if err := handleSSHError(out); err != nil {
-			record.Warnf(s.scope.HetznerBareMetalHost, "FailedResetKubeAdm", "failed to reset kubeadm: %s", err.Error())
-			s.scope.Error(err, "failed to reset kubeadm")
+		s.scope.V(1).Info("Output of ResetKubeadm", "stdout", out.StdOut, "stderr", out.StdErr, "err", out.Err)
+		if out.Err != nil {
+			record.Warnf(s.scope.HetznerBareMetalHost, "FailedResetKubeAdm", "failed to reset kubeadm: %s", out.Err.Error())
+		} else {
+			record.Event(s.scope.HetznerBareMetalHost, "SuccessfulResetKubeAdm", "Reset was successful.")
 		}
 	} else {
 		s.scope.Info("OS SSH Secret is empty - cannot reset kubeadm")


### PR DESCRIPTION
**What this PR does / why we need it**:

Up to now deprovisioning of bare-metal servers failed. The reason was because there was output on stdout.

We fixed that and improved the deprovisioning (delete all pods, stop and disable kubelet via systemclt, remove /etc/kubernetes).
