### PR TITLE
:sparkles: Add ssh keys to status and fix ssh key in secret

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -71,6 +71,9 @@ type HCloudMachineStatus struct {
 	// Region contains the name of the HCloud location the server is running.
 	Region Region `json:"region,omitempty"`
 
+	// SSHKeys specifies the ssh keys that were used for provisioning the server.
+	SSHKeys []SSHKey `json:"sshKeys,omitempty"`
+
 	// InstanceState is the state of the server for this machine.
 	// +optional
 	InstanceState *hcloud.ServerStatus `json:"instanceState,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *HCloudMachineStatus) DeepCopyInto(out *HCloudMachineStatus) {
 		*out = make([]apiv1beta1.MachineAddress, len(*in))
 		copy(*out, *in)
 	}
+	if in.SSHKeys != nil {
+		in, out := &in.SSHKeys, &out.SSHKeys
+		*out = make([]SSHKey, len(*in))
+		copy(*out, *in)
+	}
 	if in.InstanceState != nil {
 		in, out := &in.InstanceState, &out.InstanceState
 		*out = new(hcloud.ServerStatus)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -250,6 +250,24 @@ spec:
                 - ash
                 - hil
                 type: string
+              sshKeys:
+                description: SSHKeys specifies the ssh keys that were used for provisioning
+                  the server.
+                items:
+                  description: SSHKey defines the SSHKey for HCloud.
+                  properties:
+                    fingerprint:
+                      description: Fingerprint defines the fingerprint of the SSH
+                        key - added by the controller.
+                      type: string
+                    name:
+                      description: Name defines the name of the SSH key.
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -179,33 +179,6 @@ func (r *HetznerClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 		return reconcile.Result{}, err
 	}
 
-	// write ssh key name from secret to spec of HetznerCluster if it is specified
-	sshKeyName := clusterScope.HetznerSecret().Data[hetznerCluster.Spec.HetznerSecret.Key.SSHKey]
-	if len(sshKeyName) > 0 {
-		// Check if the SSH key name already exists
-		keyExists := false
-		for _, key := range hetznerCluster.Spec.SSHKeys.HCloud {
-			if string(sshKeyName) == key.Name {
-				keyExists = true
-				break
-			}
-		}
-
-		// If the SSH key name doesn't exist, append it
-		if !keyExists {
-			hetznerCluster.Spec.SSHKeys.HCloud = append(hetznerCluster.Spec.SSHKeys.HCloud, infrav1.SSHKey{Name: string(sshKeyName)})
-			// in case of a clusterclass we cannot overwrite it and just store it for this reconcile loop. Therefore no event.
-			if clusterScope.Cluster.Spec.Topology == nil {
-				record.Eventf(
-					hetznerCluster,
-					"SSHKeyNameAddedFromHetznerSecret", "added the ssh key %q from the hetzner secret specified under key %q",
-					string(sshKeyName),
-					hetznerCluster.Spec.HetznerSecret.Key.SSHKey,
-				)
-			}
-		}
-	}
-
 	// set failure domains in status using information in spec
 	clusterScope.SetStatusFailureDomain(clusterScope.GetSpecRegion())
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -453,6 +453,9 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 		return nil, fmt.Errorf("failed to create HCloud server %s: %w", s.scope.HCloudMachine.Name, err)
 	}
 
+	// set ssh keys to status
+	s.scope.HCloudMachine.Status.SSHKeys = sshKeySpecs
+
 	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)
 	record.Eventf(s.scope.HCloudMachine, "SuccessfulCreate", "Created new server %s with ID %d", server.Name, server.ID)
 	return server, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -476,6 +476,8 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 
 	// set ssh keys to status
 	s.scope.HCloudMachine.Status.SSHKeys = sshKeySpecs
+	s.scope.HCloudMachine.Spec.SSHKeys = sshKeySpecs
+	s.scope.Info("sshkeys", "sshkeys in status", s.scope.HCloudMachine.Status.SSHKeys)
 
 	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)
 	record.Eventf(s.scope.HCloudMachine, "SuccessfulCreate", "Created new server %s with ID %d", server.Name, server.ID)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -112,9 +112,11 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	// update HCloudMachineStatus
 	c := s.scope.HCloudMachine.Status.Conditions.DeepCopy()
+	sshKeys := s.scope.HCloudMachine.Status.SSHKeys
 	s.scope.HCloudMachine.Status = statusFromHCloudServer(server)
 	s.scope.SetRegion(failureDomain)
 	s.scope.HCloudMachine.Status.Conditions = c
+	s.scope.HCloudMachine.Status.SSHKeys = sshKeys
 
 	// validate labels
 	if err := validateLabels(server, s.createLabels()); err != nil {
@@ -476,8 +478,6 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 
 	// set ssh keys to status
 	s.scope.HCloudMachine.Status.SSHKeys = sshKeySpecs
-	s.scope.HCloudMachine.Spec.SSHKeys = sshKeySpecs
-	s.scope.Info("sshkeys", "sshkeys in status", s.scope.HCloudMachine.Status.SSHKeys)
 
 	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)
 	record.Eventf(s.scope.HCloudMachine, "SuccessfulCreate", "Created new server %s with ID %d", server.Name, server.ID)


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to visualize which ssh keys have been used to provision a machine, we write the keys in the status of the HCloudMachine.

On top, we fix a bug where the "patch" call for the finalizer removed the ssh key from the spec of the HetznerCluster again, because it cannot patch the HetznerCluster.spec if a ClusterClass is used.

We add the ssh key now after the patch, so that it will still get patched at the end of the function, but can be used until then. In case of a ClusterClass we just don't have the key reflected in the spec of the HetznerCluster.

This is why we also add the list of keys to the HCloudMachine status, so that it is better visible.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

