### PR TITLE
:seedling: Use GITHUB_RUN_ID for the specName of e2e tests.

### DIFF
--- a/test/e2e/caph.go
+++ b/test/e2e/caph.go
@@ -46,7 +46,7 @@ type CaphClusterDeploymentSpecInput struct {
 // CaphClusterDeploymentSpec implements a test that verifies that MachineDeployment rolling updates are successful.
 func CaphClusterDeploymentSpec(ctx context.Context, inputGetter func() CaphClusterDeploymentSpecInput) {
 	var (
-		specName         = "caph"
+		specName         = "ci" + os.Getenv("GITHUB_RUN_ID")
 		input            CaphClusterDeploymentSpecInput
 		namespace        *corev1.Namespace
 		cancelWatches    context.CancelFunc
@@ -60,7 +60,7 @@ func CaphClusterDeploymentSpec(ctx context.Context, inputGetter func() CaphClust
 		gomega.Expect(input.E2EConfig).ToNot(gomega.BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
 		gomega.Expect(input.ClusterctlConfigPath).To(gomega.BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
 		gomega.Expect(input.BootstrapClusterProxy).ToNot(gomega.BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-		gomega.Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(gomega.Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+		gomega.Expect(os.MkdirAll(input.ArtifactFolder, 0o750)).To(gomega.Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 		gomega.Expect(input.E2EConfig.Variables).To(gomega.HaveKey(KubernetesVersion))
 		gomega.Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersion)))
 


### PR DESCRIPTION
Then bm machines will get this name, and then it is easier to understand a failing e2e test.

It would be nice to see the ID here:

![image](https://github.com/user-attachments/assets/edc1ccf3-6a1e-4aba-b7c5-b4027032fc0c)


Unfortunately the JOB_ID is not available: https://github.com/actions/runner/issues/324