### PR TITLE
:seedling: Remove permanent error after bm reboot

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1317,7 +1317,7 @@ func (s *Service) actionProvisioning() actionResult {
 		}
 		failed, err := s.handleIncompleteBoot(false, isSSHTimeoutError, isSSHConnectionRefusedError)
 		if failed {
-			return s.recordActionFailure(infrav1.PermanentError, err.Error())
+			return s.recordActionFailure(infrav1.ProvisioningError, err.Error())
 		}
 		if err != nil {
 			return actionError{err: fmt.Errorf(errMsgFailedHandlingIncompleteBoot, err)}
@@ -1506,7 +1506,7 @@ func (s *Service) actionEnsureProvisioned() (ar actionResult) {
 
 		failed, err := s.handleIncompleteBoot(false, isTimeout, isSSHConnectionRefusedError)
 		if failed {
-			return s.recordActionFailure(infrav1.PermanentError, err.Error())
+			return s.recordActionFailure(infrav1.ProvisioningError, err.Error())
 		}
 		if err != nil {
 			return actionError{err: fmt.Errorf(errMsgFailedHandlingIncompleteBoot, err)}


### PR DESCRIPTION
**What this PR does / why we need it**:
In the provisioning of bare metal servers, we added permanent errors that appear after a server times out while rebooting.

This turned out to be quite unreliable, because the server reboots are very unreliable. Sometimes they take forever to reboot, in other situations they are fast and the server provisions successfully.

Therefore, we should rather try again and not stop completely.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

