### PR TITLE
🌱 change SSHKey default name to hcloud-ssh-key-name

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -126,7 +126,7 @@ type HetznerSecretKeyRef struct {
 	HetznerRobotPassword string `json:"hetznerRobotPassword"`
 	// SSHKey defines the name of the ssh key.
 	// +optional
-	// +kubebuilder:default=ssh-key
+	// +kubebuilder:default=hcloudsshkeyname
 	SSHKey string `json:"sshKey"`
 }
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -126,7 +126,7 @@ type HetznerSecretKeyRef struct {
 	HetznerRobotPassword string `json:"hetznerRobotPassword"`
 	// SSHKey defines the name of the ssh key.
 	// +optional
-	// +kubebuilder:default=hcloudsshkeyname
+	// +kubebuilder:default=hcloud-ssh-key-name
 	SSHKey string `json:"sshKey"`
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -257,7 +257,7 @@ spec:
                           where the username for the Hetzner Robot API is stored.
                         type: string
                       sshKey:
-                        default: ssh-key
+                        default: hcloud-ssh-key-name
                         description: SSHKey defines the name of the ssh key.
                         type: string
                     type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -290,7 +290,7 @@ spec:
                                   API is stored.
                                 type: string
                               sshKey:
-                                default: ssh-key
+                                default: hcloud-ssh-key-name
                                 description: SSHKey defines the name of the ssh key.
                                 type: string
                             type: object


### PR DESCRIPTION
This PR changes the default of SSHKey from `ssh-key` to `hcloud-ssh-key-name` to make it more clear and avoid confusion.