### PR TITLE
:seedling: detect efi partitions in detect-linux-on-another-disk.sh

### DIFF
--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -67,10 +67,14 @@ while read name wwn type; do
         fail=1
         continue
     fi
+    if echo "$root_directory_content" | grep -Pqi '.*\bEFI\b.*'; then # -i is needed, because grub-fstest prints "efi", but mounted it is "EFI".
+        echo "FAIL: $name $wwn looks like a Linux /boot/efi partition on another disk."
+        fail=1
+        continue
+    fi
     #echo "ok: $name $wwn $parttype, does not look like root Linux partition."
 done < <(echo "$lines" | grep -v NAME | grep -i part)
 if [ $fail -eq 1 ]; then
     exit 1
 fi
 echo "Looks good. No Linux root partition on another devices"
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Up to now `detect-linux-on-another-disk.sh` did not detect /boot/efi partitions.

Now it detects such partitions.

This means install-image won't install if an efi-partition is on another disk, because this could make the reboot boot into another OS.

