### PR TITLE
:bug: Remove false duplicate validation in webhooks 

### DIFF
--- a/api/v1beta1/hcloudmachinetemplate_webhook.go
+++ b/api/v1beta1/hcloudmachinetemplate_webhook.go
@@ -71,8 +71,6 @@ func (r *HCloudMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRa
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newHCloudMachineTemplate, "HCloudMachineTemplate.Spec is immutable"))
 	}
 
-	allErrs = append(allErrs, validateHCloudMachineSpec(oldHCloudMachineTemplate.Spec.Template.Spec, newHCloudMachineTemplate.Spec.Template.Spec)...)
-
 	return nil, aggregateObjErrors(newHCloudMachineTemplate.GroupVersionKind().GroupKind(), newHCloudMachineTemplate.Name, allErrs)
 }
 

--- a/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
+++ b/api/v1beta1/hetznerbaremetalmachinetemplate_webhook.go
@@ -83,8 +83,6 @@ func (r *HetznerBareMetalMachineTemplateWebhook) ValidateUpdate(ctx context.Cont
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec"), newHetznerBareMetalMachineTemplate, "HetznerBareMetalMachineTemplate.Spec is immutable"))
 	}
 
-	allErrs = append(allErrs, validateHetznerBareMetalMachineSpecUpdate(oldHetznerBareMetalMachineTemplate.Spec.Template.Spec, newHetznerBareMetalMachineTemplate.Spec.Template.Spec)...)
-
 	return nil, aggregateObjErrors(newHetznerBareMetalMachineTemplate.GroupVersionKind().GroupKind(), newHetznerBareMetalMachineTemplate.Name, allErrs)
 }
 

--- a/controllers/hcloudmachinetemplate_controller_test.go
+++ b/controllers/hcloudmachinetemplate_controller_test.go
@@ -54,9 +54,7 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 	Context("Basic test", func() {
 		Context("ClusterClass test", func() {
-			var (
-				capiClusterClass *clusterv1.ClusterClass
-			)
+			var capiClusterClass *clusterv1.ClusterClass
 
 			BeforeEach(func() {
 				capiClusterClass = &clusterv1.ClusterClass{
@@ -292,7 +290,6 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 				hcloudMachineTemplate.Spec.Template.Spec.ImageName = "fedora-control-plane"
 				Expect(testEnv.Client.Update(ctx, hcloudMachineTemplate)).ToNot(Succeed())
-
 			})
 
 			It("should prevent updating SSHKey", func() {
@@ -300,7 +297,6 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 				hcloudMachineTemplate.Spec.Template.Spec.SSHKeys = []infrav1.SSHKey{{Name: "ssh-key-1"}}
 				Expect(testEnv.Client.Update(ctx, hcloudMachineTemplate)).ToNot(Succeed())
-
 			})
 
 			It("should prevent updating PlacementGroups", func() {
@@ -308,7 +304,6 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 				hcloudMachineTemplate.Spec.Template.Spec.PlacementGroupName = createPlacementGroupName("placement-group-1")
 				Expect(testEnv.Client.Update(ctx, hcloudMachineTemplate)).ToNot(Succeed())
-
 			})
 
 			It("should succeed for mutable fields", func() {
@@ -325,7 +320,6 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 				Expect(testEnv.Client.Update(ctx, hcloudMachineTemplate)).To(Succeed())
 			})
 		})
-
 	})
 })
 

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -709,7 +709,6 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 				Expect(testEnv.Update(ctx, bmMachine)).NotTo(Succeed())
 			})
 		})
-
 		Context("validate update", func() {
 			var (
 				hbmmt  *infrav1.HetznerBareMetalMachineTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:
We introduced a bug previously by adding a duplicate validation in the
webhooks of HCloudMachineTemplate and HetznerBareMetalMachineTemplate in
the update function. There we used the function
ShouldSkipImmutabilityCheck that allows to use the webhook with Cluster
API's ClusterClass. However, we added another function call that again
checks that everything is immutable and didn't use the above utility
function from Cluster API. That's why the webhooks were not compatible
with ClusterClass anymore. All we have to do is to remove the duplicate
call that was not needed anyway.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

