### PR TITLE
:seedling: Rename deprecated conditions

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -169,24 +169,24 @@ const (
 // deprecated conditions.
 
 const (
-	// InstanceReadyCondition reports on current status of the instance. Ready indicates the instance is in a Running state.
-	InstanceReadyCondition clusterv1.ConditionType = "InstanceReady"
+	// DeprecatedInstanceReadyCondition reports on current status of the instance. Ready indicates the instance is in a Running state.
+	DeprecatedInstanceReadyCondition clusterv1.ConditionType = "InstanceReady"
 
-	// InstanceBootstrapReadyCondition reports on current status of the instance. BootstrapReady indicates the bootstrap is ready.
-	InstanceBootstrapReadyCondition clusterv1.ConditionType = "InstanceBootstrapReady"
+	// DeprecatedInstanceBootstrapReadyCondition reports on current status of the instance. BootstrapReady indicates the bootstrap is ready.
+	DeprecatedInstanceBootstrapReadyCondition clusterv1.ConditionType = "InstanceBootstrapReady"
 
-	// HetznerClusterTargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
-	HetznerClusterTargetClusterReadyCondition clusterv1.ConditionType = "HetznerClusterTargetClusterReady"
+	// DeprecatedHetznerClusterTargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
+	DeprecatedHetznerClusterTargetClusterReadyCondition clusterv1.ConditionType = "HetznerClusterTargetClusterReady"
 
-	// NetworkAttachedCondition reports on whether there is a network attached to the cluster.
-	NetworkAttachedCondition clusterv1.ConditionType = "NetworkAttached"
+	// DeprecatedNetworkAttachedCondition reports on whether there is a network attached to the cluster.
+	DeprecatedNetworkAttachedCondition clusterv1.ConditionType = "NetworkAttached"
 
-	// LoadBalancerAttachedToNetworkCondition reports on whether the load balancer is attached to a network.
-	LoadBalancerAttachedToNetworkCondition clusterv1.ConditionType = "LoadBalancerAttachedToNetwork"
+	// DeprecatedLoadBalancerAttachedToNetworkCondition reports on whether the load balancer is attached to a network.
+	DeprecatedLoadBalancerAttachedToNetworkCondition clusterv1.ConditionType = "LoadBalancerAttachedToNetwork"
 
-	// HetznerBareMetalHostReadyCondition reports on whether the Hetzner cluster is in ready state.
-	HetznerBareMetalHostReadyCondition clusterv1.ConditionType = "HetznerBareMetalHostReady"
+	// DeprecatedHetznerBareMetalHostReadyCondition reports on whether the Hetzner cluster is in ready state.
+	DeprecatedHetznerBareMetalHostReadyCondition clusterv1.ConditionType = "HetznerBareMetalHostReady"
 
-	// AssociateBMHCondition reports on whether the Hetzner cluster is in ready state.
-	AssociateBMHCondition clusterv1.ConditionType = "AssociateBMHCondition"
+	// DeprecatedAssociateBMHCondition reports on whether the Hetzner cluster is in ready state.
+	DeprecatedAssociateBMHCondition clusterv1.ConditionType = "AssociateBMHCondition"
 )

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -225,7 +225,7 @@ func (r *HetznerClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	}
 
 	// delete deprecated conditions of old clusters
-	conditions.Delete(clusterScope.HetznerCluster, infrav1.HetznerClusterTargetClusterReadyCondition)
+	conditions.Delete(clusterScope.HetznerCluster, infrav1.DeprecatedHetznerClusterTargetClusterReadyCondition)
 
 	result, err := r.reconcileTargetClusterManager(ctx, clusterScope)
 	if err != nil {

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -78,9 +78,9 @@ func NewService(scope *scope.BareMetalMachineScope) *Service {
 // Reconcile implements reconcilement of HetznerBareMetalMachines.
 func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err error) {
 	// delete the deprecated condition from existing machine objects
-	conditions.Delete(s.scope.BareMetalMachine, infrav1.InstanceReadyCondition)
-	conditions.Delete(s.scope.BareMetalMachine, infrav1.InstanceBootstrapReadyCondition)
-	conditions.Delete(s.scope.BareMetalMachine, infrav1.AssociateBMHCondition)
+	conditions.Delete(s.scope.BareMetalMachine, infrav1.DeprecatedInstanceReadyCondition)
+	conditions.Delete(s.scope.BareMetalMachine, infrav1.DeprecatedInstanceBootstrapReadyCondition)
+	conditions.Delete(s.scope.BareMetalMachine, infrav1.DeprecatedAssociateBMHCondition)
 
 	// Make sure bootstrap data is available and populated. If not, return, we
 	// will get an event from the machine update when the flag is set to true.

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -96,7 +96,7 @@ func (s *Service) Reconcile(ctx context.Context) (result reconcile.Result, err e
 
 	defer func() {
 		// remove deprecated conditions
-		conditions.Delete(s.scope.HetznerBareMetalHost, infrav1.HetznerBareMetalHostReadyCondition)
+		conditions.Delete(s.scope.HetznerBareMetalHost, infrav1.DeprecatedHetznerBareMetalHostReadyCondition)
 
 		conditions.SetSummary(s.scope.HetznerBareMetalHost)
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -53,7 +53,7 @@ var ErrNoLoadBalancerAvailable = fmt.Errorf("no available load balancer")
 // Reconcile implements the life cycle of HCloud load balancers.
 func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	// delete the deprecated condition from existing cluster objects
-	conditions.Delete(s.scope.HetznerCluster, infrav1.LoadBalancerAttachedToNetworkCondition)
+	conditions.Delete(s.scope.HetznerCluster, infrav1.DeprecatedLoadBalancerAttachedToNetworkCondition)
 
 	if !s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled {
 		return reconcile.Result{}, nil

--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -49,7 +49,7 @@ func NewService(scope *scope.ClusterScope) *Service {
 // Reconcile implements life cycle of networks.
 func (s *Service) Reconcile(ctx context.Context) (err error) {
 	// delete the deprecated condition from existing cluster objects
-	conditions.Delete(s.scope.HetznerCluster, infrav1.NetworkAttachedCondition)
+	conditions.Delete(s.scope.HetznerCluster, infrav1.DeprecatedNetworkAttachedCondition)
 
 	if !s.scope.HetznerCluster.Spec.HCloudNetwork.Enabled {
 		return nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -63,8 +63,8 @@ func NewService(scope *scope.MachineScope) *Service {
 // Reconcile implements reconcilement of HCloudMachines.
 func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err error) {
 	// delete the deprecated condition from existing machine objects
-	conditions.Delete(s.scope.HCloudMachine, infrav1.InstanceReadyCondition)
-	conditions.Delete(s.scope.HCloudMachine, infrav1.InstanceBootstrapReadyCondition)
+	conditions.Delete(s.scope.HCloudMachine, infrav1.DeprecatedInstanceReadyCondition)
+	conditions.Delete(s.scope.HCloudMachine, infrav1.DeprecatedInstanceBootstrapReadyCondition)
 
 	// detect failure domain
 	failureDomain, err := s.scope.GetFailureDomain()
@@ -266,7 +266,7 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 	}
 
 	// if load balancer has not been attached to a network, then it cannot add a server with private IP
-	if hasPrivateIP && conditions.IsFalse(s.scope.HetznerCluster, infrav1.LoadBalancerAttachedToNetworkCondition) {
+	if hasPrivateIP && conditions.IsFalse(s.scope.HetznerCluster, infrav1.LoadBalancerReadyCondition) {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Renaming deprecated conditions to show in the Go code easily that they should not be used anymore

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

