### PR TITLE
:seedling: disable bm-2 (1716772) since broken. And rename hosts.

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts-raid.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts-raid.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
-  name: "bm-2"
+  name: "bm-e2e-raid-1716772"
 spec:
   serverID: 1716772
   rootDeviceHints:
@@ -15,7 +15,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
-  name: "bm-6"
+  name: "bm-e2e-raid-1763731"
 spec:
   serverID: 1763731
   rootDeviceHints:

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -1,66 +1,69 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
-  name: "bm-1"
+  name: "bm-e2e-1670788"
 spec:
   serverID: 1670788
   rootDeviceHints:
     wwn: "0x5002538c0004413f"
   maintenanceMode: false
-  description: Test Machine 1
+  description: Test Machine 1670788
+
+# ---
+# Broken 2024-07-31
+# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+# kind: HetznerBareMetalHost
+# metadata:
+#   name: "bm-e2e-1716772"
+# spec:
+#   serverID: 1716772
+#   rootDeviceHints:
+#     wwn: "0x500a07510fe0ce34"
+#   maintenanceMode: false
+#   description: Test Machine 1716772
+
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
-  name: "bm-2"
-spec:
-  serverID: 1716772
-  rootDeviceHints:
-    wwn: "0x500a07510fe0ce34"
-  maintenanceMode: false
-  description: Test Machine 2
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "bm-3"
+  name: "bm-e2e-1724024"
 spec:
   serverID: 1724024
   rootDeviceHints:
     wwn: "0x500a075111968d25"
   maintenanceMode: false
-  description: Test Machine 3
-# --- We deactived bm-4 since it can't reach the rescue system.
+  description: Test Machine 1724024
+# --- We deactived 1731561 since it can't reach the rescue system.
 #     We enable it again, if we solved the issue.
 # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 # kind: HetznerBareMetalHost
 # metadata:
-#   name: "bm-4"
+#   name: "bm-e2e-1731561"
 # spec:
 #   serverID: 1731561
 #   rootDeviceHints:
 #     wwn: "0x500a075119615dc2"
 #   maintenanceMode: false
-#   description: Test Machine 4
+#   description: Test Machine 1731561
 # ---
 # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 # kind: HetznerBareMetalHost
 # metadata:
-#   name: "bm-5"
+#   name: "bm-e2e-1751550"
 # spec:
-#   serverID: 1751550 # this is the identifier in hetzner UI
+#   serverID: 1751550
 #   rootDeviceHints:
 #     wwn: "0x500a075119549dcf"
 #   maintenanceMode: false
-#   description: Test Machine 5
+#   description: Test Machine 1751550
 # ---
 # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 # kind: HetznerBareMetalHost
 # metadata:
-#   name: "bm-6"
+#   name: "bm-e2e-1763731"
 # spec:
 #   serverID: 1763731
 #   rootDeviceHints:
 #     wwn: "0x500a07511756c36d"
 #   maintenanceMode: false
-#   description: Test Machine 6
+#   description: Test Machine 1751550


### PR DESCRIPTION
**What this PR does / why we need it**:

The bm-2 (1716772)  seems broken. Rescue system is not reachable.

https://github.com/syself/cluster-api-provider-hetzner/actions/runs/10178928281/job/28153631149#step:3:825

And the hosts got renamed since "bm-2" does not say anything. If we use the robot-id in the name, then it is easier to find the related server.

