### PR TITLE
:seedling: use ubuntu-22.04

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -142,9 +142,7 @@ def caph():
             yaml = str(encode_yaml_stream(yaml_dict))
             yaml = fixup_yaml_empty_arrays(yaml)
 
-    # copy things from data directory to .tiltbuild 
-    if not os.path.exists('.tiltbuild/installimage.tgz'):
-        local("cp data/hetzner-installimage-v1.0.5.tgz .tiltbuild/installimage.tgz")
+    local("cp data/hetzner-installimage-v1.0.5.tgz .tiltbuild/installimage.tgz")
 
     # Set up a local_resource build of the provider's manager binary.
 

--- a/api/v1beta1/hetznerbaremetalmachine_types_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types_test.go
@@ -277,9 +277,9 @@ func Test_Image_String(t *testing.T) {
 		{
 			Image{
 				Name: "nfs",
-				Path: "/root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz",
+				Path: "/root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz",
 			},
-			"nfs (/root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz)",
+			"nfs (/root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz)",
 		},
 	} {
 		require.Equal(t, row.expected, row.image.String())

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -884,6 +884,11 @@ name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express
 		StdErr: "",
 		Err:    nil,
 	})
+	sshClient.On("GetHardwareDetailsDebug").Return(sshclient.Output{
+		StdOut: "Dummy outupt",
+		StdErr: "",
+		Err:    nil,
+	})
 	sshClient.On("DownloadImage", mock.Anything, mock.Anything).Return(sshclient.Output{})
 	sshClient.On("CreateAutoSetup", mock.Anything).Return(sshclient.Output{})
 	sshClient.On("UntarTGZ").Return(sshclient.Output{})
@@ -892,4 +897,5 @@ name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express
 	sshClient.On("Reboot").Return(sshclient.Output{})
 	sshClient.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 	sshClient.On("DetectLinuxOnAnotherDisk", mock.Anything).Return(sshclient.Output{})
+	sshClient.On("GetRunningInstallImageProcesses").Return(sshclient.Output{})
 }

--- a/pkg/services/baremetal/client/mocks/ssh/Client.go
+++ b/pkg/services/baremetal/client/mocks/ssh/Client.go
@@ -848,6 +848,47 @@ func (_c *Client_GetHardwareDetailsCPUThreads_Call) RunAndReturn(run func() sshc
 	return _c
 }
 
+// GetHardwareDetailsDebug provides a mock function with given fields:
+func (_m *Client) GetHardwareDetailsDebug() sshclient.Output {
+	ret := _m.Called()
+
+	var r0 sshclient.Output
+	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(sshclient.Output)
+	}
+
+	return r0
+}
+
+// Client_GetHardwareDetailsDebug_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetHardwareDetailsDebug'
+type Client_GetHardwareDetailsDebug_Call struct {
+	*mock.Call
+}
+
+// GetHardwareDetailsDebug is a helper method to define mock.On call
+func (_e *Client_Expecter) GetHardwareDetailsDebug() *Client_GetHardwareDetailsDebug_Call {
+	return &Client_GetHardwareDetailsDebug_Call{Call: _e.mock.On("GetHardwareDetailsDebug")}
+}
+
+func (_c *Client_GetHardwareDetailsDebug_Call) Run(run func()) *Client_GetHardwareDetailsDebug_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_GetHardwareDetailsDebug_Call) Return(_a0 sshclient.Output) *Client_GetHardwareDetailsDebug_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_GetHardwareDetailsDebug_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsDebug_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetHardwareDetailsNics provides a mock function with given fields:
 func (_m *Client) GetHardwareDetailsNics() sshclient.Output {
 	ret := _m.Called()
@@ -1008,6 +1049,47 @@ func (_c *Client_GetHostName_Call) Return(_a0 sshclient.Output) *Client_GetHostN
 }
 
 func (_c *Client_GetHostName_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHostName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetRunningInstallImageProcesses provides a mock function with given fields:
+func (_m *Client) GetRunningInstallImageProcesses() sshclient.Output {
+	ret := _m.Called()
+
+	var r0 sshclient.Output
+	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(sshclient.Output)
+	}
+
+	return r0
+}
+
+// Client_GetRunningInstallImageProcesses_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRunningInstallImageProcesses'
+type Client_GetRunningInstallImageProcesses_Call struct {
+	*mock.Call
+}
+
+// GetRunningInstallImageProcesses is a helper method to define mock.On call
+func (_e *Client_Expecter) GetRunningInstallImageProcesses() *Client_GetRunningInstallImageProcesses_Call {
+	return &Client_GetRunningInstallImageProcesses_Call{Call: _e.mock.On("GetRunningInstallImageProcesses")}
+}
+
+func (_c *Client_GetRunningInstallImageProcesses_Call) Run(run func()) *Client_GetRunningInstallImageProcesses_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Client_GetRunningInstallImageProcesses_Call) Return(_a0 sshclient.Output) *Client_GetRunningInstallImageProcesses_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_GetRunningInstallImageProcesses_Call) RunAndReturn(run func() sshclient.Output) *Client_GetRunningInstallImageProcesses_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1103,7 +1103,7 @@ var _ = Describe("actionRegistering", func() {
 			sshMock.On("GetHardwareDetailsCPUFlags").Return(sshclient.Output{StdOut: "flag1 flag2 flag3"})
 			sshMock.On("GetHardwareDetailsCPUThreads").Return(sshclient.Output{StdOut: "123"})
 			sshMock.On("GetHardwareDetailsCPUCores").Return(sshclient.Output{StdOut: "12"})
-
+			sshMock.On("GetHardwareDetailsDebug").Return(sshclient.Output{StdOut: "Dummy outupt"})
 			service := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 
 			actResult := service.actionRegistering()

--- a/pkg/services/hcloud/server/server_suite_test.go
+++ b/pkg/services/hcloud/server/server_suite_test.go
@@ -79,14 +79,14 @@ const serverJSON = `
 		},
 		"deleted": null,
 		"deprecated": "2018-02-28T00:00:00+00:00",
-		"description": "Ubuntu 20.04 Standard 64 bit",
+		"description": "Ubuntu 22.04 Standard 64 bit",
 		"disk_size": 10,
 		"id": 42,
 		"image_size": 2.3,
 		"labels": {},
-		"name": "ubuntu-20.04",
+		"name": "ubuntu-22.04",
 		"os_flavor": "ubuntu",
-		"os_version": "20.04",
+		"os_version": "22.04",
 		"protection": {
 			"delete": false
 		},

--- a/templates/cluster-templates/bases/hcloud-kcp-fedora.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-fedora.yaml
@@ -251,8 +251,8 @@ spec:
       - dnf install --setopt=obsoletes=0 -y kubelet-0:1.23.4-0 kubeadm-0:1.23.4-0 kubectl-0:1.23.4-0 python3-dnf-plugin-versionlock bash-completion --disableexcludes=kubernetes && dnf versionlock kubelet kubectl kubeadm && systemctl enable kubelet && systemctl start crio && kubeadm config images pull --kubernetes-version 1.23.4
       - dnf install -y policycoreutils-python-utils
       - semanage fcontext -a -t container_file_t /var/lib/etcd && mkdir -p /var/lib/etcd && restorecon -rv /var /etc
-      - echo 'source <(kubectl completion bash)' >>~/.bashrc
-      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+      - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
       - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
       - dnf -y remove firewalld
       - dnf -y autoremove && dnf -y clean all

--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -194,7 +194,7 @@ spec:
       - apt-get update
       - apt-get install -y kubelet=$KUBERNETES_VERSION-1.1 kubeadm=$KUBERNETES_VERSION-1.1 kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl kubeadm && systemctl enable kubelet
       - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-      - echo 'source <(kubectl completion bash)' >>~/.bashrc
-      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+      - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
       - apt-get -y autoremove && apt-get -y clean all
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -211,7 +211,7 @@ spec:
       - apt-get update
       - apt-get install -y kubelet=$KUBERNETES_VERSION-1.1 kubeadm=$KUBERNETES_VERSION-1.1 kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl kubeadm && systemctl enable kubelet
       - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-      - echo 'source <(kubectl completion bash)' >>~/.bashrc
-      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+      - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+      - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
       - apt-get -y autoremove && apt-get -y clean all
   version: "${KUBERNETES_VERSION}"

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       installImage:
         image:
-          path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi
@@ -23,6 +23,7 @@ spec:
           mkdir -p /etc/cloud/cloud.cfg.d && touch /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           echo "network: { config: disabled }" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           apt-get update && apt-get install -y cloud-init apparmor apparmor-utils
+          cloud-init clean --logs
       sshSpec:
         portAfterInstallImage: 22
         portAfterCloudInit: 22

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       installImage:
         image:
-          path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi
@@ -23,6 +23,7 @@ spec:
           mkdir -p /etc/cloud/cloud.cfg.d && touch /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           echo "network: { config: disabled }" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           apt-get update && apt-get install -y cloud-init apparmor apparmor-utils
+          cloud-init clean --logs
       sshSpec:
         portAfterInstallImage: 22
         portAfterCloudInit: 22

--- a/templates/cluster-templates/bases/kct-md-0-fedora.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-fedora.yaml
@@ -129,8 +129,8 @@ spec:
         - dnf install --setopt=obsoletes=0 -y kubelet-0:1.23.4-0 kubeadm-0:1.23.4-0 kubectl-0:1.23.4-0 python3-dnf-plugin-versionlock bash-completion --disableexcludes=kubernetes && dnf versionlock kubelet kubectl kubeadm && systemctl enable kubelet && systemctl start crio && kubeadm config images pull --kubernetes-version 1.23.4
         - dnf install -y policycoreutils-python-utils
         - semanage fcontext -a -t container_file_t /var/lib/etcd && mkdir -p /var/lib/etcd && restorecon -rv /var /etc
-        - echo 'source <(kubectl completion bash)' >>~/.bashrc
-        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
         - setenforce 0 && sed -i -e '/^\(#\|\)SELINUX/s/^.*$/SELINUX=disabled/' /etc/selinux/config
         - dnf -y remove firewalld
         - dnf -y autoremove && dnf -y clean all

--- a/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
@@ -83,6 +83,6 @@ spec:
         - apt-get update
         - apt-get install -y kubelet=$KUBERNETES_VERSION-1.1 kubeadm=$KUBERNETES_VERSION-1.1 kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl kubeadm && systemctl enable kubelet
         - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-        - echo 'source <(kubectl completion bash)' >>~/.bashrc
-        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
         - apt-get -y autoremove && apt-get -y clean all

--- a/templates/cluster-templates/cluster-class.yaml
+++ b/templates/cluster-templates/cluster-class.yaml
@@ -565,8 +565,8 @@ spec:
             kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl
             kubeadm && systemctl enable kubelet
           - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-          - echo 'source <(kubectl completion bash)' >>~/.bashrc
-          - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+          - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+          - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
           - apt-get -y autoremove && apt-get -y clean all
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -652,8 +652,8 @@ spec:
           kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl
           kubeadm && systemctl enable kubelet
         - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-        - echo 'source <(kubectl completion bash)' >>~/.bashrc
-        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
         - apt-get -y autoremove && apt-get -y clean all
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -679,7 +679,7 @@ spec:
         swraid: 0
         swraidLevel: 1
         image:
-          path: /root/.oldroot/nfs/install/../images/Ubuntu-2004-focal-64-minimal-hwe.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi
@@ -695,6 +695,7 @@ spec:
           mkdir -p /etc/cloud/cloud.cfg.d && touch /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           echo "network: { config: disabled }" > /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
           apt-get update && apt-get install -y cloud-init apparmor apparmor-utils
+          cloud-init clean --logs
       sshSpec:
         portAfterCloudInit: 22
         portAfterInstallImage: 22
@@ -788,6 +789,6 @@ spec:
           kubectl=$KUBERNETES_VERSION-1.1  bash-completion && apt-mark hold kubelet kubectl
           kubeadm && systemctl enable kubelet
         - kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
-        - echo 'source <(kubectl completion bash)' >>~/.bashrc
-        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+        - echo 'source <(kubectl completion bash)' >>/root/.bashrc
+        - echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc
         - apt-get -y autoremove && apt-get -y clean all

--- a/templates/node-image/1.27.8-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.27.8-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -35,7 +35,7 @@ systemctl enable kubelet
 kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
 # enable completion
-echo 'source <(kubectl completion bash)' >>~/.bashrc
+echo 'source <(kubectl completion bash)' >>/root/.bashrc
 
 # set the kubeadm default path for kubeconfig
-echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc

--- a/templates/node-image/1.28.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.28.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -35,7 +35,7 @@ systemctl enable kubelet
 kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
 # enable completion
-echo 'source <(kubectl completion bash)' >>~/.bashrc
+echo 'source <(kubectl completion bash)' >>/root/.bashrc
 
 # set the kubeadm default path for kubeconfig
-echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>~/.bashrc
+echo 'export KUBECONFIG=/etc/kubernetes/admin.conf' >>/root/.bashrc


### PR DESCRIPTION
**What this PR does / why we need it**:

The default templates of caph use Ubuntu 20.04.

This is old, and we have seen issues with new uefi-only machines, which could be related to that.

The PR changes some other things. `EOF` was changed to `EOF_VIA_SSH` because a nested heredoc which uses also EOF would fail.

And ~/.bashrc is not resolved. I use /root/.bashrc now.
