### PR TITLE
:seedling: CSR uses INFO level if providerID was not set yet.

### DIFF
--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -117,7 +117,7 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		if err != nil {
 			log.Error(err, "could not find an associated bm machine or hcloud machine",
 				"userName", certificateSigningRequest.Spec.Username)
-			return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
 		machineName := machineNameFromCSR(certificateSigningRequest, isHCloudMachine)

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -112,12 +112,12 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		if errors.Is(err, errNoHetznerBareMetalMachineByProviderIDFound) {
 			log.Info(fmt.Sprintf("ProviderID not set yet. The hbmm seems to be in 'ensure-provision'. Retrying. %s",
 				err.Error()))
-			return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		if err != nil {
 			log.Error(err, "could not find an associated bm machine or hcloud machine",
 				"userName", certificateSigningRequest.Spec.Username)
-			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
 		}
 
 		machineName := machineNameFromCSR(certificateSigningRequest, isHCloudMachine)

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -108,6 +109,11 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 	} else {
 		// get machine addresses from corresponding machine
 		machineAddresses, isHCloudMachine, err := r.getMachineAddresses(ctx, certificateSigningRequest)
+		if errors.Is(err, errNoHetznerBareMetalMachineByProviderIDFound) {
+			log.Info(fmt.Sprintf("ProviderID not set yet. The hbmm seems to be in 'ensure-provision'. Retrying. %s",
+				err.Error()))
+			return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
+		}
 		if err != nil {
 			log.Error(err, "could not find an associated bm machine or hcloud machine",
 				"userName", certificateSigningRequest.Spec.Username)
@@ -200,13 +206,39 @@ func machineNameWithPrefix(machineName string, isHCloudMachine bool) string {
 	return hostNamePrefix + machineName
 }
 
-var constantBareMetalHostnameRegex = regexp.MustCompile(`^bm-(\S*)-(\d+)$`)
+var (
+	constantBareMetalHostnameRegex                = regexp.MustCompile(`^bm-(\S*)-(\d+)$`)
+	errNoHetznerBareMetalMachineByProviderIDFound = fmt.Errorf("no HetznerBaremetalMachine by ProviderID found")
+)
 
 func (r *GuestCSRReconciler) getMachineAddresses(
 	ctx context.Context,
 	certificateSigningRequest *certificatesv1.CertificateSigningRequest,
 ) (machineAddresses []clusterv1.MachineAddress, isHCloudMachine bool, err error) {
-	// try to find matching HCloudMachine object
+	_, serverID := getServerIDFromConstantHostname(ctx, certificateSigningRequest.Spec.Username, r.clusterName)
+
+	if serverID != "" {
+		// According the the regex this is BM server with ConstantHostname. Handle that fist,
+		// no need to check for a HCloud server.
+
+		hbmm, err := getHbmmWithConstantHostname(ctx, certificateSigningRequest.Spec.Username, r.clusterName, r.mCluster)
+		if errors.Is(err, errNoHetznerBareMetalMachineByProviderIDFound) {
+			// No machine found yet. Likely: Cloud-init has run, the kubelet has started. But machine is still in ensure-provisioned.
+			// The providerID will be set soon.
+			return nil, false, err
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("getHbmmWithConstantHostname(%q) failed: %w", certificateSigningRequest.Spec.Username, err)
+		}
+		if hbmm != nil {
+			return hbmm.Status.Addresses, false, nil
+		}
+		return nil, false, fmt.Errorf("getHbmmWithConstantHostname(%q) failed to get hbmm (should not happen)", certificateSigningRequest.Spec.Username)
+	}
+
+	// It could be both: A hcloud machine or a bm-machine without ConstantHostname.
+
+	// Try to find matching HCloudMachine object
 	var hcloudMachine infrav1.HCloudMachine
 
 	hcloudMachineName := types.NamespacedName{
@@ -215,19 +247,7 @@ func (r *GuestCSRReconciler) getMachineAddresses(
 	}
 	err = r.mCluster.Get(ctx, hcloudMachineName, &hcloudMachine)
 	if err != nil {
-		// Could not find HCloud machine. Try to find bare metal machine.
-
-		// We don't know whether the HetznerBareMetalMachine uses a constant hostname or not. If it does, we'll find it with getHbmmWithConstantHostname.
-		// If we don't find it, then it does not use a constant hostname and we'll find it in another way.
-		hbmm, err := getHbmmWithConstantHostname(ctx, certificateSigningRequest.Spec.Username, r.clusterName, r.mCluster)
-		if err != nil {
-			return nil, false, fmt.Errorf("getHbmmWithConstantHostname(%q) failed: %w", certificateSigningRequest.Spec.Username, err)
-		}
-		if hbmm != nil {
-			return hbmm.Status.Addresses, false, nil
-		}
-
-		// HetznerBareMetalMachine does not have a constant hostname - use the following method to find it
+		// Could not find HCloud machine. Try to find bare metal machine without ConstantHostname.
 
 		var bmMachine infrav1.HetznerBareMetalMachine
 		bmMachineName := types.NamespacedName{
@@ -283,24 +303,29 @@ func (r *GuestCSRReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		Complete(r)
 }
 
-func getHbmmWithConstantHostname(ctx context.Context, csrUsername string, clusterName string, mCluster ManagementCluster) (*infrav1.HetznerBareMetalMachine, error) {
+func getServerIDFromConstantHostname(ctx context.Context, csrUsername string, clusterName string) (clusterFromCSR string, serverID string) {
 	log := ctrl.LoggerFrom(ctx)
-
 	// example csrUsername: system:node:bm-my-cluster-1234567
 	matches := constantBareMetalHostnameRegex.FindStringSubmatch(strings.TrimPrefix(csrUsername, nodePrefix))
 	if len(matches) != 3 {
 		log.V(1).Info("No constant baremetal hostname - regex does not match CSR username",
 			"regex", constantBareMetalHostnameRegex.String(), "csrUserName", csrUsername)
-		return nil, nil
+		return "", ""
 	}
 
-	clusterFromCSR := matches[1]
+	clusterFromCSR = matches[1]
 	if clusterFromCSR != clusterName {
 		log.V(1).Info("No constant baremetal hostname - mismatch of cluster found in csrUserName", "got", clusterFromCSR, "want", clusterName)
-		return nil, nil
+		return "", ""
 	}
+	return clusterFromCSR, matches[2]
+}
 
-	providerID := "hcloud://bm-" + matches[2]
+func getHbmmWithConstantHostname(ctx context.Context, csrUsername string, clusterName string, mCluster ManagementCluster) (*infrav1.HetznerBareMetalMachine, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	clusterFromCSR, serverID := getServerIDFromConstantHostname(ctx, csrUsername, clusterName)
+	providerID := "hcloud://bm-" + serverID
 	hList := &infrav1.HetznerBareMetalMachineList{}
 	selector := labels.NewSelector()
 	req, err := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Equals, []string{clusterFromCSR})
@@ -329,8 +354,7 @@ func getHbmmWithConstantHostname(ctx context.Context, csrUsername string, cluste
 		}
 	}
 	if hbmm == nil {
-		log.V(1).Info("no constant baremetal hostname - did not find HetznerBareMetalMachine by ProviderID", "providerID", providerID)
-		return nil, nil
+		return nil, fmt.Errorf("ProviderID: %q %w", providerID, errNoHetznerBareMetalMachineByProviderIDFound)
 	}
 
 	log.Info("Found HetznerBareMetalMachine with constant hostname", "csr-username", csrUsername, "hetznerBareMetalMachine", hbmm.Name)

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -89,7 +89,7 @@ func (collector logCollector) CollectMachineLog(_ context.Context, _ client.Clie
 				return fmt.Errorf("failed to tar dir %s: %w", pathToDir, err)
 			}
 
-			err = os.MkdirAll(outputDir, os.ModePerm) //nolint:gosec //nolint:ignore
+			err = os.MkdirAll(outputDir, 0o750)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ func (collector logCollector) CollectMachineLog(_ context.Context, _ client.Clie
 }
 
 func createOutputFile(path string) (*os.File, error) {
-	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil { //nolint:gosec //nolint:ignore
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, err
 	}
 	return os.Create(path) // #nosec


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR https://github.com/syself/cluster-api-provider-hetzner/pull/1351 we set the ProviderID earlier, but this did not work.

The linked PR was done to avoid error messages in the CSR-controller.

This PR changes the error messages of the CSR-controller. If the CSR exists, but there is no hbmm with the corresponding ProviderID, then this is fine. We wait some seconds and then we try again.

The hbmm is likely in state "ensure-provisioned", and the providerID will be set soon. INFO level logging is fine in this case.