### PR TITLE
:seedling: Make link checker lychee show  unknown http status codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,7 +745,7 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 		$(BUILDER_IMAGE):$(BUILDER_IMAGE_VERSION) $@;
 else
 	@lychee --version
-	lychee --config .lychee.toml ./*.md  ./docs/**/*.md
+	lychee --verbose --config .lychee.toml ./*.md  ./docs/**/*.md 2>&1 | grep -vP '\[(200|EXCLUDED)\]'
 endif
 
 ##@ Main Targets


### PR DESCRIPTION
Example output (new):

```
lychee --verbose --config .lychee.toml ./*.md  ./docs/**/*.md 2>&1 | grep -vP '\[(200|EXCLUDED)\]'
? [999] https://www.linkedin.com/company/syself/ | Unknown status (999 <unknown status code>)

🔍 110 Total (in 6s) ✅ 96 OK 🚫 0 Errors 💤 13 Excluded
make: *** [Makefile:748: lint-links] Error 2
```

Now we would see the error, if this happens again.
