### PR TITLE
:seedling: Add new CX server types

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -37,7 +37,7 @@ type HCloudMachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// Type is the HCloud Machine Type for this machine. It defines the desired server type of server in Hetzner's Cloud API. Example: cpx11.
-	// +kubebuilder:validation:Enum=cpx11;cx21;cpx21;cx31;cpx31;cx41;cpx41;cx51;cpx51;ccx11;ccx12;ccx13;ccx21;ccx22;ccx23;ccx31;ccx32;ccx33;ccx41;ccx42;ccx43;ccx51;ccx52;ccx53;ccx62;ccx63;cax11;cax21;cax31;cax41
+	// +kubebuilder:validation:Enum=cpx11;cx21;cpx21;cx31;cpx31;cx41;cpx41;cx51;cpx51;ccx11;ccx12;ccx13;ccx21;ccx22;ccx23;ccx31;ccx32;ccx33;ccx41;ccx42;ccx43;ccx51;ccx52;ccx53;ccx62;ccx63;cax11;cax21;cax31;cax41;cx22;cx32;cx42;cx52
 	Type HCloudMachineType `json:"type"`
 
 	// ImageName is the reference to the Machine Image from which to create the machine instance.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -151,6 +151,10 @@ spec:
                 - cax21
                 - cax31
                 - cax41
+                - cx22
+                - cx32
+                - cx42
+                - cx52
                 type: string
             required:
             - imageName

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -178,6 +178,10 @@ spec:
                         - cax21
                         - cax31
                         - cax41
+                        - cx22
+                        - cx32
+                        - cx42
+                        - cx52
                         type: string
                     required:
                     - imageName


### PR DESCRIPTION


<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Adds the new server types `cx22`, `cx32`, `cx42` and `cx52` to the CRD validation. (There is no `cx12`). These were just launched and you can find out more at https://www.hetzner.com/news/new-cx-plans/

The previous generation (`cx11` - `cx51`) was deprecated and will be removed on 06 September 2024. I saw that you reference them in some templates and you might want to replace them until then.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

