### PR TITLE
:seedling: Improve startup of target cluster manager

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -20,7 +20,7 @@ settings = {
     "deploy_observability": False,
     "preload_images_for_kind": True,
     "kind_cluster_name": "caph",
-    "capi_version": "v1.5.0",
+    "capi_version": "v1.5.2",
     "cabpt_version": "v0.5.6",
     "cacppt_version": "v0.4.11",
     "cert_manager_version": "v1.11.0",

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -112,10 +112,15 @@ const (
 	KubeAPIServerNotRespondingReason = "KubeAPIServerNotResponding"
 	// TargetClusterCreateFailedReason indicates that the target cluster could not be created.
 	TargetClusterCreateFailedReason = "TargetClusterCreateFailed"
-	// TargetSecretSyncFailedReason indicates that the target secret could not be synced.
-	TargetSecretSyncFailedReason = "TargetSecretSyncFailed"
 	// TargetClusterControlPlaneNotReadyReason indicates that the target cluster's control plane is not ready yet.
 	TargetClusterControlPlaneNotReadyReason = "TargetClusterControlPlaneNotReady"
+)
+
+const (
+	// TargetClusterSecretReadyCondition reports on whether the hetzner secret in the target cluster is ready.
+	TargetClusterSecretReadyCondition clusterv1.ConditionType = "TargetClusterSecretReady"
+	// TargetSecretSyncFailedReason indicates that the target secret could not be synced.
+	TargetSecretSyncFailedReason = "TargetSecretSyncFailed"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Improving the startup of the target (workload) cluster manager to avoid unnecessary and temporary errors that come while the first control plane is still provisioning.

This is done by an additional check whether the control plane is available already.

Furthermore, this commit introduces a new condition so that the Hetzner secret that is stored in the target cluster reconciles with an own condition.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

