### PR TITLE
:seedling: Get BM machine image via oci token

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -77,3 +77,7 @@ exclude_loopback = true
 
 # Exclude all mail addresses from checking
 exclude_mail = false
+
+# Avoid https://docs.hetzner.com/... | Failed: Network error: Connection reset by peer (os error 104)
+max_concurrency = 3
+retry_wait_time = 3

--- a/docs/reference/hetzner-bare-metal-machine-template.md
+++ b/docs/reference/hetzner-bare-metal-machine-template.md
@@ -127,7 +127,13 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: my-oci-registry-secret    # The name of the secret
+<<<<<<< Updated upstream
                 key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret to use
+||||||| constructed merge base
+                key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret. Format: user:token
+=======
+                key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret. Format: "user:pwd" or just "token"
+>>>>>>> Stashed changes
       # ... other container specs
 ```
 

--- a/docs/reference/hetzner-bare-metal-machine-template.md
+++ b/docs/reference/hetzner-bare-metal-machine-template.md
@@ -127,13 +127,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: my-oci-registry-secret    # The name of the secret
-<<<<<<< Updated upstream
-                key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret to use
-||||||| constructed merge base
-                key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret. Format: user:token
-=======
                 key: OCI_REGISTRY_AUTH_TOKEN    # The key in the secret. Format: "user:pwd" or just "token"
->>>>>>> Stashed changes
       # ... other container specs
 ```
 

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -65,14 +65,8 @@ function usage {
     echo "  image: for example ghcr.io/foo/bar/my-machine-image:v9"
     echo "  outfile: Created file. Usually with file extensions '.tgz'"
     echo "  If the oci registry needs a token, then the script uses OCI_REGISTRY_AUTH_TOKEN (if set)"
-<<<<<<< Updated upstream
-    echo "  Example of OCI_REGISTRY_AUTH_TOKEN: github:ghp_SN51...."
-||||||| constructed merge base
-    echo "  Example of OCI_REGISTRY_AUTH_TOKEN: mygithubuser:ghp_SN51...."
-=======
     echo "  Example 1: of OCI_REGISTRY_AUTH_TOKEN: mygithubuser:mypassword"
     echo "  Example 2: of OCI_REGISTRY_AUTH_TOKEN: ghp_SN51...."
->>>>>>> Stashed changes
     echo
 }
 if [ -z "$outfile" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Get BM machine image via oci token.

Before the PR $OCI_REGISTRY_AUTH_TOKEN needed to be "username:password"

How to test:

extract the shell script from the go code and use it to download an image.

for example: ghcr.io/syself/autopilot/node-images/staging/hetzner-apalla-1-27-workeramd64baremetal:v0-sha.2ae2207

