### PR TITLE
:seedling: Add event if host is provisioned

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1290,6 +1290,7 @@ func (s *Service) actionEnsureProvisioned() (ar actionResult) {
 		}
 	}
 
+	record.Event(s.scope.HetznerBareMetalHost, "ServerProvisioned", "server successfully provisioned")
 	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.ProvisionSucceededCondition)
 	s.scope.HetznerBareMetalHost.ClearError()
 	return actionComplete{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an event to show that the provisioning process has been completed. This is important to find out based on events where an issue happens. Even if it is successfully provisioned, it might not be added to the cluster, as the CCM does some work after CAPH. To know more about the state, this event will be helpful.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

