### PR TITLE
:seedling: added --debug-hcloud-api-calls to log all hcloud api calls.

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 	fs.StringVar(&logLevel, "log-level", "info", "Specifies log level. Options are 'debug', 'info' and 'error'")
 	fs.DurationVar(&syncPeriod, "sync-period", 3*time.Minute, "The minimum interval at which watched resources are reconciled (e.g. 3m)")
 	fs.DurationVar(&rateLimitWaitTime, "rate-limit", 5*time.Minute, "The rate limiting for HCloud controller (e.g. 5m)")
+	fs.BoolVar(&hcloudclient.DebugAPICalls, "debug-hcloud-api-calls", false, "Debug all calls to the hcloud API.")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes we want to see all calls to the hcloud api (to debug rate-limiting issues).

