### PR TITLE
:seedling: better error message if secret for BM is missing.

### DIFF
--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -218,14 +218,15 @@ func (r *HetznerBareMetalHostReconciler) getSecrets(
 		osSSHSecret, err = secretManager.ObtainSecret(ctx, osSSHSecretNamespacedName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
+				msg := fmt.Sprintf("%s: %s", infrav1.ErrorMessageMissingOSSSHSecret, err.Error())
 				conditions.MarkFalse(
 					bmHost,
 					infrav1.CredentialsAvailableCondition,
 					infrav1.OSSSHSecretMissingReason,
 					clusterv1.ConditionSeverityError,
-					infrav1.ErrorMessageMissingOSSSHSecret,
+					msg,
 				)
-				record.Warnf(bmHost, infrav1.OSSSHSecretMissingReason, infrav1.ErrorMessageMissingOSSSHSecret)
+				record.Warnf(bmHost, infrav1.OSSSHSecretMissingReason, msg)
 				conditions.SetSummary(bmHost)
 				result, err := host.SaveHostAndReturn(ctx, r.Client, bmHost)
 				if result != emptyResult || err != nil {

--- a/docs/developers/releasing.md
+++ b/docs/developers/releasing.md
@@ -4,6 +4,7 @@
 
 1. Create an annotated tag
    - `git switch main`
+   - `git pull`
    - Have a look at the current (old) version: [Github Releases](https://github.com/syself/cluster-api-provider-hetzner/releases) 
    - `export RELEASE_TAG=<the tag of the release to be cut>` (eg. `export RELEASE_TAG=v1.0.1`)
    - `git tag -a ${RELEASE_TAG} -m ${RELEASE_TAG}`
@@ -18,6 +19,7 @@
 1. If it is pre-release, activate the corresponding check at the bottom of the page. And add `:rotating_light: This is a RELEASE CANDIDATE. If you find any bugs, file an [issue](https://github.com/syself/cluster-api-provider-hetzner/issues/new).` at the top of the release notes.
 1. Before publishing you can check the [Recent tagged image versions](https://github.com/syself/cluster-api-provider-hetzner/pkgs/container/caph): "latest" should be some seconds old and the new version number.
 1. Publish the release
+1. Write to the corresponding channels: "FYI: .... was released, (add hyperlink). A big "thank you" to all contributors!"
 
 Done 🥳
 


### PR DESCRIPTION
**What this PR does / why we need it**:

better error message if secret for BM is missing.
