### PR TITLE
:seedling: Fix getting NIC info if more than one card was found.

### DIFF
--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -257,7 +257,7 @@ do
 
 MAC=\""$(ip a | grep -A2 $iname | awk '/link/{print $2}')\""
 SPEED=\""$(ethtool eth0 |grep "Speed:" | awk '{print $2}' | sed 's/[^0-9]//g')\""
-MODEL=\""$( lspci | grep net | awk '{$1=$2=$3=""; print $0}' | sed "s/^[ \t]*//")\""
+MODEL=\""$( lspci | grep net | head -1 | awk '{$1=$2=$3=""; print $0}' | sed "s/^[ \t]*//")\""
 IP_V4=\""$(ip a | grep -A2 eth0 | sed -n '/\binet\b/p' | awk '{print $2}')\""
 IP_V6=\""$(ip a | grep -A2 eth0 | sed -n '/\binet6\b/p' | awk '{print $2}')\""
 


### PR DESCRIPTION

**What this PR does / why we need it**:

If a bare-metal machine has several network interface cards, the provisioning did fail.

Fixes #939 

# Caveat

The PR makes the provisioning no longer fail.

BUT: Getting the INFO is broken in several ways:

* SPEED gets always fetched from eth0. It should be $iname instead.
* Getting the NIC via grepping lspci is not reliable. The name does not match to $iname.

Getting the NIC info in a more reliable way is a different PR.






**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

