### PR TITLE
:seedling: Remove HetznerBareMetalMachineTemplate create webhook

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
+++ b/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
@@ -57,9 +57,9 @@ func (r *HetznerBareMetalMachineTemplateWebhook) ValidateCreate(_ context.Contex
 		hbmmt.Spec.Template.Spec.SSHSpec.PortAfterCloudInit = hbmmt.Spec.Template.Spec.SSHSpec.PortAfterInstallImage
 	}
 
-	allErrs := validateHetznerBareMetalMachineSpecCreate(hbmmt.Spec.Template.Spec)
-
-	return nil, aggregateObjErrors(hbmmt.GroupVersionKind().GroupKind(), hbmmt.Name, allErrs)
+	// TODO: Cannot validate it because ClusterClass applies empty template objects
+	// allErrs := validateHetznerBareMetalMachineSpecCreate(hbmmt.Spec.Template.Spec)
+	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
@@ -83,8 +83,7 @@ func (r *HetznerBareMetalMachineTemplateWebhook) ValidateUpdate(ctx context.Cont
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newHetznerBareMetalMachineTemplate, "HetznerBareMetalMachineTemplate.Spec is immutable"))
 	}
 
-	// TODO: Cannot validate it because ClusterClass applies empty template objects
-	// allErrs = append(allErrs, validateHetznerBareMetalMachineSpecUpdate(oldHetznerBareMetalMachineTemplate.Spec.Template.Spec, newHetznerBareMetalMachineTemplate.Spec.Template.Spec)...)
+	allErrs = append(allErrs, validateHetznerBareMetalMachineSpecUpdate(oldHetznerBareMetalMachineTemplate.Spec.Template.Spec, newHetznerBareMetalMachineTemplate.Spec.Template.Spec)...)
 
 	return nil, aggregateObjErrors(newHetznerBareMetalMachineTemplate.GroupVersionKind().GroupKind(), newHetznerBareMetalMachineTemplate.Name, allErrs)
 }

--- a/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
+++ b/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
@@ -83,7 +83,8 @@ func (r *HetznerBareMetalMachineTemplateWebhook) ValidateUpdate(ctx context.Cont
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newHetznerBareMetalMachineTemplate, "HetznerBareMetalMachineTemplate.Spec is immutable"))
 	}
 
-	allErrs = append(allErrs, validateHetznerBareMetalMachineSpecUpdate(oldHetznerBareMetalMachineTemplate.Spec.Template.Spec, newHetznerBareMetalMachineTemplate.Spec.Template.Spec)...)
+	// TODO: Cannot validate it because ClusterClass applies empty template objects
+	// allErrs = append(allErrs, validateHetznerBareMetalMachineSpecUpdate(oldHetznerBareMetalMachineTemplate.Spec.Template.Spec, newHetznerBareMetalMachineTemplate.Spec.Template.Spec)...)
 
 	return nil, aggregateObjErrors(newHetznerBareMetalMachineTemplate.GroupVersionKind().GroupKind(), newHetznerBareMetalMachineTemplate.Name, allErrs)
 }

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -710,43 +710,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 			})
 		})
 
-		Context("validate create", func() {
-			var (
-				hbmmt  *infrav1.HetznerBareMetalMachineTemplate
-				testNs *corev1.Namespace
-			)
-			BeforeEach(func() {
-				var err error
-				testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachine-validation")
-				Expect(err).NotTo(HaveOccurred())
-
-				hbmmt = &infrav1.HetznerBareMetalMachineTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      bmMachineName,
-						Namespace: testNs.Name,
-						Labels: map[string]string{
-							clusterv1.ClusterNameLabel: capiCluster.Name,
-						},
-					},
-					Spec: infrav1.HetznerBareMetalMachineTemplateSpec{
-						Template: infrav1.HetznerBareMetalMachineTemplateResource{
-							Spec: getDefaultHetznerBareMetalMachineSpec(),
-						},
-					},
-				}
-
-			})
-
-			AfterEach(func() {
-				Expect(testEnv.Cleanup(ctx, testNs, hbmmt)).To(Succeed())
-			})
-
-			It("should allow creation of hbmmt", func() {
-				Expect(testEnv.Create(ctx, hbmmt)).To(Succeed())
-			})
-
-		})
-
 		Context("validate update", func() {
 			var (
 				hbmmt  *infrav1.HetznerBareMetalMachineTemplate
@@ -777,7 +740,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 				Eventually(func() error {
 					return testEnv.Client.Get(ctx, key, hbmmt)
 				}, timeout, time.Second).Should(BeNil())
-
 			})
 
 			AfterEach(func() {
@@ -807,7 +769,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 					},
 				}
 				Expect(testEnv.Client.Update(ctx, hbmmt)).ToNot(Succeed())
-
 			})
 
 			It("should not allow update of SSHSpec", func() {
@@ -832,7 +793,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 					},
 				}
 				Expect(testEnv.Client.Update(ctx, hbmmt)).ToNot(Succeed())
-
 			})
 
 			It("should not allow update of Host Selectors", func() {
@@ -857,7 +817,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 					},
 				}
 				Expect(testEnv.Client.Update(ctx, hbmmt)).ToNot(Succeed())
-
 			})
 
 			It("should allow update of mutable fields", func() {
@@ -868,9 +827,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 				}
 				hbmmt.ObjectMeta.Annotations["test"] = "should_succeed"
 				Expect(testEnv.Client.Update(ctx, hbmmt)).To(Succeed())
-
 			})
-
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
We have to remove it as it is currently incapable of working with the ClusterClass.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

