### PR TITLE
:seedling: Allow constant hostname annotation on machines

### DIFF
--- a/docs/topics/hetzner-baremetal.md
+++ b/docs/topics/hetzner-baremetal.md
@@ -391,4 +391,6 @@ In some cases it has advantages to fix the hostname and with it the names of nod
 
 Therefore, there is the possibility to create a cluster that uses fixed node names for bare metal servers. Please note: this only applies to the bare metal servers and not to Hetzner Cloud servers.
 
-You can trigger this feature by creating a `Cluster` with the annotation `"capi.syself.com/constant-bare-metal-hostname": "true"`. This is still an experimental feature but it should be save to use and to also update existing clusters with this annotation. All new machines will be created with this constant hostname.
+You can trigger this feature by creating a `Cluster` or `HetznerBareMetalMachine` (you can choose) with the annotation `"capi.syself.com/constant-bare-metal-hostname": "true"`. Of course, `HetznerBareMetalMachines` are not created by the user. However, if you use the `ClusterClass`, then you can add the annotation to a `MachineDeployment`, so that all machines are created with this annotation. 
+
+This is still an experimental feature but it should be safe to use and to also update existing clusters with this annotation. All new machines will be created with this constant hostname.

--- a/pkg/scope/baremetalhost.go
+++ b/pkg/scope/baremetalhost.go
@@ -36,16 +36,17 @@ import (
 
 // BareMetalHostScopeParams defines the input parameters used to create a new scope.
 type BareMetalHostScopeParams struct {
-	Client               client.Client
-	Logger               logr.Logger
-	HetznerBareMetalHost *infrav1.HetznerBareMetalHost
-	HetznerCluster       *infrav1.HetznerCluster
-	Cluster              *clusterv1.Cluster
-	RobotClient          robotclient.Client
-	SSHClientFactory     sshclient.Factory
-	OSSSHSecret          *corev1.Secret
-	RescueSSHSecret      *corev1.Secret
-	SecretManager        *secretutil.SecretManager
+	Client                  client.Client
+	Logger                  logr.Logger
+	HetznerBareMetalHost    *infrav1.HetznerBareMetalHost
+	HetznerBareMetalMachine *infrav1.HetznerBareMetalMachine
+	HetznerCluster          *infrav1.HetznerCluster
+	Cluster                 *clusterv1.Cluster
+	RobotClient             robotclient.Client
+	SSHClientFactory        sshclient.Factory
+	OSSSHSecret             *corev1.Secret
+	RescueSSHSecret         *corev1.Secret
+	SecretManager           *secretutil.SecretManager
 }
 
 // NewBareMetalHostScope creates a new Scope from the supplied parameters.
@@ -79,31 +80,33 @@ func NewBareMetalHostScope(params BareMetalHostScopeParams) (*BareMetalHostScope
 	}
 
 	return &BareMetalHostScope{
-		Logger:               params.Logger,
-		Client:               params.Client,
-		RobotClient:          params.RobotClient,
-		SSHClientFactory:     params.SSHClientFactory,
-		HetznerCluster:       params.HetznerCluster,
-		Cluster:              params.Cluster,
-		HetznerBareMetalHost: params.HetznerBareMetalHost,
-		OSSSHSecret:          params.OSSSHSecret,
-		RescueSSHSecret:      params.RescueSSHSecret,
-		SecretManager:        params.SecretManager,
+		Logger:                  params.Logger,
+		Client:                  params.Client,
+		RobotClient:             params.RobotClient,
+		SSHClientFactory:        params.SSHClientFactory,
+		HetznerCluster:          params.HetznerCluster,
+		Cluster:                 params.Cluster,
+		HetznerBareMetalHost:    params.HetznerBareMetalHost,
+		HetznerBareMetalMachine: params.HetznerBareMetalMachine,
+		OSSSHSecret:             params.OSSSHSecret,
+		RescueSSHSecret:         params.RescueSSHSecret,
+		SecretManager:           params.SecretManager,
 	}, nil
 }
 
 // BareMetalHostScope defines the basic context for an actuator to operate upon.
 type BareMetalHostScope struct {
 	logr.Logger
-	Client               client.Client
-	SecretManager        *secretutil.SecretManager
-	RobotClient          robotclient.Client
-	SSHClientFactory     sshclient.Factory
-	HetznerBareMetalHost *infrav1.HetznerBareMetalHost
-	HetznerCluster       *infrav1.HetznerCluster
-	Cluster              *clusterv1.Cluster
-	OSSSHSecret          *corev1.Secret
-	RescueSSHSecret      *corev1.Secret
+	Client                  client.Client
+	SecretManager           *secretutil.SecretManager
+	RobotClient             robotclient.Client
+	SSHClientFactory        sshclient.Factory
+	HetznerBareMetalHost    *infrav1.HetznerBareMetalHost
+	HetznerBareMetalMachine *infrav1.HetznerBareMetalMachine
+	HetznerCluster          *infrav1.HetznerCluster
+	Cluster                 *clusterv1.Cluster
+	OSSSHSecret             *corev1.Secret
+	RescueSSHSecret         *corev1.Secret
 }
 
 // Name returns the HetznerCluster name.
@@ -148,5 +151,6 @@ func (s *BareMetalHostScope) Hostname() (hostname string) {
 }
 
 func (s *BareMetalHostScope) hasConstantHostname() bool {
-	return s.Cluster.GetAnnotations()[infrav1.ConstantBareMetalHostnameAnnotation] == "true"
+	return s.Cluster.GetAnnotations()[infrav1.ConstantBareMetalHostnameAnnotation] == "true" ||
+		s.HetznerBareMetalMachine != nil && s.HetznerBareMetalMachine.GetAnnotations()[infrav1.ConstantBareMetalHostnameAnnotation] == "true"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allowing the annotation also on HetznerBaremetalMachine to achieve more flexibility (e.g. with regards to ClusterClass approaches).

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

