### PR TITLE
:bug: Remove deprecated KCM argument `pod-eviction-timeout`

### DIFF
--- a/templates/cluster-templates/bases/hcloud-kcp-fedora.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-fedora.yaml
@@ -73,7 +73,6 @@ spec:
           port: "0"
           secure-port: "10257"
           allocate-node-cidrs: "true"
-          pod-eviction-timeout: 2m
       scheduler:
         extraArgs:
           profiling: "false"

--- a/templates/cluster-templates/bases/hcloud-kcp-packer.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-packer.yaml
@@ -70,7 +70,6 @@ spec:
           bind-address: "0.0.0.0"
           secure-port: "10257"
           allocate-node-cidrs: "true"
-          pod-eviction-timeout: 2m
       scheduler:
         extraArgs:
           profiling: "false"

--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -70,7 +70,6 @@ spec:
           bind-address: "0.0.0.0"
           secure-port: "10257"
           allocate-node-cidrs: "true"
-          pod-eviction-timeout: 2m
       scheduler:
         extraArgs:
           profiling: "false"

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -70,7 +70,6 @@ spec:
           bind-address: "0.0.0.0"
           secure-port: "10257"
           allocate-node-cidrs: "true"
-          pod-eviction-timeout: 2m
       scheduler:
         extraArgs:
           profiling: "false"

--- a/templates/cluster-templates/cluster-class.yaml
+++ b/templates/cluster-templates/cluster-class.yaml
@@ -434,7 +434,6 @@ spec:
               cluster-signing-duration: 6h0m0s
               cluster-signing-key-file: /etc/kubernetes/pki/ca.key
               kubeconfig: /etc/kubernetes/controller-manager.conf
-              pod-eviction-timeout: 2m
               profiling: "false"
               requestheader-client-ca-file: /etc/kubernetes/pki/front-proxy-ca.crt
               root-ca-file: /etc/kubernetes/pki/ca.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
The Kubernetes Controller Manager argument `pod-eviction-timeout` was deprecated with Kubernetes 1.26. Hence KCM won't come up successfully with clusters starting from version 1.27 when still passing this argument in cluster templates.
