### PR TITLE
:seedling: fix flaky unit-tests

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
 
@@ -45,10 +44,9 @@ const (
 )
 
 var (
-	testEnv      *helpers.TestEnvironment
-	hcloudClient hcloudclient.Client
-	ctx          = ctrl.SetupSignalHandler()
-	wg           sync.WaitGroup
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+	wg      sync.WaitGroup
 
 	defaultPlacementGroupName = "caph-placement-group"
 	defaultFailureDomain      = "fsn1"
@@ -64,7 +62,6 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 
 	testEnv = helpers.NewTestEnvironment()
-	hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 
 	wg.Add(1)
 

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -320,7 +322,10 @@ var _ = Describe("HCloudMachineReconciler", func() {
 
 	Context("Basic test", func() {
 		Context("correct server", func() {
+			var hcloudClient hcloudclient.Client
+
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				// remove bootstrap infos
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{}
 				Expect(testEnv.Create(ctx, capiMachine)).To(Succeed())
@@ -365,7 +370,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 				}, timeout).Should(BeTrue())
 			})
 
-			It("creates the HCloud machine in Hetzner 1 (flaky)", func() {
+			FIt("creates the HCloud machine in Hetzner 1 (flaky)", func() {
 				By("checking that no servers exist")
 
 				Eventually(func(start time.Time) bool {
@@ -517,7 +522,10 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("without network", func() {
+			var hcloudClient hcloudclient.Client
+
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				hetznerCluster.Spec.HCloudNetwork.Enabled = false
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 				Expect(testEnv.Create(ctx, hcloudMachine)).To(Succeed())
@@ -543,7 +551,10 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("without placement groups", func() {
+			var hcloudClient hcloudclient.Client
+
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				hetznerCluster.Spec.HCloudPlacementGroups = nil
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 
@@ -609,7 +620,9 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("with public network specs", func() {
+			var hcloudClient hcloudclient.Client
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				hcloudMachine.Spec.PublicNetwork = &infrav1.PublicNetworkSpec{
 					EnableIPv4: false,
 					EnableIPv6: false,

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -370,7 +369,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 				}, timeout).Should(BeTrue())
 			})
 
-			FIt("creates the HCloud machine in Hetzner 1 (flaky)", func() {
+			It("creates the HCloud machine in Hetzner 1", func() {
 				By("checking that no servers exist")
 
 				Eventually(func(start time.Time) bool {
@@ -380,16 +379,13 @@ var _ = Describe("HCloudMachineReconciler", func() {
 						},
 					})
 					if err != nil {
-						fmt.Printf("flaky test. ListServers failed: %s\n", err.Error())
 						return false
 					}
 					if len(servers) != 0 {
-						fmt.Printf("flaky test. There are still servers: %+v\n", servers)
 						return false
 					}
-					fmt.Printf("flaky test. OK after %s\n", time.Since(start).String())
 					return true
-				}, 2*timeout, interval).WithArguments(time.Now()).Should(BeTrue())
+				}, timeout, interval).WithArguments(time.Now()).Should(BeTrue())
 
 				By("checking that bootstrap condition is not ready")
 

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -18,9 +18,6 @@ package controllers
 
 import (
 	"testing"
-	"time"
-
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
 
@@ -372,7 +370,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			It("creates the HCloud machine in Hetzner 1", func() {
 				By("checking that no servers exist")
 
-				Eventually(func(start time.Time) bool {
+				Eventually(func() bool {
 					servers, err := hcloudClient.ListServers(ctx, hcloud.ServerListOpts{
 						ListOpts: hcloud.ListOpts{
 							LabelSelector: utils.LabelsToLabelSelector(map[string]string{hetznerCluster.ClusterTagKey(): "owned"}),
@@ -385,7 +383,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 						return false
 					}
 					return true
-				}, timeout, interval).WithArguments(time.Now()).Should(BeTrue())
+				}, timeout, interval).Should(BeTrue())
 
 				By("checking that bootstrap condition is not ready")
 

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -322,7 +322,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				// remove bootstrap infos
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{}
 				Expect(testEnv.Create(ctx, capiMachine)).To(Succeed())
@@ -519,7 +519,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hetznerCluster.Spec.HCloudNetwork.Enabled = false
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 				Expect(testEnv.Create(ctx, hcloudMachine)).To(Succeed())
@@ -548,7 +548,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hetznerCluster.Spec.HCloudPlacementGroups = nil
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 
@@ -616,7 +616,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		Context("with public network specs", func() {
 			var hcloudClient hcloudclient.Client
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hcloudMachine.Spec.PublicNetwork = &infrav1.PublicNetworkSpec{
 					EnableIPv4: false,
 					EnableIPv6: false,

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -322,7 +322,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				// remove bootstrap infos
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{}
 				Expect(testEnv.Create(ctx, capiMachine)).To(Succeed())
@@ -519,7 +519,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				hetznerCluster.Spec.HCloudNetwork.Enabled = false
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 				Expect(testEnv.Create(ctx, hcloudMachine)).To(Succeed())
@@ -548,7 +548,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				hetznerCluster.Spec.HCloudPlacementGroups = nil
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 
@@ -616,7 +616,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		Context("with public network specs", func() {
 			var hcloudClient hcloudclient.Client
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				hcloudMachine.Spec.PublicNetwork = &infrav1.PublicNetworkSpec{
 					EnableIPv4: false,
 					EnableIPv6: false,

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -189,7 +189,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 	Context("Basic test", func() {
 		var hcloudClient hcloudclient.Client
 		BeforeEach(func() {
-			hcloudClient = testEnv.ResetAndGetHCloudClient()
+			hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 		})
 
 		It("creates the hcloudRemediation successfully", func() {

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
@@ -186,6 +187,11 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 	})
 
 	Context("Basic test", func() {
+		var hcloudClient hcloudclient.Client
+		BeforeEach(func() {
+			hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+		})
+
 		It("creates the hcloudRemediation successfully", func() {
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -189,7 +189,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 	Context("Basic test", func() {
 		var hcloudClient hcloudclient.Client
 		BeforeEach(func() {
-			hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+			hcloudClient = testEnv.ResetAndGetHCloudClient()
 		})
 
 		It("creates the hcloudRemediation successfully", func() {

--- a/controllers/hetznerbaremetalremediation_controller_test.go
+++ b/controllers/hetznerbaremetalremediation_controller_test.go
@@ -257,7 +257,7 @@ var _ = Describe("HetznerBareMetalRemediationReconciler", func() {
 					Expect(testEnv.Cleanup(ctx, hetznerBareMetalRemediation, hetznerBaremetalMachine)).To(Succeed())
 				})
 
-				It("should not remediate if no annotations is present in the hetznerBaremetalMachine (flaky)", func() {
+				It("should not remediate if no annotations is present in the hetznerBaremetalMachine", func() {
 					Expect(testEnv.Create(ctx, hetznerBaremetalMachine)).To(Succeed())
 					Expect(testEnv.Create(ctx, hetznerBareMetalRemediation)).To(Succeed())
 

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 			})
 
 			It("should create load balancer and update it accordingly", func() {
@@ -745,7 +745,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())
 			})
@@ -785,7 +785,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetHCloudClient()
+				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				// Create the bootstrap secret
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
@@ -333,6 +334,12 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 		})
 
 		Context("load balancer", func() {
+			var hcloudClient hcloudclient.Client
+
+			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+			})
+
 			It("should create load balancer and update it accordingly", func() {
 				Expect(testEnv.Create(ctx, instance)).To(Succeed())
 
@@ -735,8 +742,10 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 
 		Context("HetznerMachines belonging to the cluster", func() {
 			var bootstrapSecret *corev1.Secret
+			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())
 			})
@@ -773,8 +782,10 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 
 		Context("Placement groups", func() {
 			var bootstrapSecret *corev1.Secret
+			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
+				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 				// Create the bootstrap secret
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 			})
 
 			It("should create load balancer and update it accordingly", func() {
@@ -745,7 +745,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())
 			})
@@ -785,7 +785,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.HCloudClientFactory.NewClient("")
+				hcloudClient = testEnv.ResetAndGetHCloudClient()
 				// Create the bootstrap secret
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -40,7 +40,8 @@ var ErrUnauthorized = fmt.Errorf("unauthorized")
 
 // Client collects all methods used by the controller in the hcloud cloud API.
 type Client interface {
-	Close()
+	// Reset resets the local cache. Only implemented in the fake client.
+	Reset() Client
 
 	CreateLoadBalancer(context.Context, hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error)
 	DeleteLoadBalancer(context.Context, int64) error
@@ -141,8 +142,10 @@ type realClient struct {
 	client *hcloud.Client
 }
 
-// Close implements the Close method of the HCloudClient interface.
-func (c *realClient) Close() {}
+// Reset implements the Reset method of the HCloudClient interface.
+func (c *realClient) Reset() Client {
+	return c
+}
 
 func (c *realClient) CreateLoadBalancer(ctx context.Context, opts hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error) {
 	res, _, err := c.client.LoadBalancer.Create(ctx, opts)

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -79,6 +79,7 @@ type Client interface {
 
 // Factory is the interface for creating new Client objects.
 type Factory interface {
+	// NewClient returns a new Client in the real implementation, and the shared global Client in the fake implementation.
 	NewClient(hcloudToken string) Client
 }
 

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -55,8 +55,8 @@ func (f *cacheHCloudClientFactory) NewClient(string) hcloudclient.Client {
 	return cacheHCloudClientInstance
 }
 
-// Close implements Close method of hcloud client interface.
-func (c *cacheHCloudClient) Close() {
+// Reset implements Reset method of hcloud client interface.
+func (c *cacheHCloudClient) Reset() hcloudclient.Client {
 	c.counterMutex.Lock()
 	defer c.counterMutex.Unlock()
 
@@ -86,6 +86,7 @@ func (c *cacheHCloudClient) Close() {
 	cacheHCloudClientInstance.placementGroupIDCounter = 0
 	cacheHCloudClientInstance.loadBalancerIDCounter = 0
 	cacheHCloudClientInstance.networkIDCounter = 0
+	return c
 }
 
 type cacheHCloudClientFactory struct{}

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	hcloud "github.com/hetznercloud/hcloud-go/v2/hcloud"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -714,8 +715,23 @@ func (_m *Client) RebootServer(_a0 context.Context, _a1 *hcloud.Server) error {
 }
 
 // Reset provides a mock function with given fields:
-func (_m *Client) Reset() {
-	_m.Called()
+func (_m *Client) Reset() hcloudclient.Client {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Reset")
+	}
+
+	var r0 hcloudclient.Client
+	if rf, ok := ret.Get(0).(func() hcloudclient.Client); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(hcloudclient.Client)
+		}
+	}
+
+	return r0
 }
 
 // ShutdownServer provides a mock function with given fields: _a0, _a1

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -161,11 +161,6 @@ func (_m *Client) ChangeLoadBalancerType(_a0 context.Context, _a1 *hcloud.LoadBa
 	return r0
 }
 
-// Close provides a mock function with given fields:
-func (_m *Client) Close() {
-	_m.Called()
-}
-
 // CreateLoadBalancer provides a mock function with given fields: _a0, _a1
 func (_m *Client) CreateLoadBalancer(_a0 context.Context, _a1 hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error) {
 	ret := _m.Called(_a0, _a1)
@@ -716,6 +711,11 @@ func (_m *Client) RebootServer(_a0 context.Context, _a1 *hcloud.Server) error {
 	}
 
 	return r0
+}
+
+// Reset provides a mock function with given fields:
+func (_m *Client) Reset() {
+	_m.Called()
 }
 
 // ShutdownServer provides a mock function with given fields: _a0, _a1

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -257,6 +257,11 @@ func (t *TestEnvironment) CreateKubeconfigSecret(ctx context.Context, cluster *c
 	return t.Create(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(t.Config, cluster)))
 }
 
+// ResetAndGetHCloudClient resets the cache of the fake Client and returns it.
+func (t *TestEnvironment) ResetAndGetHCloudClient() hcloudclient.Client {
+	return t.HCloudClientFactory.NewClient("").Reset()
+}
+
 func getFilePathToCAPICRDs(root string) string {
 	mod, err := newMod(filepath.Join(root, "go.mod"))
 	if err != nil {

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -257,8 +257,8 @@ func (t *TestEnvironment) CreateKubeconfigSecret(ctx context.Context, cluster *c
 	return t.Create(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(t.Config, cluster)))
 }
 
-// ResetAndGetHCloudClient resets the cache of the fake Client and returns it.
-func (t *TestEnvironment) ResetAndGetHCloudClient() hcloudclient.Client {
+// ResetAndGetGlobalHCloudClient resets the cache of the fake Client and returns it.
+func (t *TestEnvironment) ResetAndGetGlobalHCloudClient() hcloudclient.Client {
 	return t.HCloudClientFactory.NewClient("").Reset()
 }
 


### PR DESCRIPTION
Avoid global hcloudClient. The hcloudClient got created once, and stored in a global variable. If the previous test left a fake hcloud-server in the client, then the next test sees a different result from hcloudClient.ListServers().
