### PR TITLE
🐛 Fix server deletion

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -202,8 +202,13 @@ func (s *Service) Delete(ctx context.Context) (res reconcile.Result, err error) 
 
 	// control planes have to be deleted as targets of server
 	if s.scope.IsControlPlane() && s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled {
-		if err := s.deleteServerOfLoadBalancer(ctx, server); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to delete attached server of loadbalancer: %w", err)
+		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
+			if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {
+				if err := s.deleteServerOfLoadBalancer(ctx, server); err != nil {
+					return reconcile.Result{}, fmt.Errorf("failed to delete attached server of loadbalancer: %w", err)
+				}
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue of deleting servers introduced by [PR 1145](https://github.com/syself/cluster-api-provider-hetzner/pull/1145).

The server was being removed as a target from the load balancer during the load balancer reconciliation, and the server deletion function was trying to do that removal again and failing. Now there is a check, and only servers registered as targets are removed.

**Special notes for your reviewer**:
_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits

