### PR TITLE
:bug: Fix provision condition time lag

### DIFF
--- a/pkg/services/baremetal/host/state_machine.go
+++ b/pkg/services/baremetal/host/state_machine.go
@@ -87,15 +87,6 @@ func (hsm *hostStateMachine) ReconcileState() (actionRes actionResult) {
 	// Assume credentials are ready for now. This can be changed while the state is handled.
 	conditions.MarkTrue(hsm.host, infrav1.CredentialsAvailableCondition)
 
-	// Set condition on false. It will be set on true if host is provisioned during reconcilement
-	conditions.MarkFalse(
-		hsm.host,
-		infrav1.ProvisionSucceededCondition,
-		infrav1.StillProvisioningReason,
-		clusterv1.ConditionSeverityInfo,
-		"host is provisioning - current state: %q", hsm.host.Spec.Status.ProvisioningState,
-	)
-
 	if stateHandler, found := hsm.handlers()[initialState]; found {
 		return stateHandler()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There has been a time lag in the condition that shows the provisioning status of the HetznerBareMetalHost. It was only updated after a new reconcilement has started, not during the reconcilement where the state actually changed.

This commit places the update of the condition to the start of the respective functions to ensure it is up to date.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

