### PR TITLE
:bug: Fix CSR for ConstantBareMetalHostname

### DIFF
--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -53,9 +54,11 @@ type ManagementCluster interface {
 // GuestCSRReconciler reconciles a CSR object.
 type GuestCSRReconciler struct {
 	client.Client
-	WatchFilterValue string
-	clientSet        *kubernetes.Clientset
-	mCluster         ManagementCluster
+	WatchFilterValue             string
+	clientSet                    *kubernetes.Clientset
+	mCluster                     ManagementCluster
+	clusterName                  string
+	hasConstantBareMetalHostname bool
 }
 
 const nodePrefix = "system:node:"
@@ -196,6 +199,8 @@ func machineNameWithPrefix(machineName string, isHCloudMachine bool) string {
 	return hostNamePrefix + machineName
 }
 
+var constantBareMetalHostnameRegex = regexp.MustCompile(`^bm-(\S*)-(\d+)$`)
+
 func (r *GuestCSRReconciler) getMachineAddresses(
 	ctx context.Context,
 	certificateSigningRequest *certificatesv1.CertificateSigningRequest,
@@ -207,10 +212,43 @@ func (r *GuestCSRReconciler) getMachineAddresses(
 		Namespace: r.mCluster.Namespace(),
 		Name:      hcloudMachineNameFromCSR(certificateSigningRequest),
 	}
-
 	err = r.mCluster.Get(ctx, hcloudMachineName, &hcloudMachine)
 	if err != nil {
 		// Could not find HCloud machine. Try to find bare metal machine.
+
+		if r.hasConstantBareMetalHostname {
+			matches := constantBareMetalHostnameRegex.FindStringSubmatch(strings.TrimPrefix(certificateSigningRequest.Spec.Username, nodePrefix))
+			if len(matches) != 3 {
+				return nil, false, fmt.Errorf("CSR %q is no hcloud or bm-machine", certificateSigningRequest.Spec.Username)
+			}
+			clusterName := matches[1]
+			if clusterName != r.clusterName {
+				return nil, false, fmt.Errorf("CSR expected cluster to be %q, but is %q",
+					r.clusterName, clusterName)
+			}
+			providerID := "hcloud://bm-" + matches[2]
+			hList := &infrav1.HetznerBareMetalMachineList{}
+			if err := r.mCluster.List(ctx, hList, &client.ListOptions{}); err != nil {
+				return nil, false, fmt.Errorf("failed to get HetznerBareMetalMachineList: %w", err)
+			}
+
+			var bmMachine *infrav1.HetznerBareMetalMachine
+			for i := range hList.Items {
+				if hList.Items[i].Spec.ProviderID == nil {
+					continue
+				}
+				if *hList.Items[i].Spec.ProviderID == providerID {
+					bmMachine = &hList.Items[i]
+				}
+			}
+			if bmMachine == nil {
+				return nil, false, fmt.Errorf("failed to find HetznerBareMetalMachine with ProviderID %q", providerID)
+			}
+			return bmMachine.Status.Addresses, false, nil
+		}
+
+		// hasConstantBareMetalHostname is false
+
 		var bmMachine infrav1.HetznerBareMetalMachine
 		bmMachineName := types.NamespacedName{
 			Namespace: r.mCluster.Namespace(),

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-
 	certificatesv1 "k8s.io/api/certificates/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -232,11 +232,10 @@ func (r *GuestCSRReconciler) getMachineAddresses(
 			providerID := "hcloud://bm-" + matches[2]
 			hList := &infrav1.HetznerBareMetalMachineList{}
 			selector := labels.NewSelector()
-			key := "cluster.x-k8s.io/cluster-name"
-			req, err := labels.NewRequirement(key, selection.Equals, []string{clusterName})
+			req, err := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Equals, []string{clusterName})
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to create selector %s=%s. %w",
-					key, clusterName, err)
+					clusterv1.ClusterNameLabel, clusterName, err)
 			}
 			selector.Add(*req)
 			if err := r.mCluster.List(ctx, hList, &client.ListOptions{

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -701,14 +701,18 @@ func (r *HetznerClusterReconciler) newTargetClusterManager(ctx context.Context, 
 		return nil, fmt.Errorf("failed to setup guest cluster manager: %w", err)
 	}
 
+	hasConstantBareMetalHostname := clusterScope.Cluster.Annotations[infrav1.ConstantBareMetalHostnameAnnotation] == "true"
+
 	gr := &GuestCSRReconciler{
 		Client: clusterMgr.GetClient(),
 		mCluster: &managementCluster{
 			Client:         r.Client,
 			hetznerCluster: hetznerCluster,
 		},
-		WatchFilterValue: r.WatchFilterValue,
-		clientSet:        clientSet,
+		WatchFilterValue:             r.WatchFilterValue,
+		clientSet:                    clientSet,
+		clusterName:                  clusterScope.Cluster.Name,
+		hasConstantBareMetalHostname: hasConstantBareMetalHostname,
 	}
 
 	if err := gr.SetupWithManager(ctx, clusterMgr, controller.Options{}); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

If a cluster uses ConstantBareMetalHostname, then the CSRs were not approved, since the node-name
did not match the expected pattern.

This PR extends the CSR approving, so that CSRs for constant bm hostnames get approved.
