### PR TITLE
:sparkles: Add ssh key name via hetzner secret

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -102,6 +102,7 @@ type HCloudPlacementGroupStatus struct {
 // HetznerSecretRef defines all the names of the secret and the relevant keys needed to access Hetzner API.
 type HetznerSecretRef struct {
 	// Name defines the name of the secret.
+	// +kubebuilder:default=hetzner
 	Name string `json:"name"`
 	// Key defines the keys that are used in the secret.
 	// Need to specify either HCloudToken or both HetznerRobotUser and HetznerRobotPassword.
@@ -113,13 +114,20 @@ type HetznerSecretRef struct {
 type HetznerSecretKeyRef struct {
 	// HCloudToken defines the name of the key where the token for the Hetzner Cloud API is stored.
 	// +optional
+	// +kubebuilder:default=hcloud-token
 	HCloudToken string `json:"hcloudToken"`
 	// HetznerRobotUser defines the name of the key where the username for the Hetzner Robot API is stored.
 	// +optional
+	// +kubebuilder:default=hetzner-robot-user
 	HetznerRobotUser string `json:"hetznerRobotUser"`
 	// HetznerRobotPassword defines the name of the key where the password for the Hetzner Robot API is stored.
 	// +optional
+	// +kubebuilder:default=hetzner-robot-password
 	HetznerRobotPassword string `json:"hetznerRobotPassword"`
+	// SSHKey defines the name of the ssh key.
+	// +optional
+	// +kubebuilder:default=ssh-key
+	SSHKey string `json:"sshKey"`
 }
 
 // PublicNetworkSpec contains specs about the public network spec of an HCloud server.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -242,19 +242,27 @@ spec:
                       Need to specify either HCloudToken or both HetznerRobotUser and HetznerRobotPassword.
                     properties:
                       hcloudToken:
+                        default: hcloud-token
                         description: HCloudToken defines the name of the key where
                           the token for the Hetzner Cloud API is stored.
                         type: string
                       hetznerRobotPassword:
+                        default: hetzner-robot-password
                         description: HetznerRobotPassword defines the name of the
                           key where the password for the Hetzner Robot API is stored.
                         type: string
                       hetznerRobotUser:
+                        default: hetzner-robot-user
                         description: HetznerRobotUser defines the name of the key
                           where the username for the Hetzner Robot API is stored.
                         type: string
+                      sshKey:
+                        default: ssh-key
+                        description: SSHKey defines the name of the ssh key.
+                        type: string
                     type: object
                   name:
+                    default: hetzner
                     description: Name defines the name of the secret.
                     type: string
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -273,21 +273,29 @@ spec:
                               Need to specify either HCloudToken or both HetznerRobotUser and HetznerRobotPassword.
                             properties:
                               hcloudToken:
+                                default: hcloud-token
                                 description: HCloudToken defines the name of the key
                                   where the token for the Hetzner Cloud API is stored.
                                 type: string
                               hetznerRobotPassword:
+                                default: hetzner-robot-password
                                 description: HetznerRobotPassword defines the name
                                   of the key where the password for the Hetzner Robot
                                   API is stored.
                                 type: string
                               hetznerRobotUser:
+                                default: hetzner-robot-user
                                 description: HetznerRobotUser defines the name of
                                   the key where the username for the Hetzner Robot
                                   API is stored.
                                 type: string
+                              sshKey:
+                                default: ssh-key
+                                description: SSHKey defines the name of the ssh key.
+                                type: string
                             type: object
                           name:
+                            default: hetzner
                             description: Name defines the name of the secret.
                             type: string
                         required:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding the ssh key name via hetzner secret facilitates use cases where a lot of clusters are created with the same ssh key. Instead of having to specify it every time in the HetznerClusterTemplate object, it can be specified in the secret ones.

On top, this commit introduces default values for the HetznerSecret to allow use cases where all is hard-coded and doesn't have to be specified e.g. in a ClusterClass or in the templates of the cluster object anymore.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

