### PR TITLE
:seedling: Detect raid spanning root-device and non-root-device.

### DIFF
--- a/hack/ci-e2e-get-token.sh
+++ b/hack/ci-e2e-get-token.sh
@@ -6,8 +6,8 @@ newtoken=$(curl --fail-with-body --retry 2 --silent -A "github.com/syself/cluste
 
 if [ -e .envrc ]; then
     echo "Updating .envrc"
-    sed -i "s/HCLOUD_TOKEN=.*/HCLOUD_TOKEN=$newtoken/" .envrc
-    if type -P direnv > /dev/null; then
+    sed -i "s/^export HCLOUD_TOKEN=.*/export HCLOUD_TOKEN=$newtoken/" .envrc
+    if type -P direnv >/dev/null; then
         direnv allow
     fi
 fi

--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -95,7 +95,7 @@ fi
 # Write all WWNs which will contain the new OS into a file.
 wwn_file=$(mktemp)
 for wwn in "$@"; do
-    echo $wwn >>"$wwn_file"
+    echo "$wwn" >>"$wwn_file"
 done
 sort --unique -o "$wwn_file" "$wwn_file"
 
@@ -105,7 +105,7 @@ for mdraid in /dev/md?*; do
     rm -f "$md_file"
     device=$(basename "$mdraid")
     for dev_of_mdraid in /sys/block/"$device"/md/dev-*; do
-        dev_of_mdraid=$(echo $dev_of_mdraid | cut -d- -f2)
+        dev_of_mdraid=$(echo "$dev_of_mdraid" | cut -d- -f2)
         wwn=$(udevadm info --query=property "--name=$dev_of_mdraid" | grep ID_WWN | cut -d= -f2)
         if [ -z "$wwn" ]; then
             echo "<<<<<<<<<<<<<<<<<<<<"

--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -63,7 +63,7 @@ fail=0
 
 lines=$(lsblk -r -oNAME,WWN,TYPE)
 
-while read -r name wwn; do
+while read -r name wwn _; do
     if [[ " $* " == *" $wwn "* ]]; then
         #echo "ok: skipping $name $wwn, since it was an argument to the script."
         continue

--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -148,4 +148,4 @@ done
 
 rm -f "$md_file" "$wwn_file"
 
-echo "Looks good. No Linux root partition on another devices"
+echo "Looks good. No Linux root partition on another devices."

--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -112,13 +112,13 @@ for mdraid in /dev/md?*; do
             udevadm info --query=property "--name=$dev_of_mdraid"
             echo ">>>>>>>>>>>>>>>>>>>>"
             echo "failed to get WWN of $dev_of_mdraid"
-            exit 1
+            exit 3
         fi
         echo "$wwn" >>"$md_file"
     done
     if [ ! -s "$md_file" ]; then
         echo "failed to find devices of $mdraid"
-        exit 1
+        exit 3
     fi
     sort --unique -o "$md_file" "$md_file"
     if cmp --silent "$md_file" "$wwn_file"; then

--- a/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
+++ b/pkg/services/baremetal/client/ssh/detect-linux-on-another-disk.sh
@@ -100,6 +100,7 @@ done
 sort --unique -o "$wwn_file" "$wwn_file"
 
 md_file=$(mktemp)
+shopt -s nullglob
 for mdraid in /dev/md?*; do
     rm -f "$md_file"
     device=$(basename "$mdraid")


### PR DESCRIPTION
**What this PR does / why we need it**:

If there is an existing raid in a bare-metal server, and this old raid spans from root-devices to non-root-devices, then we don't want to use that machines.

It is likely that after executing installimage and restarting the server, that the old OS on the raid gets executed instead of the OS installed by installimage.



