### PR TITLE
:seedling: update dependencies to address cloudflare/circl vuln

### DIFF
--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -41,9 +41,9 @@ const (
 
 // RootDeviceHints holds the hints for specifying the storage location
 // for the root filesystem for the image. Need to specify either WWN or raid
-// to provision the host machine successfully. It is important to find the correct root device. 
-// If none are specified, the host will stop provisioning in between to wait for 
-// the details to be specified. HardwareDetails in the host's status can be used to find the correct device. 
+// to provision the host machine successfully. It is important to find the correct root device.
+// If none are specified, the host will stop provisioning in between to wait for
+// the details to be specified. HardwareDetails in the host's status can be used to find the correct device.
 // Currently, you can specify one disk or a raid setup.
 type RootDeviceHints struct {
 	// Unique storage identifier. The hint must match the actual value
@@ -197,8 +197,8 @@ type HetznerBareMetalHostSpec struct {
 	// +optional
 	Description string `json:"description,omitempty"`
 
-	// Status contains all status information. The controller writes this status. 
-	// As some cannot be regenerated during any reconcilement, the status 
+	// Status contains all status information. The controller writes this status.
+	// As some cannot be regenerated during any reconcilement, the status
 	// is in the specs of the object - not the actual status. DO NOT EDIT!!!
 	// +optional
 	Status ControllerGeneratedStatus `json:"status,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
-github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
-github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
+github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
+github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist.go
+++ b/vendor/github.com/cloudflare/circl/ecc/goldilocks/twist.go
@@ -9,7 +9,7 @@ import (
 	fp "github.com/cloudflare/circl/math/fp448"
 )
 
-// twistCurve is -x^2+y^2=1-39082x^2y^2 and is 4-isogeneous to Goldilocks.
+// twistCurve is -x^2+y^2=1-39082x^2y^2 and is 4-isogenous to Goldilocks.
 type twistCurve struct{}
 
 // Identity returns the identity point.

--- a/vendor/github.com/cloudflare/circl/internal/sha3/keccakf.go
+++ b/vendor/github.com/cloudflare/circl/internal/sha3/keccakf.go
@@ -6,13 +6,21 @@ package sha3
 
 // KeccakF1600 applies the Keccak permutation to a 1600b-wide
 // state represented as a slice of 25 uint64s.
+// If turbo is true, applies the 12-round variant instead of the
+// regular 24-round variant.
 // nolint:funlen
-func KeccakF1600(a *[25]uint64) {
+func KeccakF1600(a *[25]uint64, turbo bool) {
 	// Implementation translated from Keccak-inplace.c
 	// in the keccak reference code.
 	var t, bc0, bc1, bc2, bc3, bc4, d0, d1, d2, d3, d4 uint64
 
-	for i := 0; i < 24; i += 4 {
+	i := 0
+
+	if turbo {
+		i = 12
+	}
+
+	for ; i < 24; i += 4 {
 		// Combines the 5 steps in each round into 2 steps.
 		// Unrolls 4 rounds per loop and spreads some steps across rounds.
 

--- a/vendor/github.com/cloudflare/circl/internal/sha3/shake.go
+++ b/vendor/github.com/cloudflare/circl/internal/sha3/shake.go
@@ -57,11 +57,33 @@ func NewShake128() State {
 	return State{rate: rate128, dsbyte: dsbyteShake}
 }
 
+// NewTurboShake128 creates a new TurboSHAKE128 variable-output-length ShakeHash.
+// Its generic security strength is 128 bits against all attacks if at
+// least 32 bytes of its output are used.
+// D is the domain separation byte and must be between 0x01 and 0x7f inclusive.
+func NewTurboShake128(D byte) State {
+	if D == 0 || D > 0x7f {
+		panic("turboshake: D out of range")
+	}
+	return State{rate: rate128, dsbyte: D, turbo: true}
+}
+
 // NewShake256 creates a new SHAKE256 variable-output-length ShakeHash.
 // Its generic security strength is 256 bits against all attacks if
 // at least 64 bytes of its output are used.
 func NewShake256() State {
 	return State{rate: rate256, dsbyte: dsbyteShake}
+}
+
+// NewTurboShake256 creates a new TurboSHAKE256 variable-output-length ShakeHash.
+// Its generic security strength is 256 bits against all attacks if
+// at least 64 bytes of its output are used.
+// D is the domain separation byte and must be between 0x01 and 0x7f inclusive.
+func NewTurboShake256(D byte) State {
+	if D == 0 || D > 0x7f {
+		panic("turboshake: D out of range")
+	}
+	return State{rate: rate256, dsbyte: D, turbo: true}
 }
 
 // ShakeSum128 writes an arbitrary-length digest of data into hash.
@@ -76,4 +98,22 @@ func ShakeSum256(hash, data []byte) {
 	h := NewShake256()
 	_, _ = h.Write(data)
 	_, _ = h.Read(hash)
+}
+
+// TurboShakeSum128 writes an arbitrary-length digest of data into hash.
+func TurboShakeSum128(hash, data []byte, D byte) {
+	h := NewTurboShake128(D)
+	_, _ = h.Write(data)
+	_, _ = h.Read(hash)
+}
+
+// TurboShakeSum256 writes an arbitrary-length digest of data into hash.
+func TurboShakeSum256(hash, data []byte, D byte) {
+	h := NewTurboShake256(D)
+	_, _ = h.Write(data)
+	_, _ = h.Read(hash)
+}
+
+func (d *State) SwitchDS(D byte) {
+	d.dsbyte = D
 }

--- a/vendor/github.com/cloudflare/circl/math/primes.go
+++ b/vendor/github.com/cloudflare/circl/math/primes.go
@@ -1,0 +1,34 @@
+package math
+
+import (
+	"crypto/rand"
+	"io"
+	"math/big"
+)
+
+// IsSafePrime reports whether p is (probably) a safe prime.
+// The prime p=2*q+1 is safe prime if both p and q are primes.
+// Note that ProbablyPrime is not suitable for judging primes
+// that an adversary may have crafted to fool the test.
+func IsSafePrime(p *big.Int) bool {
+	pdiv2 := new(big.Int).Rsh(p, 1)
+	return p.ProbablyPrime(20) && pdiv2.ProbablyPrime(20)
+}
+
+// SafePrime returns a number of the given bit length that is a safe prime with high probability.
+// The number returned p=2*q+1 is a safe prime if both p and q are primes.
+// SafePrime will return error for any error returned by rand.Read or if bits < 2.
+func SafePrime(random io.Reader, bits int) (*big.Int, error) {
+	one := big.NewInt(1)
+	p := new(big.Int)
+	for {
+		q, err := rand.Prime(random, bits-1)
+		if err != nil {
+			return nil, err
+		}
+		p.Lsh(q, 1).Add(p, one)
+		if p.ProbablyPrime(20) {
+			return p, nil
+		}
+	}
+}

--- a/vendor/github.com/cloudflare/circl/sign/ed25519/ed25519.go
+++ b/vendor/github.com/cloudflare/circl/sign/ed25519/ed25519.go
@@ -1,7 +1,7 @@
 // Package ed25519 implements Ed25519 signature scheme as described in RFC-8032.
 //
 // This package provides optimized implementations of the three signature
-// variants and maintaining closer compatiblilty with crypto/ed25519.
+// variants and maintaining closer compatibility with crypto/ed25519.
 //
 //	| Scheme Name | Sign Function     | Verification  | Context           |
 //	|-------------|-------------------|---------------|-------------------|

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/blang/semver/v4
 # github.com/cespare/xxhash/v2 v2.2.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cloudflare/circl v1.3.3
+# github.com/cloudflare/circl v1.3.7
 ## explicit; go 1.19
 github.com/cloudflare/circl/dh/x25519
 github.com/cloudflare/circl/dh/x448


### PR DESCRIPTION
Ref: https://github.com/syself/cluster-api-provider-hetzner/security/dependabot/28

- **update dependencies to address security vuln**
  we were using cloudflare/circl as indirect
  dependency and dependabot alerted us about the
  same. This commit updates the dependencies to the
  latest version which has the fixes for the
  security vulnerability.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>