### PR TITLE
e2e host has a new disk, adapting WWN

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   serverID: 1716772
   rootDeviceHints:
-    wwn: "0x500a07510fe0ce34"
+    wwn: "0x5000cca22de4ef84"
   maintenanceMode: false
   description: Test Machine 1716772
 ---


### PR DESCRIPTION
Fixing failing BM e2e test.

> missing storage device for root device hint "0x500a07510fe0ce34".
> Known WWNs: [0x5000cca22de4db5a 0x500a0751160cdc2d 0x5000cca22de4ef84 0x5002538d41d70a46]
