### PR TITLE
:seedling: increase wait time for e2e upgrade test.

### DIFF
--- a/test/e2e/config/hetzner-ci.yaml
+++ b/test/e2e/config/hetzner-ci.yaml
@@ -159,3 +159,4 @@ intervals:
   default/wait-control-plane: ["20m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
   default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted
+  default/wait-deployment-available: ["20s", "1s"] ## wait until deployment with unevictable pods is available (upgrade test)

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -165,3 +165,4 @@ intervals:
   default/wait-control-plane: ["20m", "10s"] ## wait until first control plane is ready
   default/wait-worker-nodes: ["20m", "10s"] ## wait until all workers are ready from the moment when the control plane is ready
   default/wait-delete-cluster: ["20m", "10s"] ## wait until cluster is deleted
+  default/wait-deployment-available: ["20s", "1s"] ## wait until deployment with unevictable pods is available (upgrade test)


### PR DESCRIPTION
**What this PR does / why we need it**:

e2e upgrade test failed after waiting just one second.

This PR increases the wait time to 20 seconds.

Error was this:

> [FAILED] Timed out after 1.011s.
> 
> Deployment caph-system/caph-controller-manager failed to get status.Available = True condition
