### PR TITLE
:seedling: Show api calls only in debug mode

### DIFF
--- a/pkg/services/baremetal/client/robot/robot_client.go
+++ b/pkg/services/baremetal/client/robot/robot_client.go
@@ -65,10 +65,10 @@ func (lt *LoggingTransport) RoundTrip(req *http.Request) (resp *http.Response, e
 
 	resp, err = lt.roundTripper.RoundTrip(req)
 	if err != nil {
-		lt.log.Info("hetzner robot API. Error.", "err", err, "method", req.Method, "url", req.URL, "stack", stack)
+		lt.log.V(1).Info("hetzner robot API. Error.", "err", err, "method", req.Method, "url", req.URL, "stack", stack)
 		return resp, err
 	}
-	lt.log.Info("hetzner robot API called.", "statusCode", resp.StatusCode, "method", req.Method, "url", req.URL, "stack", stack)
+	lt.log.V(1).Info("hetzner robot API called.", "statusCode", resp.StatusCode, "method", req.Method, "url", req.URL, "stack", stack)
 	return resp, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Showing robot api calls only on debug level

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

