### PR TITLE
:bug: Increase timeout on connection refused errors

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -49,15 +49,16 @@ import (
 )
 
 const (
-	rebootWaitTime       time.Duration = 15 * time.Second
-	sshResetTimeout      time.Duration = 5 * time.Minute
-	softwareResetTimeout time.Duration = 5 * time.Minute
-	hardwareResetTimeout time.Duration = 5 * time.Minute
-	rescue               string        = "rescue"
-	rescuePort           int           = 22
-	gbToMebiBytes        int           = 1000
-	gbToBytes            int           = 1000000 * gbToMebiBytes
-	kikiToMebiBytes      int           = 1024
+	rebootWaitTime           time.Duration = 15 * time.Second
+	sshResetTimeout          time.Duration = 5 * time.Minute
+	softwareResetTimeout     time.Duration = 10 * time.Minute
+	hardwareResetTimeout     time.Duration = 10 * time.Minute
+	connectionRefusedTimeout time.Duration = 10 * time.Minute
+	rescue                   string        = "rescue"
+	rescuePort               int           = 22
+	gbToMebiBytes            int           = 1000
+	gbToBytes                int           = 1000000 * gbToMebiBytes
+	kikiToMebiBytes          int           = 1024
 
 	errMsgFailedReboot                 = "failed to reboot bare metal server: %w"
 	errMsgInvalidSSHStdOut             = "invalid output in stdOut: %w"
@@ -347,7 +348,7 @@ func (s *Service) handleIncompleteBoot(isRebootIntoRescue, isTimeout, isConnecti
 	if isConnectionRefused {
 		if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeConnectionError {
 			// if error has occurred before, check the timeout
-			if hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.LastUpdated, time.Minute) {
+			if hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.LastUpdated, connectionRefusedTimeout) {
 				msg := "Connection error when targeting server with ssh that might be due to a wrong ssh port. Please check."
 				if isRebootIntoRescue {
 					msg = "Connection error. Can't reach rescue system via ssh."

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -449,7 +449,7 @@ var _ = Describe("handleIncompleteBoot", func() {
 			},
 			Entry("timed out sw reset", testCaseHandleIncompleteBootDifferentTimeouts{
 				hostErrorType:         infrav1.ErrorTypeSoftwareRebootTriggered,
-				lastUpdated:           time.Now().Add(-5 * time.Minute),
+				lastUpdated:           time.Now().Add(-15 * time.Minute),
 				expectedHostErrorType: infrav1.ErrorTypeHardwareRebootTriggered,
 				expectedRebootType:    infrav1.RebootTypeHardware,
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:
We have the timeout of one minute that we allow connection refused errors to come after reboot of a server.

In this commit we added the (correct) permanent error if we conclude the reboot to be "failed". However, apparently, for a long time already, we marked reboots as failed that did not actually fail.

This commit introduces a larger timeout, so that we don't mark the reboots as failed, and in turn don't mark the HetznerBareMetalHost as failed.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

