### PR TITLE
🌱 fix yamllint indentation

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,22 +1,22 @@
 ---
 area/code:
   - changed-files:
-    - any-glob-to-any-file: "controllers/**/*"
-    - any-glob-to-any-file: "pkg/**/*"
+      - any-glob-to-any-file: "controllers/**/*"
+      - any-glob-to-any-file: "pkg/**/*"
 area/api:
   - changed-files:
-    - any-glob-to-any-file: "api/**/*"
-    - any-glob-to-any-file: "config/crd/**/*"
+      - any-glob-to-any-file: "api/**/*"
+      - any-glob-to-any-file: "config/crd/**/*"
 area/github:
   - changed-files:
-    - any-glob-to-any-file: ".github/**/*"
+      - any-glob-to-any-file: ".github/**/*"
 area/hack:
   - changed-files:
-    - any-glob-to-any-file: "hack/**/*"
-    - any-glob-to-any-file: "Makefile"
+      - any-glob-to-any-file: "hack/**/*"
+      - any-glob-to-any-file: "Makefile"
 area/test:
   - changed-files:
-    - any-glob-to-any-file: "test/**/*"
+      - any-glob-to-any-file: "test/**/*"
 area/templates:
   - changed-files:
-    - any-glob-to-any-file: "templates/**/*"
+      - any-glob-to-any-file: "templates/**/*"


### PR DESCRIPTION
```bash
 $ make lint-yaml-ci
docker run  --rm -t -i \
        -v /home/k7/go/pkg:/go/pkg \
        -v /home/k7/work/urgent/caph:/src/cluster-api-provider-hetzner \
        ghcr.io/syself/caph-builder:1.0.13 lint-yaml-ci;
make: Entering directory '/src/cluster-api-provider-hetzner'
yamllint --version
yamllint 1.33.0
yamllint -c .yamllint.yaml . --format github
make: Leaving directory '/src/cluster-api-provider-hetzner'

$ make lint-yaml
docker run  --rm -t -i \
        -v /home/k7/go/pkg:/go/pkg \
        -v /home/k7/work/urgent/caph:/src/cluster-api-provider-hetzner \
        ghcr.io/syself/caph-builder:1.0.13 lint-yaml;
make: Entering directory '/src/cluster-api-provider-hetzner'
yamllint --version
yamllint 1.33.0
yamllint -c .yamllint.yaml --strict .
make: Leaving directory '/src/cluster-api-provider-hetzner'
```

Signed-off-by: Anurag <81210977+kranurag7@users.noreply.github.com>
