### PR TITLE
:seedling: Add back fixed baremetal hosts

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -1,14 +1,14 @@
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-1"
-# spec:
-#   serverID: 1670788
-#   rootDeviceHints:
-#     wwn: "0x5002538c0004413f"
-#   maintenanceMode: false
-#   description: Test Machine 1
-# ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-1"
+spec:
+  serverID: 1670788
+  rootDeviceHints:
+    wwn: "0x5002538c0004413f"
+  maintenanceMode: false
+  description: Test Machine 1
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -19,17 +19,17 @@ spec:
     wwn: "0x500a07510fe0ce34"
   maintenanceMode: false
   description: Test Machine 2
-# ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-3"
-# spec:
-#   serverID: 1724024
-#   rootDeviceHints:
-#     wwn: "0x500a075111968d25"
-#   maintenanceMode: false
-#   description: Test Machine 3
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-3"
+spec:
+  serverID: 1724024
+  rootDeviceHints:
+    wwn: "0x500a075111968d25"
+  maintenanceMode: false
+  description: Test Machine 3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost


### PR DESCRIPTION
**What this PR does / why we need it**:
Two of the failing bare metal hosts used for testing has been fixed and this change is only to add them back.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits

