### PR TITLE
🌱 avoid redacting logs when running e2e tests

### DIFF
--- a/test/e2e/caph.go
+++ b/test/e2e/caph.go
@@ -98,6 +98,5 @@ func CaphClusterDeploymentSpec(ctx context.Context, inputGetter func() CaphClust
 	ginkgo.AfterEach(func() {
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
-		redactLogs(input.E2EConfig.GetVariable)
 	})
 }

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -20,12 +20,10 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/blang/semver/v4"
 	ginkgo "github.com/onsi/ginkgo/v2"
-	gomega "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -127,11 +125,4 @@ func (m *validVersionMatcher) FailureMessage(_ interface{}) (message string) {
 
 func (m *validVersionMatcher) NegatedFailureMessage(_ interface{}) (message string) {
 	return fmt.Sprintf("Expected\n%s\n%s", m.version, " not to be a valid version ")
-}
-
-func redactLogs(variableGetter func(string) string) {
-	ginkgo.By("Redacting sensitive information from the logs")
-	gomega.Expect(variableGetter(RedactLogScriptPath)).To(gomega.BeAnExistingFile(), "Missing redact log script")
-	cmd := exec.Command(variableGetter(RedactLogScriptPath)) //#nosec
-	_ = cmd.Run()                                            //#nosec
 }


### PR DESCRIPTION
We were running a script to redact the token in _artifacts directory which gets produced when we run our e2e tests. Since, ginkgo spec are run one after another, once first spec runs and we redact the logs, the manifest (kind: Secret) gets invalid and we get an error in our e2e tests.

`Error from server (BadRequest): error when creating "secret.yaml": Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 0`

This commit avoids redacting logs after each spec. We still do it after the whole suite completes.