### PR TITLE
:seedling: enable bm-e2e-1716772

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -9,17 +9,17 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1716772"
-# spec:
-#   serverID: 1716772
-#   rootDeviceHints:
-#     wwn: "0x5000cca22de4ef84"
-#   maintenanceMode: false
-#   description: Test Machine 1716772
-# ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1716772"
+spec:
+  serverID: 1716772
+  rootDeviceHints:
+    wwn: "0x5000cca22de4ef84"
+  maintenanceMode: false
+  description: Test Machine 1716772
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:


### PR DESCRIPTION
enable bm-e2e-1716772 again. It was fixed by the Hetzner support.

