### PR TITLE
:seedling: Always create UEFI partition

### DIFF
--- a/pkg/services/baremetal/host/utils.go
+++ b/pkg/services/baremetal/host/utils.go
@@ -48,11 +48,7 @@ SWRAID %v`, autoSetupInput.hostName, installImageSpec.Swraid)
 SWRAIDLEVEL %v`, hostName, installImageSpec.SwraidLevel)
 	}
 
-	// We always create the UEFI partition, even for legacy BIOS.
-	// This makes the setup easier, if the partition table type should
-	// get changed later.
-	partitions := "PART /boot/efi esp 512\n"
-
+	var partitions string
 	for _, partition := range installImageSpec.Partitions {
 		partitions = fmt.Sprintf(`%s
 PART %s %s %s`, partitions, partition.Mount, partition.FileSystem, partition.Size)

--- a/pkg/services/baremetal/host/utils.go
+++ b/pkg/services/baremetal/host/utils.go
@@ -48,7 +48,11 @@ SWRAID %v`, autoSetupInput.hostName, installImageSpec.Swraid)
 SWRAIDLEVEL %v`, hostName, installImageSpec.SwraidLevel)
 	}
 
-	var partitions string
+	// We always create the UEFI partition, even for legacy BIOS.
+	// This makes the setup easier, if the partition table type should
+	// get changed later.
+	partitions := "PART /boot/efi esp 512\n"
+
 	for _, partition := range installImageSpec.Partitions {
 		partitions = fmt.Sprintf(`%s
 PART %s %s %s`, partitions, partition.Mount, partition.FileSystem, partition.Size)

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -9,6 +9,9 @@ spec:
         image:
           path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
         partitions:
+          - fileSystem: esp
+            mount: /boot/efi
+            size: 512M
           - mount: /boot
             fileSystem: ext4
             size: 1024M

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -9,6 +9,9 @@ spec:
         image:
           path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
         partitions:
+          - fileSystem: esp
+            mount: /boot/efi
+            size: 512M
           - mount: /boot
             fileSystem: ext4
             size: 1024M

--- a/templates/cluster-templates/cluster-class.yaml
+++ b/templates/cluster-templates/cluster-class.yaml
@@ -681,6 +681,9 @@ spec:
         image:
           path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
         partitions:
+          - fileSystem: esp
+            mount: /boot/efi
+            size: 512M
           - fileSystem: ext4
             mount: /boot
             size: 1024M


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes provisioning bare-metal machines. From now on we always create an UEFI boot partition.

This wastes 514MByte for systems without UEFI, but we think that should not matter much.

This should fix #1118 

# TODO

- [ ] Test with a machine with legacy BIOS (demo account:  the one from germany: FSN1-DC8)
- [ ] Test with a machine with UEFI (demo account: AX41)


on the ax41 (after the node is running). Check for uefi support:

```
root@... ~ # efibootmgr 
```

If you see that, then uefi is NOT running:

```
EFI variables are not supported on this system.
```

