### PR TITLE
:seedling: fix flaky test, increase timeout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ E2E_CONF_FILE ?= $(E2E_DIR)/config/$(INFRA_PROVIDER)-ci-envsubst.yaml
 .PHONY: test-unit
 test-unit: $(SETUP_ENVTEST) $(GOTESTSUM) ## Run unit and integration tests
 	@mkdir -p $(shell pwd)/.coverage
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GOTESTSUM) --junitfile=.coverage/junit.xml --format testname -- -covermode=atomic -coverprofile=.coverage/cover.out -p=4 ./controllers/... ./pkg/... ./api/...
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GOTESTSUM) --junitfile=.coverage/junit.xml --format testname -- -covermode=atomic -coverprofile=.coverage/cover.out -p=4 -timeout 5m ./controllers/... ./pkg/... ./api/...
 
 .PHONY: e2e-image
 e2e-image: ## Build the e2e manager image

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -344,7 +344,7 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 						return true
 					}
 					return false
-				}, timeout).Should(BeTrue())
+				}, 10*time.Second).Should(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This test was flaky. Increasing the timeout helped.

```
Summarizing 1 Failure:
  [FAIL] HetznerBareMetalHostReconciler Tests with bm machine Test root device life cycle [It] reaches the state image installing
  /home/guettli/syself/caph2/controllers/hetznerbaremetalhost_controller_test.go:347

Ran 95 of 95 Specs in 54.401 seconds
FAIL! -- 94 Passed | 1 Failed | 0 Pending | 0 Skipped

```

And decrease the timeout for tests. They take 2.5 min today. I decreased from 10min (default) to 5min, so that you don't want too long if they hang.
