### PR TITLE
:seedling: Disable "bm-e2e-1716772" since rescue system not reachable.

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -9,17 +9,17 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "bm-e2e-1716772"
-spec:
-  serverID: 1716772
-  rootDeviceHints:
-    wwn: "0x5000cca22de4ef84"
-  maintenanceMode: false
-  description: Test Machine 1716772
----
+# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+# kind: HetznerBareMetalHost
+# metadata:
+#   name: "bm-e2e-1716772"
+# spec:
+#   serverID: 1716772
+#   rootDeviceHints:
+#     wwn: "0x5000cca22de4ef84"
+#   maintenanceMode: false
+#   description: Test Machine 1716772
+# ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:


### PR DESCRIPTION
I sent a message to the support via the robot web-ui.

Example of a failing test: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/10266506742/job/28406889169