### PR TITLE
✨ change registration of types to scheme

### DIFF
--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -20,17 +20,26 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -134,5 +134,5 @@ type HCloudMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HCloudMachine{}, &HCloudMachineList{})
+	objectTypes = append(objectTypes, &HCloudMachine{}, &HCloudMachineList{})
 }

--- a/api/v1beta1/hcloudmachinetemplate_types.go
+++ b/api/v1beta1/hcloudmachinetemplate_types.go
@@ -94,5 +94,5 @@ type HCloudMachineTemplateResource struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HCloudMachineTemplate{}, &HCloudMachineTemplateList{})
+	objectTypes = append(objectTypes, &HCloudMachineTemplate{}, &HCloudMachineTemplateList{})
 }

--- a/api/v1beta1/hcloudremediation_types.go
+++ b/api/v1beta1/hcloudremediation_types.go
@@ -102,5 +102,5 @@ type HCloudRemediationList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HCloudRemediation{}, &HCloudRemediationList{})
+	objectTypes = append(objectTypes, &HCloudRemediation{}, &HCloudRemediationList{})
 }

--- a/api/v1beta1/hcloudremediationtemplate_types.go
+++ b/api/v1beta1/hcloudremediationtemplate_types.go
@@ -68,5 +68,5 @@ type HCloudRemediationTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HCloudRemediationTemplate{}, &HCloudRemediationTemplateList{})
+	objectTypes = append(objectTypes, &HCloudRemediationTemplate{}, &HCloudRemediationTemplateList{})
 }

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -571,5 +571,5 @@ type HetznerBareMetalHostList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerBareMetalHost{}, &HetznerBareMetalHostList{})
+	objectTypes = append(objectTypes, &HetznerBareMetalHost{}, &HetznerBareMetalHostList{})
 }

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -358,5 +358,5 @@ type HetznerBareMetalMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerBareMetalMachine{}, &HetznerBareMetalMachineList{})
+	objectTypes = append(objectTypes, &HetznerBareMetalMachine{}, &HetznerBareMetalMachineList{})
 }

--- a/api/v1beta1/hetznerbaremetalmachinetemplate_types.go
+++ b/api/v1beta1/hetznerbaremetalmachinetemplate_types.go
@@ -57,5 +57,5 @@ type HetznerBareMetalMachineTemplateResource struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerBareMetalMachineTemplate{}, &HetznerBareMetalMachineTemplateList{})
+	objectTypes = append(objectTypes, &HetznerBareMetalMachineTemplate{}, &HetznerBareMetalMachineTemplateList{})
 }

--- a/api/v1beta1/hetznerbaremetalremediation_types.go
+++ b/api/v1beta1/hetznerbaremetalremediation_types.go
@@ -86,5 +86,5 @@ type HetznerBareMetalRemediationList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerBareMetalRemediation{}, &HetznerBareMetalRemediationList{})
+	objectTypes = append(objectTypes, &HetznerBareMetalRemediation{}, &HetznerBareMetalRemediationList{})
 }

--- a/api/v1beta1/hetznerbaremetalremediationtemplate_types.go
+++ b/api/v1beta1/hetznerbaremetalremediationtemplate_types.go
@@ -68,5 +68,5 @@ type HetznerBareMetalRemediationTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerBareMetalRemediationTemplate{}, &HetznerBareMetalRemediationTemplateList{})
+	objectTypes = append(objectTypes, &HetznerBareMetalRemediationTemplate{}, &HetznerBareMetalRemediationTemplateList{})
 }

--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -118,5 +118,5 @@ func (r *HetznerCluster) ClusterTagKey() string {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerCluster{}, &HetznerClusterList{})
+	objectTypes = append(objectTypes, &HetznerCluster{}, &HetznerClusterList{})
 }

--- a/api/v1beta1/hetznerclustertemplate_types.go
+++ b/api/v1beta1/hetznerclustertemplate_types.go
@@ -49,7 +49,7 @@ type HetznerClusterTemplateList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&HetznerClusterTemplate{}, &HetznerClusterTemplateList{})
+	objectTypes = append(objectTypes, &HetznerClusterTemplate{}, &HetznerClusterTemplateList{})
 }
 
 // HetznerClusterTemplateResource contains spec for HetznerClusterSpec.


### PR DESCRIPTION
This commit uses apimachinery runtime package to create a new
schemeBuilder and then use that for registration of our types.

This removes adding types using controller-runtime scheme package.

Ref: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.5-to-v1.6#suggested-changes-for-providers

Signed-off-by: Anurag <81210977+kranurag7@users.noreply.github.com>
