### PR TITLE
:seedling: re-enable bm server  bm-2 (1716772)

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -8,20 +8,17 @@ spec:
     wwn: "0x5002538c0004413f"
   maintenanceMode: false
   description: Test Machine 1670788
-
-# ---
-# Broken 2024-07-31
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1716772"
-# spec:
-#   serverID: 1716772
-#   rootDeviceHints:
-#     wwn: "0x500a07510fe0ce34"
-#   maintenanceMode: false
-#   description: Test Machine 1716772
-
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1716772"
+spec:
+  serverID: 1716772
+  rootDeviceHints:
+    wwn: "0x500a07510fe0ce34"
+  maintenanceMode: false
+  description: Test Machine 1716772
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost


### PR DESCRIPTION
**What this PR does / why we need it**:

> Dear Client,
> We have replaced the defective SATA SSDs and started the server afterwards into the Linux rescue system

hardware was replaced. Rescue system works (tested by hand),
