### PR TITLE
🌱 log name of server and lb

### DIFF
--- a/pkg/services/hcloud/remediation/remediation.go
+++ b/pkg/services/hcloud/remediation/remediation.go
@@ -96,7 +96,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 		if err := s.scope.HCloudClient.RebootServer(ctx, server); err != nil {
 			hcloudutil.HandleRateLimitExceeded(s.scope.HCloudMachine, err, "RebootServer")
 			record.Warn(s.scope.HCloudRemediation, "FailedRebootServer", err.Error())
-			return reconcile.Result{}, fmt.Errorf("failed to reboot server %v: %w", server.ID, err)
+			return reconcile.Result{}, fmt.Errorf("failed to reboot server %s with ID %d: %w", server.Name, server.ID, err)
 		}
 		record.Event(s.scope.HCloudRemediation, "ServerRebooted", "Server has been rebooted")
 
@@ -124,7 +124,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 	if err := s.scope.HCloudClient.RebootServer(ctx, server); err != nil {
 		hcloudutil.HandleRateLimitExceeded(s.scope.HCloudMachine, err, "RebootServer")
 		record.Warn(s.scope.HCloudRemediation, "FailedRebootServer", err.Error())
-		return reconcile.Result{}, fmt.Errorf("failed to reboot server %v: %w", server.ID, err)
+		return reconcile.Result{}, fmt.Errorf("failed to reboot server %s with ID %d: %w", server.Name, server.ID, err)
 	}
 	record.Event(s.scope.HCloudRemediation, "ServerRebooted", "Server has been rebooted")
 


### PR DESCRIPTION
till now we only used numeric ID in logs which becomes sometimes hard during debugging as things needs to cross checked.