### PR TITLE
:seedling: Add Singapore location and ap-southeast Network Zone

### DIFF
--- a/api/v1beta1/hetznercluster_webhook.go
+++ b/api/v1beta1/hetznercluster_webhook.go
@@ -39,6 +39,7 @@ var regionNetworkZoneMap = map[string]string{
 	"hel1": "eu-central",
 	"ash":  "us-east",
 	"hil":  "us-west",
+	"sin":  "ap-southeast",
 }
 
 // SetupWebhookWithManager initializes webhook manager for HetznerCluster.
@@ -91,7 +92,7 @@ func (r *HetznerCluster) ValidateCreate() (admission.Warnings, error) {
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("spec", "controlPlaneRegions"),
 				r.Spec.ControlPlaneRegions,
-				"wrong control plane region. Should be fsn1, nbg1, hel1, or ash",
+				"wrong control plane region. Should be fsn1, nbg1, hel1, ash, hil or sin",
 			))
 		}
 	}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -233,7 +233,7 @@ type HCloudNetworkSpec struct {
 
 	// NetworkZone specifies the HCloud network zone of the private network.
 	// The zones must be one of eu-central, us-east, or us-west. The default is eu-central.
-	// +kubebuilder:validation:Enum=eu-central;us-east;us-west
+	// +kubebuilder:validation:Enum=eu-central;us-east;us-west;ap-southeast
 	// +kubebuilder:default=eu-central
 	// +optional
 	NetworkZone HCloudNetworkZone `json:"networkZone,omitempty"`
@@ -247,7 +247,7 @@ type NetworkStatus struct {
 }
 
 // Region is a Hetzner Location.
-// +kubebuilder:validation:Enum=fsn1;hel1;nbg1;ash;hil
+// +kubebuilder:validation:Enum=fsn1;hel1;nbg1;ash;hil;sin
 type Region string
 
 // HCloudNetworkZone describes the Network zone.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -253,6 +253,7 @@ spec:
                 - nbg1
                 - ash
                 - hil
+                - sin
                 type: string
               sshKeys:
                 description: SSHKeys specifies the ssh keys that were used for provisioning

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -157,6 +157,7 @@ spec:
                     - nbg1
                     - ash
                     - hil
+                    - sin
                     type: string
                   type:
                     default: lb11
@@ -181,6 +182,7 @@ spec:
                   - nbg1
                   - ash
                   - hil
+                  - sin
                   type: string
                 type: array
               hcloudNetwork:
@@ -205,6 +207,7 @@ spec:
                     - eu-central
                     - us-east
                     - us-west
+                    - ap-southeast
                     type: string
                   subnetCidrBlock:
                     default: 10.0.0.0/24

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -187,6 +187,7 @@ spec:
                             - nbg1
                             - ash
                             - hil
+                            - sin
                             type: string
                           type:
                             default: lb11
@@ -211,6 +212,7 @@ spec:
                           - nbg1
                           - ash
                           - hil
+                          - sin
                           type: string
                         type: array
                       hcloudNetwork:
@@ -236,6 +238,7 @@ spec:
                             - eu-central
                             - us-east
                             - us-west
+                            - ap-southeast
                             type: string
                           subnetCidrBlock:
                             default: 10.0.0.0/24


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the new location `sin` (Singapore) and network zone `ap-southeast` to the CRDs + webhook validations.

The new location was released on 2024-08-06. Learn more at https://docs.hetzner.cloud/changelog#2024-08-06-new-location-singapore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

