### PR TITLE
:seedling: Set PermanentErrorAnnotation, if removed by user, then remove the error state.

### DIFF
--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/record"
 )
 
 const (
@@ -550,6 +551,8 @@ func (host *HetznerBareMetalHost) SetError(errType ErrorType, errMessage string)
 	host.Spec.Status.ErrorMessage = errMessage
 	if errType == PermanentError {
 		host.Annotations[PermanentErrorAnnotation] = time.Now().Format(time.RFC3339)
+		record.Warnf(host, "PermanentErrorSet", "Remove annotation %q, if you want the controller to use the hbmh again.",
+			PermanentErrorAnnotation)
 	}
 }
 

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -547,6 +548,9 @@ func (host *HetznerBareMetalHost) SetError(errType ErrorType, errMessage string)
 	}
 	host.Spec.Status.ErrorType = errType
 	host.Spec.Status.ErrorMessage = errMessage
+	if errType == PermanentError {
+		host.Annotations[PermanentErrorAnnotation] = time.Now().Format(time.RFC3339)
+	}
 }
 
 // ClearError removes the error on the host and resets the error count to 0.

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -550,6 +550,9 @@ func (host *HetznerBareMetalHost) SetError(errType ErrorType, errMessage string)
 	host.Spec.Status.ErrorType = errType
 	host.Spec.Status.ErrorMessage = errMessage
 	if errType == PermanentError {
+		if host.Annotations == nil {
+			host.Annotations = make(map[string]string, 1)
+		}
 		host.Annotations[PermanentErrorAnnotation] = time.Now().Format(time.RFC3339)
 		record.Warnf(host, "PermanentErrorSet", "Remove annotation %q, if you want the controller to use the hbmh again.",
 			PermanentErrorAnnotation)

--- a/api/v1beta1/hetznerbaremetalhost_types_test.go
+++ b/api/v1beta1/hetznerbaremetalhost_types_test.go
@@ -484,7 +484,7 @@ func TestHetznerBareMetalHost_SetError(t *testing.T) {
 		},
 	}
 	host.SetError(PermanentError, "some error")
-	require.Equal(t, []string{"other-annotation", PermanentErrorAnnotation}, mapKeys(host.Annotations))
+	require.Equal(t, []string{PermanentErrorAnnotation, "other-annotation"}, mapKeys(host.Annotations))
 
 	// Other errors should not add the PermanentErrorAnnotation
 	host = HetznerBareMetalHost{

--- a/api/v1beta1/hetznerbaremetalhost_types_test.go
+++ b/api/v1beta1/hetznerbaremetalhost_types_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"cmp"
+	"slices"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Test update secret status", func() {
@@ -458,3 +464,36 @@ var _ = Describe("Test ClearRebootAnnotations", func() {
 		}),
 	)
 })
+
+func mapKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	ret := make([]K, 0, len(m))
+	for k := range m {
+		ret = append(ret, k)
+	}
+	slices.Sort(ret)
+	return ret
+}
+
+func TestHetznerBareMetalHost_SetError(t *testing.T) {
+	// A PermanentError should add the PermanentErrorAnnotation
+	host := HetznerBareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"other-annotation": "some value",
+			},
+		},
+	}
+	host.SetError(PermanentError, "some error")
+	require.Equal(t, []string{"other-annotation", PermanentErrorAnnotation}, mapKeys(host.Annotations))
+
+	// Other errors should not add the PermanentErrorAnnotation
+	host = HetznerBareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"other-annotation": "some value",
+			},
+		},
+	}
+	host.SetError(ProvisioningError, "some error")
+	require.Equal(t, []string{"other-annotation"}, mapKeys(host.Annotations))
+}

--- a/api/v1beta1/hetznerbaremetalremediation_types.go
+++ b/api/v1beta1/hetznerbaremetalremediation_types.go
@@ -27,6 +27,11 @@ const (
 
 	// RebootAnnotation indicates that a bare metal host object should be rebooted.
 	RebootAnnotation = "reboot.hetznerbaremetalhost.infrastructure.cluster.x-k8s.io"
+
+	// PermanentErrorAnnotation indicates that the bare metal host has an error which needs to be resolved manually.
+	// After the permanent error the annotation got removed (usually by a human), the controller removes
+	// ErrorType, ErrorCount and ErrorMessages, so that the hbmh will be usable again.
+	PermanentErrorAnnotation = "permanenterror.hetznerbaremetalhost.infrastructure.cluster.x-k8s.io"
 )
 
 // HetznerBareMetalRemediationSpec defines the desired state of HetznerBareMetalRemediation.

--- a/api/v1beta1/hetznerbaremetalremediation_types.go
+++ b/api/v1beta1/hetznerbaremetalremediation_types.go
@@ -31,7 +31,7 @@ const (
 	// PermanentErrorAnnotation indicates that the bare metal host has an error which needs to be resolved manually.
 	// After the permanent error the annotation got removed (usually by a human), the controller removes
 	// ErrorType, ErrorCount and ErrorMessages, so that the hbmh will be usable again.
-	PermanentErrorAnnotation = "permanenterror.hetznerbaremetalhost.infrastructure.cluster.x-k8s.io"
+	PermanentErrorAnnotation = "error.hetznerbaremetalhost.infrastructure.cluster.x-k8s.io"
 )
 
 // HetznerBareMetalRemediationSpec defines the desired state of HetznerBareMetalRemediation.

--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -175,7 +175,7 @@ func (r *GuestCSRReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			certificateSigningRequest.Spec.Username, err)
 	}
 
-	record.Event(certificateSigningRequest, "CSRApproved", "approved csr")
+	record.Eventf(certificateSigningRequest, "CSRApproved", "approved csr for %q", certificateSigningRequest.Spec.Username)
 	return reconcile.Result{}, nil
 }
 

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -97,6 +97,18 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Remove permanent error, if the corresponding annotation was removed by the user.
+	requeue := removePermanentErrorIfAnnotationIsGone(bmHost)
+	if requeue {
+		// The permanent error was removed from Spec.Status.
+		// Save the changes, and then reconcile again.
+		err := r.Update(ctx, bmHost)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to update (after removePermanentErrorIfAnnotationIsGone): %w", err)
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// Certain cases need to be handled here and not later in the host state machine.
 	// If res != nil, then we should return, otherwise not.
 	res, err = r.reconcileSelectedStates(ctx, bmHost)
@@ -450,4 +462,24 @@ func (r *HetznerBareMetalHostReconciler) SetupWithManager(ctx context.Context, m
 			}).
 		Owns(&corev1.Secret{}).
 		Complete(r)
+}
+
+func removePermanentErrorIfAnnotationIsGone(bmHost *infrav1.HetznerBareMetalHost,
+) (requeue bool) {
+	if bmHost.Spec.Status.ErrorType != infrav1.PermanentError {
+		// PermanentError not set. Do nothing.
+		return false
+	}
+	for k := range bmHost.GetAnnotations() {
+		if k == infrav1.PermanentErrorAnnotation {
+			// Annotation was not removed by user. Do nothing.
+			return false
+		}
+	}
+	bmHost.Spec.Status.ErrorType = ""
+	bmHost.Spec.Status.ErrorMessage = ""
+	bmHost.Spec.Status.ErrorCount = 0
+	record.Eventf(bmHost, "PermanentErrorWasRemoved", "The permanent error was removed, because the annotation %q was removed",
+		infrav1.PermanentErrorAnnotation)
+	return true
 }

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -98,8 +98,8 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	// Remove permanent error, if the corresponding annotation was removed by the user.
-	requeue := removePermanentErrorIfAnnotationIsGone(bmHost)
-	if requeue {
+	removed := removePermanentErrorIfAnnotationIsGone(bmHost)
+	if removed {
 		// The permanent error was removed from Spec.Status.
 		// Save the changes, and then reconcile again.
 		err := r.Update(ctx, bmHost)
@@ -465,7 +465,7 @@ func (r *HetznerBareMetalHostReconciler) SetupWithManager(ctx context.Context, m
 }
 
 func removePermanentErrorIfAnnotationIsGone(bmHost *infrav1.HetznerBareMetalHost,
-) (requeue bool) {
+) (removed bool) {
 	if bmHost.Spec.Status.ErrorType != infrav1.PermanentError {
 		// PermanentError not set. Do nothing.
 		return false

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -918,8 +918,8 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 			},
 		},
 	}
-	requeue := removePermanentErrorIfAnnotationIsGone(&bmHost)
-	require.False(t, requeue)
+	removed := removePermanentErrorIfAnnotationIsGone(&bmHost)
+	require.False(t, removed)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorType)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorCount)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorMessage)
@@ -940,8 +940,8 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 			},
 		},
 	}
-	requeue = removePermanentErrorIfAnnotationIsGone(&bmHost)
-	require.True(t, requeue)
+	removed = removePermanentErrorIfAnnotationIsGone(&bmHost)
+	require.True(t, removed)
 	require.Empty(t, bmHost.Spec.Status.ErrorType)
 	require.Empty(t, bmHost.Spec.Status.ErrorCount)
 	require.Empty(t, bmHost.Spec.Status.ErrorMessage)
@@ -961,8 +961,8 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 			},
 		},
 	}
-	requeue = removePermanentErrorIfAnnotationIsGone(&bmHost)
-	require.False(t, requeue)
+	removed = removePermanentErrorIfAnnotationIsGone(&bmHost)
+	require.False(t, removed)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorType)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorCount)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorMessage)

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -24,13 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	robotmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/robot"
-	sshmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/ssh"
-	sshclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh"
-	hostpkg "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host"
-	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
-	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 	"github.com/syself/hrobot-go/models"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +33,14 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	robotmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/robot"
+	sshmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/ssh"
+	sshclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh"
+	hostpkg "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
+	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
 
 const (

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -183,6 +183,7 @@ func (s *Service) actionPreparing(_ context.Context) actionResult {
 				clusterv1.ConditionSeverityError,
 				msg,
 			)
+			record.Warnf(s.scope.HetznerBareMetalHost, infrav1.ServerNotFoundReason, msg)
 			s.scope.HetznerBareMetalHost.SetError(infrav1.PermanentError, msg)
 			return actionStop{}
 		}
@@ -263,7 +264,8 @@ func (s *Service) actionPreparing(_ context.Context) actionResult {
 	}
 
 	msg := createRebootEvent(s.scope.HetznerBareMetalHost, rebootType, "Reboot into rescue system.")
-	// we immediately set an error message in the host status to track the reboot we just performed
+	// we immediately set an error message in the host status to track the reboot we just performed.
+	// This is not a real error. Sooner or later we should track the reboots differently.
 	s.scope.HetznerBareMetalHost.SetError(errorType, msg)
 	return actionComplete{} // next: Registering
 }


### PR DESCRIPTION


Fixes #1335

> There are multiple reasons why a HetznerBareMetalHost object has a "permanent error" set. This means that user intervention is required.

> The current work flow for users that have taken action on the server so that it can be used again to delete the custom resource and to recreate it. This is no issue at all from the workflow. However, it is not very elegant to delete an object and to manually re-create it.
