### PR TITLE
:seedling: Stop calling API when HCloudMachineTemplate status is set

### DIFF
--- a/pkg/services/hcloud/machinetemplate/machinetemplate.go
+++ b/pkg/services/hcloud/machinetemplate/machinetemplate.go
@@ -46,12 +46,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	// delete the deprecated condition from existing machinetemplate objects
 	conditions.Delete(s.scope.HCloudMachineTemplate, infrav1.DeprecatedRateLimitExceededCondition)
 
-	capacity, err := s.getCapacity(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get capacity: %w", err)
-	}
+	if s.scope.HCloudMachineTemplate.Status.Capacity == nil {
+		capacity, err := s.getCapacity(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get capacity: %w", err)
+		}
 
-	s.scope.HCloudMachineTemplate.Status.Capacity = capacity
+		s.scope.HCloudMachineTemplate.Status.Capacity = capacity
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We call the HCloud API in every reconcile loop of the hcloudmachine_template controller. This is not necessary since the server type does not change for one template object. We can set it once when the status is empty and then don't have to set it while the status is not nil anymore.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

