### PR TITLE
:sparkles: download BM images via oci-registry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ wait-and-get-secret:
 	$(KUBECTL) get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > $(WORKER_CLUSTER_KUBECONFIG)
 	${TIMEOUT} 15m bash -c "while ! $(KUBECTL) --kubeconfig=$(WORKER_CLUSTER_KUBECONFIG) get nodes | grep control-plane; do sleep 1; done"
 
-install-cilium-in-wl-cluster:
+install-cilium-in-wl-cluster: $(HELM)
 	# Deploy cilium
 	$(HELM) repo add cilium https://helm.cilium.io/
 	$(HELM) repo update cilium

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -174,6 +174,13 @@ const (
 )
 
 const (
+	// SSHAfterInstallImageSucceededCondition indicates that the host is reachable via ssh after installImage.
+	SSHAfterInstallImageSucceededCondition clusterv1.ConditionType = "SSHAfterInstallImageSucceeded"
+
+	// SSHAfterInstallImageFailedReason indicates that the host was not reachable via ssh.
+	SSHAfterInstallImageFailedReason = "SSHAfterInstallImageFailed"
+)
+const (
 	// HostAssociateSucceededCondition indicates that a host has been associated.
 	HostAssociateSucceededCondition clusterv1.ConditionType = "HostAssociateSucceeded"
 	// NoAvailableHostReason indicates that there is no available host.

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -316,6 +316,9 @@ func (bmMachine *HetznerBareMetalMachine) SetFailure(reason capierrors.MachineSt
 
 // GetImageSuffix tests whether the suffix is known and outputs it if yes. Otherwise it returns an error.
 func GetImageSuffix(url string) (string, error) {
+	if strings.HasPrefix(url, "oci://") {
+		return "tar.gz", nil
+	}
 	for _, suffix := range []ImageType{
 		ImageTypeTar,
 		ImageTypeTarGz,

--- a/hack/filter-caph-controller-manager-logs.py
+++ b/hack/filter-caph-controller-manager-logs.py
@@ -27,6 +27,8 @@ keys_to_skip = ['controller', 'controllerGroup', 'controllerKind', 'reconcileID'
 rows_to_skip = [
     'controller-runtime.webhook', 'certwatcher/certwatcher', 'Registering a validating webhook',
     'Registering a mutating webhook', 'Starting EventSource',
+    'Starting Controller',
+    '"Starting workers" controller/controller',
     '"Reconciling finished"',
     '"Creating cluster scope"',
     '"Starting reconciling cluster"',

--- a/hack/output-for-watch.sh
+++ b/hack/output-for-watch.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function print_heading(){
+function print_heading() {
     blue='\033[0;34m'
     nc='\033[0m' # No Color
     echo -e "${blue}${1}${nc}"
@@ -36,6 +36,10 @@ print_heading hetznerbaremetalmachine:
 
 kubectl get hetznerbaremetalmachine -A
 
+print_heading hetznerbaremetalhost:
+
+kubectl get hetznerbaremetalhost -A
+
 print_heading events:
 
 kubectl get events -A --sort-by=lastTimestamp | grep -vP 'LeaderElection' | tail -8
@@ -51,9 +55,9 @@ if [ $(kubectl get machine -l cluster.x-k8s.io/control-plane 2>/dev/null | wc -l
     exit 1
 fi
 
-ip=$(kubectl get machine -l cluster.x-k8s.io/control-plane  -o  jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}' | grep -oP '[0-9.]{8,}')
+ip=$(kubectl get machine -l cluster.x-k8s.io/control-plane -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}' | grep -oP '[0-9.]{8,}')
 if [ -z "$ip" ]; then
-    ip=$(kubectl get machine -l cluster.x-k8s.io/control-plane  -o  jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' | grep -oP '[0-9.]{8,}')
+    ip=$(kubectl get machine -l cluster.x-k8s.io/control-plane -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' | grep -oP '[0-9.]{8,}')
     if [ -z "$ip" ]; then
         echo "❌ Could not get IP of control-plane"
     fi
@@ -75,7 +79,6 @@ echo
 
 kubeconfig_wl=".workload-cluster-kubeconfig.yaml"
 
-
 echo "KUBECONFIG=$kubeconfig_wl kubectl cluster-info"
 if KUBECONFIG=$kubeconfig_wl kubectl cluster-info >/dev/null 2>&1; then
     echo "👌 cluster is reachable"
@@ -90,7 +93,7 @@ deployment=$(KUBECONFIG=$kubeconfig_wl kubectl get -n kube-system deployment | g
 if [ -z "$deployment" ]; then
     echo "❌ ccm not installed?"
 else
-    echo  "👌 ccm installed:"
+    echo "👌 ccm installed:"
     KUBECONFIG=$kubeconfig_wl kubectl get -n kube-system deployment "$deployment"
     yaml=$(KUBECONFIG=$kubeconfig_wl kubectl get -n kube-system deployment "$deployment" -o yaml)
     if [[ $yaml =~ "unavailableReplicas:" ]]; then

--- a/pkg/services/baremetal/client/ssh/download-from-oci.sh
+++ b/pkg/services/baremetal/client/ssh/download-from-oci.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts gets copied from the controller into the rescue system
+# of the bare-metal machine.
+
+set -euo pipefail
+
+image="${1:-}"
+outfile="${2:-}"
+
+function usage {
+    echo "$0 image outfile."
+    echo "  Download a machine image from a container registry"
+    echo "  image: for example ghcr.io/foo/bar/my-machine-image:v9"
+    echo "  outfile: Created file. Usualy with file extensions '.tgz'"
+    echo "  If the oci registry needs a token, then the script uses OCI_REGISTRY_AUTH_TOKEN (if set)"
+    echo "  Example of OCI_REGISTRY_AUTH_TOKEN: github:ghp_SN51...."
+    echo
+}
+if [ -z "$outfile" ]; then
+    usage
+    exit 1
+fi
+OCI_REGISTRY_AUTH_TOKEN="${OCI_REGISTRY_AUTH_TOKEN:-}" # github:$GITHUB_TOKEN
+
+# Extract registry
+registry="${image%%/*}"
+
+# Extract scope and tag
+remainder="${image#*/}"
+scope="${remainder%:*}"
+tag="${remainder##*:}"
+
+if [[ -z "$registry" || -z "$scope" || -z "$tag" ]]; then
+    echo "failed to parse registry, scope and tag from image"
+    echo "image=$image"
+    echo "registry=$registry"
+    echo "scope=$scope"
+    echo "tag=$tag"
+    exit 1
+fi
+
+function download_with_token {
+    echo "download with token (OCI_REGISTRY_AUTH_TOKEN set)"
+    if [[ "$OCI_REGISTRY_AUTH_TOKEN" != *:* ]]; then
+        echo "OCI_REGISTRY_AUTH_TOKEN needs to contain a ':' (user:token)"
+        exit 1
+    fi
+
+    token=$(curl -fsSL -u "$OCI_REGISTRY_AUTH_TOKEN" "https://${registry}/token?scope=repository:$scope:pull" | jq -r '.token')
+    if [ -z "$token" ]; then
+        echo "Failed to get token for container registry"
+        exit 1
+    fi
+
+    echo "Login to $registry was successful"
+
+    digest=$(curl -sSL -H "Authorization: Bearer $token" -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        "https://${registry}/v2/${scope}/manifests/${tag}" | jq -r '.layers[0].digest')
+
+    if [ -z "$digest" ]; then
+        echo "Failed to get digest from container registry"
+        exit 1
+    fi
+
+    echo "Start download of $image"
+    curl -fsSL -H "Authorization: Bearer $token" \
+        "https://${registry}/v2/${scope}/blobs/$digest" >"$outfile"
+}
+
+function download_without_token {
+    echo "download without token (OCI_REGISTRY_AUTH_TOKEN empty)"
+    digest=$(curl -sSL -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        "https://${registry}/v2/${scope}/manifests/${tag}" | jq -r '.layers[0].digest')
+
+    if [ -z "$digest" ]; then
+        echo "Failed to get digest from container registry"
+        exit 1
+    fi
+
+    echo "Start download of $image"
+    curl -fsSL "https://${registry}/v2/${scope}/blobs/$digest" >"$outfile"
+}
+
+if [ -z "$OCI_REGISTRY_AUTH_TOKEN" ]; then
+    download_without_token
+else
+    download_with_token
+fi

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -35,6 +35,111 @@ const (
 	sshTimeOut time.Duration = 5 * time.Second
 )
 
+var downloadFromOciShellScript = `#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts gets copied from the controller into the rescue system
+# of the bare-metal machine.
+
+set -euo pipefail
+
+image="${1:-}"
+outfile="${2:-}"
+
+function usage {
+    echo "$0 image outfile."
+    echo "  Download a machine image from a container registry"
+    echo "  image: for example ghcr.io/foo/bar/my-machine-image:v9"
+    echo "  outfile: Created file. Usually with file extensions '.tgz'"
+    echo "  If the oci registry needs a token, then the script uses OCI_REGISTRY_AUTH_TOKEN (if set)"
+    echo "  Example of OCI_REGISTRY_AUTH_TOKEN: github:ghp_SN51...."
+    echo
+}
+if [ -z "$outfile" ]; then
+    usage
+    exit 1
+fi
+OCI_REGISTRY_AUTH_TOKEN="${OCI_REGISTRY_AUTH_TOKEN:-}" # github:$GITHUB_TOKEN
+
+# Extract registry
+registry="${image%%/*}"
+
+# Extract scope and tag
+remainder="${image#*/}"
+scope="${remainder%:*}"
+tag="${remainder##*:}"
+
+if [[ -z "$registry" || -z "$scope" || -z "$tag" ]]; then
+    echo "failed to parse registry, scope and tag from image"
+    echo "image=$image"
+    echo "registry=$registry"
+    echo "scope=$scope"
+    echo "tag=$tag"
+    exit 1
+fi
+
+function download_with_token {
+    echo "download with token (OCI_REGISTRY_AUTH_TOKEN set)"
+    if [[ "$OCI_REGISTRY_AUTH_TOKEN" != *:* ]]; then
+        echo "OCI_REGISTRY_AUTH_TOKEN needs to contain a ':' (user:token)"
+        exit 1
+    fi
+
+    token=$(curl -fsSL -u "$OCI_REGISTRY_AUTH_TOKEN" "https://${registry}/token?scope=repository:$scope:pull" | jq -r '.token')
+    if [ -z "$token" ]; then
+        echo "Failed to get token for container registry"
+        exit 1
+    fi
+
+    echo "Login to $registry was successful"
+
+    digest=$(curl -sSL -H "Authorization: Bearer $token" -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        "https://${registry}/v2/${scope}/manifests/${tag}" | jq -r '.layers[0].digest')
+
+    if [ -z "$digest" ]; then
+        echo "Failed to get digest from container registry"
+        exit 1
+    fi
+
+    echo "Start download of $image"
+    curl -fsSL -H "Authorization: Bearer $token" \
+        "https://${registry}/v2/${scope}/blobs/$digest" >"$outfile"
+}
+
+function download_without_token {
+    echo "download without token (OCI_REGISTRY_AUTH_TOKEN empty)"
+    digest=$(curl -sSL -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        "https://${registry}/v2/${scope}/manifests/${tag}" | jq -r '.layers[0].digest')
+
+    if [ -z "$digest" ]; then
+        echo "Failed to get digest from container registry"
+        exit 1
+    fi
+
+    echo "Start download of $image"
+    curl -fsSL "https://${registry}/v2/${scope}/blobs/$digest" >"$outfile"
+}
+
+if [ -z "$OCI_REGISTRY_AUTH_TOKEN" ]; then
+    download_without_token
+else
+    download_with_token
+fi
+`
+
 var (
 	// ErrCommandExitedWithoutExitSignal means the ssh command exited unplanned.
 	ErrCommandExitedWithoutExitSignal = errors.New("wait: remote command exited without exit status or exit signal")
@@ -221,7 +326,16 @@ EOF`, data))
 
 // DownloadImage implements the DownloadImage method of the SSHClient interface.
 func (c *sshClient) DownloadImage(path, url string) Output {
-	return c.runSSH(fmt.Sprintf(`curl -sLo "%q" "%q"`, path, url))
+	if !strings.HasPrefix(url, "oci://") {
+		return c.runSSH(fmt.Sprintf(`curl -sLo "%q" "%q"`, path, url))
+	}
+	return c.runSSH(fmt.Sprintf(`cat << 'ENDOFSCRIPT' > /root/download-from-oci.sh
+%s
+ENDOFSCRIPT
+chmod a+rx /root/download-from-oci.sh
+OCI_REGISTRY_AUTH_TOKEN=%s /root/download-from-oci.sh %s %s`, downloadFromOciShellScript,
+		os.Getenv("OCI_REGISTRY_AUTH_TOKEN"),
+		strings.TrimPrefix(url, "oci://"), path))
 }
 
 // CreatePostInstallScript implements the CreatePostInstallScript method of the SSHClient interface.


### PR DESCRIPTION
**What this PR does / why we need it**:

Up to now, bare-metal machine images could only be downloaded from http/https URLs.

This PR make it possible to download the machine images from oci-registries.

You can use a tool like [oras](https://oras.land) to upload the machine image in tgz format to an oci registry.

