### PR TITLE
:seedling: migrate to create-github-app-token

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -42,11 +42,11 @@ jobs:
           done
 
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@f4c6bf6752984b3a29fcc135a5e70eb792c40c6b # v1
         id: generate-token
         with:
-          app_id: ${{ secrets.SYSELF_APP_ID }}
-          private_key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SYSELF_APP_ID }}
+          private-key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
       - name: Generate Size
         uses: pascalgn/size-label-action@37a5ad4ae20ea8032abf169d953bcd661fd82cd3 # v0.5.0
         env:

--- a/.github/workflows/schedule-link-checker.yml
+++ b/.github/workflows/schedule-link-checker.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@f4c6bf6752984b3a29fcc135a5e70eb792c40c6b # v1
         id: generate-token
         with:
-          app_id: ${{ secrets.SYSELF_APP_ID }}
-          private_key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SYSELF_APP_ID }}
+          private-key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421 # v1.8.0

--- a/.github/workflows/schedule-update-bot.yaml
+++ b/.github/workflows/schedule-update-bot.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@f4c6bf6752984b3a29fcc135a5e70eb792c40c6b # v1
         id: generate-token
         with:
-          app_id: ${{ secrets.SYSELF_APP_ID }}
-          private_key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SYSELF_APP_ID }}
+          private-key: ${{ secrets.SYSELF_APP_PRIVATE_KEY }}
       - name: Override default config from dispatch variables
         run: |
           echo "DRY_RUN=${{ github.event.inputs.dryRun || env.DRY_RUN }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
- **migrate to create-github-app-token**
  this commit migrates to officially maintained
  way of generating token.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>