### PR TITLE
:sparkles: Add conditions for rootDeviceHint validation

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -104,6 +104,15 @@ const (
 )
 
 const (
+	// RootDeviceHintsValidatedCondition reports on whether the root device hints could be validated.
+	RootDeviceHintsValidatedCondition clusterv1.ConditionType = "RootDeviceHintsValidated"
+	// ValidationFailedReason indicates that the specified root device hints could not be successfully validated.
+	ValidationFailedReason = "ValidationFailed"
+	// StorageDeviceNotFoundReason indicates that the storage device specified in the root device hints could not be found.
+	StorageDeviceNotFoundReason = "StorageDeviceNotFound"
+)
+
+const (
 	// TargetClusterReadyCondition reports on whether the kubeconfig in the target cluster is ready.
 	TargetClusterReadyCondition clusterv1.ConditionType = "TargetClusterReady"
 	// KubeConfigNotFoundReason indicates that the Kubeconfig could not be found.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add conditions to make validation of rootDeviceHints in the bare metal provisioning process easily visible to the user.

small other change: remove second call to obtain storage devices, as the information is already specified in the object itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1044

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

