### PR TITLE
:sparkles: Add constant hostnames to bare metal servers

### DIFF
--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -29,6 +29,8 @@ const (
 	// AllowEmptyControlPlaneAddressAnnotation allows HetznerCluster Webhook
 	// to skip some validation steps for externally managed control planes.
 	AllowEmptyControlPlaneAddressAnnotation = "capi.syself.com/allow-empty-control-plane-address"
+	// ConstantBareMetalHostnameAnnotation makes hostnames of bare metal servers constant.
+	ConstantBareMetalHostnameAnnotation = "capi.syself.com/constant-bare-metal-hostname"
 )
 
 // HetznerClusterSpec defines the desired state of HetznerCluster.

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -117,6 +117,7 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 						UID:        capiCluster.UID,
 					},
 				},
+				Labels: map[string]string{clusterv1.ClusterNameLabel: capiCluster.Name},
 			},
 			Spec: helpers.GetDefaultHetznerClusterSpec(),
 		}
@@ -647,6 +648,7 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 						UID:        capiCluster.UID,
 					},
 				},
+				Labels: map[string]string{clusterv1.ClusterNameLabel: capiCluster.Name},
 			},
 			Spec: helpers.GetDefaultHetznerClusterSpec(),
 		}

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -107,6 +107,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 						UID:        capiCluster.UID,
 					},
 				},
+				Labels: map[string]string{clusterv1.ClusterNameLabel: capiCluster.Name},
 			},
 			Spec: helpers.GetDefaultHetznerClusterSpec(),
 		}
@@ -160,7 +161,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 			Err:    nil,
 		})
 		osSSHClient.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
-
 	})
 
 	AfterEach(func() {

--- a/controllers/hetznerbaremetalremediation_controller_test.go
+++ b/controllers/hetznerbaremetalremediation_controller_test.go
@@ -130,6 +130,7 @@ var _ = Describe("HetznerBareMetalRemediationReconciler", func() {
 						UID:        capiCluster.UID,
 					},
 				},
+				Labels: map[string]string{clusterv1.ClusterNameLabel: capiCluster.Name},
 			},
 			Spec: getDefaultHetznerClusterSpec(),
 		}

--- a/docs/topics/hetzner-baremetal.md
+++ b/docs/topics/hetzner-baremetal.md
@@ -382,3 +382,13 @@ default     my-cluster-md-1-cp2fd-7nld7      my-cluster   bm-my-cluster-md-1-d75
 default     my-cluster-md-1-cp2fd-n74sm      my-cluster   bm-my-cluster-md-1-l5dnr         hcloud://bm-2105469   Running        10h   v1.27.7
 ```
 Please note that hcloud servers are prefixed with `hcloud://` and baremetal servers are prefixed with `hcloud://bm-`.
+
+## Advanced
+
+### Constant hostnames for bare metal servers
+
+In some cases it has advantages to fix the hostname and with it the names of nodes in your clusters. For cloud servers not so much as for bare metal servers, where there are storage integrations that allow you to use the storage of the bare metal servers and that work with fixed node names. 
+
+Therefore, there is the possibility to create a cluster that uses fixed node names for bare metal servers. Please note: this only applies to the bare metal servers and not to Hetzner Cloud servers.
+
+You can trigger this feature by creating a `Cluster` with the annotation `"capi.syself.com/constant-bare-metal-hostname": "true"`. This is still an experimental feature but it should be save to use and to also update existing clusters with this annotation. All new machines will be created with this constant hostname.

--- a/pkg/scope/baremetalhost.go
+++ b/pkg/scope/baremetalhost.go
@@ -148,8 +148,5 @@ func (s *BareMetalHostScope) Hostname() (hostname string) {
 }
 
 func (s *BareMetalHostScope) hasConstantHostname() bool {
-	if s.Cluster.Annotations != nil {
-		return s.Cluster.Annotations[infrav1.ConstantBareMetalHostnameAnnotation] == "true"
-	}
-	return false
+	return s.Cluster.GetAnnotations()[infrav1.ConstantBareMetalHostnameAnnotation] == "true"
 }

--- a/pkg/services/baremetal/host/host_suite_test.go
+++ b/pkg/services/baremetal/host/host_suite_test.go
@@ -23,9 +23,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2/textlogger"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -88,6 +90,8 @@ func newTestService(
 			HetznerCluster: &infrav1.HetznerCluster{
 				Spec: helpers.GetDefaultHetznerClusterSpec(),
 			},
+			// Attention: this doesn't make sense if we test with constant node names
+			Cluster:         &v1beta1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 			OSSSHSecret:     osSSHSecret,
 			RescueSSHSecret: rescueSSHSecret,
 		},

--- a/pkg/services/baremetal/host/host_suite_test.go
+++ b/pkg/services/baremetal/host/host_suite_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2/textlogger"
-	"sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -91,7 +91,7 @@ func newTestService(
 				Spec: helpers.GetDefaultHetznerClusterSpec(),
 			},
 			// Attention: this doesn't make sense if we test with constant node names
-			Cluster:         &v1beta1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
+			Cluster:         &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}},
 			OSSSHSecret:     osSSHSecret,
 			RescueSSHSecret: rescueSSHSecret,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding the feature to keep hostnames of bare metal servers constant. This can be triggered by a feature flag on the Cluster object. It takes the usual "bm-" prefix together with the cluster name as well as the serverID of the bare metal server.

This feature can be used by adding the annotation `"capi.syself.com/constant-bare-metal-hostname": "true"` to `Cluster` objects.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

