### PR TITLE
🌱 fix links failures and enable link checking in docs directory

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,6 +14,7 @@ on: # yamllint disable-line rule:truthy
       - "images/caph/**"
       - "!**/vendor/**"
       - "test/e2e/**"
+      - "docs/**"
 # yamllint disable rule:line-length
 jobs:
   pr-lint:

--- a/docs/developers/development.md
+++ b/docs/developers/development.md
@@ -2,7 +2,7 @@
 
 Developing our provider is quite easy. Please follow the steps mentioned below: 
 1. You need to install some base requirements. 
-2. You need to follow the [preparation document](docs/topics/preparation.md) to set up everything related to Hetzner. 
+2. You need to follow the [preparation document](/docs/topics/preparation.md) to set up everything related to Hetzner. 
 
 ## Install Base requirements
 

--- a/docs/topics/preparation.md
+++ b/docs/topics/preparation.md
@@ -7,13 +7,13 @@ There are several tasks that have to be completed before a workload cluster can 
 ### Preparing Hetzner Cloud
 
 1. Create a new [HCloud project](https://console.hetzner.cloud/projects).
-1. Generate an API token with read and write access. You'll find this if you click on the project and go to "security".
-1. If you want to use it, generate an SSH key, upload the public key to HCloud (also via "security"), and give it a name. Read more about [Managing SSH Keys](managing-ssh-keys.md).
+2. Generate an API token with read and write access. You'll find this if you click on the project and go to "security".
+3. If you want to use it, generate an SSH key, upload the public key to HCloud (also via "security"), and give it a name. Read more about [Managing SSH Keys](managing-ssh-keys.md).
 
 ### Preparing Hetzner Robot
 
-1. Create a new web service user. [Here](https://robot.hetzner.com/preferences/index), you can define a password and copy your user name.
-1. Generate an SSH key. You can either upload it via Hetzner Robot UI or just rely on the controller to upload a key that it does not find in the robot API. This is possible, as you have to store the public and private key together with the SSH key's name in a secret that the controller reads.
+1. Create a new web service user. [Here](https://robot.your-server.de/doc/webservice/en.html#preface), you can define a password and copy your user name
+2. Generate an SSH key. You can either upload it via Hetzner Robot UI or just rely on the controller to upload a key that it does not find in the robot API. This is possible, as you have to store the public and private key together with the SSH key's name in a secret that the controller reads.
 
 ---
 ## Bootstrap or Management Cluster Installation


### PR DESCRIPTION
when we mark a PR ready_for_review and if the changes are in docs directory then we are not checking for link failures and this was the reason why there was a commit on main which introduced link failures.

This commit fixes the same and introduces link checking even if we do some changes in the docs directory.

