### PR TITLE
:bug: Fix Lychee Link Checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -58,6 +58,7 @@ exclude = [
     "https://www.hetzner.com/*",
     "https://opensource.org/license/apache-2-0/",
     "https://robot.your-server.de/*",
+    "https://www.linkedin.com/company/syself/",
 ]
 
 include = []

--- a/Makefile
+++ b/Makefile
@@ -744,6 +744,7 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 		-v $(shell pwd):/src/cluster-api-provider-$(INFRA_PROVIDER)$(MOUNT_FLAGS) \
 		$(BUILDER_IMAGE):$(BUILDER_IMAGE_VERSION) $@;
 else
+	@lychee --version
 	lychee --config .lychee.toml ./*.md  ./docs/**/*.md
 endif
 


### PR DESCRIPTION
LinkedIn return http status 999, which seem to confuse Lychee.

Related:

https://github.com/lycheeverse/lychee/issues/1477