### PR TITLE
🌱Fix whitespace at end of storage vendor

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -820,7 +820,7 @@ func obtainHardwareDetailsStorage(sshClient sshclient.Client) ([]infrav1.Storage
 				Name:         storage.Name,
 				SizeBytes:    infrav1.Capacity(sizeBytes),
 				SizeGB:       capacityGB,
-				Vendor:       storage.Vendor,
+				Vendor:       strings.TrimSpace(storage.Vendor),
 				Model:        storage.Model,
 				SerialNumber: storage.SerialNumber,
 				WWN:          storage.WWN,


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fix whitespace at end of `storage.vendor`

### After Fix
![Screenshot 2024-04-26 at 7 14 41 PM](https://github.com/syself/cluster-api-provider-hetzner/assets/98258627/cd1f0fd7-7b9a-4f8b-888b-8f582a2669fd)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1279 
**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

