### PR TITLE
:seedling: support externally managed control planes

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -123,6 +123,8 @@ const (
 	TargetClusterCreateFailedReason = "TargetClusterCreateFailed"
 	// TargetClusterControlPlaneNotReadyReason indicates that the target cluster's control plane is not ready yet.
 	TargetClusterControlPlaneNotReadyReason = "TargetClusterControlPlaneNotReady"
+	// ControlPlaneEndpointSetCondition indicates that the control plane is set.
+	ControlPlaneEndpointSetCondition = "ControlPlaneEndpointSet"
 )
 
 const (
@@ -130,6 +132,8 @@ const (
 	TargetClusterSecretReadyCondition clusterv1.ConditionType = "TargetClusterSecretReady"
 	// TargetSecretSyncFailedReason indicates that the target secret could not be synced.
 	TargetSecretSyncFailedReason = "TargetSecretSyncFailed"
+	// ControlPlaneEndpointNotSetReason indicates that the control plane endpoint is not set.
+	ControlPlaneEndpointNotSetReason = "ControlPlaneEndpointNotSet"
 )
 
 const (

--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -26,6 +26,9 @@ const (
 	// resources associated with HetznerCluster before removing it from the
 	// apiserver.
 	ClusterFinalizer = "hetznercluster.infrastructure.cluster.x-k8s.io"
+	// AllowEmptyControlPlaneAddressAnnotation allows HetznerCluster Webhook
+	// to skip some validation steps for external managed controle planes.
+	AllowEmptyControlPlaneAddressAnnotation = "capi.syself.com/allow-empty-control-plane-address"
 )
 
 // HetznerClusterSpec defines the desired state of HetznerCluster.
@@ -43,7 +46,7 @@ type HetznerClusterSpec struct {
 	SSHKeys HetznerSSHKeys `json:"sshKeys"`
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
-	ControlPlaneEndpoint *clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+	ControlPlaneEndpoint *clusterv1.APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 
 	// ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior. Naming convention is from upstream cluster-api project.
 	ControlPlaneLoadBalancer LoadBalancerSpec `json:"controlPlaneLoadBalancer,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables provisioning of Hetzner-based worker nodes using an externally managed Control Plane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/syself/cluster-api-provider-hetzner/issues/845

**Special notes for your reviewer**:

This PR is related to the PR https://github.com/syself/cluster-api-provider-hetzner/pull/848. With this code I was able to create a HetznerCluster with an external control plane and hetzner worker nodes.

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

