### PR TITLE
:seedling: Better error message if CSR could not find machine.

### DIFF
--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -218,7 +218,10 @@ func (r *GuestCSRReconciler) getMachineAddresses(
 		}
 
 		if err := r.mCluster.Get(ctx, bmMachineName, &bmMachine); err != nil {
-			return nil, false, fmt.Errorf("failed to get hcloud and bare metal machine")
+			return nil, false, fmt.Errorf("failed to get hcloud (%s) or bare metal machine (%s): %w",
+				hcloudMachineName.Name,
+				bmMachineName.Name,
+				err)
 		}
 
 		return bmMachine.Status.Addresses, false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Better error message if CSR could not find machine.

From this log (converted from json to yaml), you don' know which machine was not found.

```
level: ERROR
time: "2024-05-02T12:41:30.204Z"
file: controllers/csr_controller.go:108
message: could not find an associated bm machine or hcloud machine
controller: certificatesigningrequest
controllerGroup: certificates.k8s.io
controllerKind: CertificateSigningRequest
"CertificateSigningRequest": {"name": "csr-7wttr"}
namespace: ""
name: csr-7wttr
reconcileID: 4f67ee9f-f920-4a32-8bac-36e7dfa38ee6
CertificateSigningRequest:
  name: csr-7wttr
userName: system:node:guettli-1
error: failed to get hcloud and bare metal machine
stacktrace: |-
  github.com/syself/cluster-api-provider-hetzner/controllers.(*GuestCSRReconciler).Reconcile
  	github.com/syself/cluster-api-provider-hetzner/controllers/csr_controller.go:108
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
  	sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:119
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
  	sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:316
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
  	sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:266
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
  	sigs.k8s.io/controller-runtime@v0.16.5/pkg/internal/controller/controller.go:227
```

This PR adds the hcloud and bm-machine name.