### PR TITLE
:seedling: Fix typos in docs.

### DIFF
--- a/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
+++ b/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
@@ -51,7 +51,6 @@ For production use, a “real” Kubernetes cluster should be used with appropri
 ### Install Clusterctl
 
 To install Clusterctl, refer to the instructions available in the official ClusterAPI documentation [here](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl).
-Alternatively, use the `make install-clusterctl` command to do the same.
 
 ### Initialize the management cluster
 

--- a/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
+++ b/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
@@ -73,13 +73,9 @@ For a specific version, use the `--infrastructure hetzner:vX.X.X` flag with the 
 ## Variable Preparation to generate a cluster-template
 
 ```shell
-export SSH_KEY_NAME="<ssh-key-name>" \
-export CLUSTER_NAME="my-cluster" \
-export HCLOUD_REGION="fsn1" \
-export CONTROL_PLANE_MACHINE_COUNT=3 \
-export WORKER_MACHINE_COUNT=3 \
-export KUBERNETES_VERSION=1.29.4 \
-export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31 \
+export SSH_KEY_NAME="<ssh-key-name>"
+export HCLOUD_REGION="fsn1"
+export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31
 export HCLOUD_WORKER_MACHINE_TYPE=cpx31
 ```
 

--- a/docs/caph/01-getting-started/03-preparation.md
+++ b/docs/caph/01-getting-started/03-preparation.md
@@ -66,13 +66,13 @@ Or for a specific [version](https://github.com/syself/cluster-api-provider-hetzn
 ## Variable Preparation to generate a cluster-template
 
 ```shell
-export SSH_KEY_NAME="<ssh-key-name>" \
-export CLUSTER_NAME="my-cluster" \
-export HCLOUD_REGION="fsn1" \
-export CONTROL_PLANE_MACHINE_COUNT=3 \
-export WORKER_MACHINE_COUNT=3 \
-export KUBERNETES_VERSION=1.29.4 \
-export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31 \
+export SSH_KEY_NAME="<ssh-key-name>"
+export CLUSTER_NAME="my-cluster"
+export HCLOUD_REGION="fsn1"
+export CONTROL_PLANE_MACHINE_COUNT=3
+export WORKER_MACHINE_COUNT=3
+export KUBERNETES_VERSION=1.29.4
+export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31
 export HCLOUD_WORKER_MACHINE_TYPE=cpx31
 ```
 
@@ -120,10 +120,10 @@ The secret name and the tokens can also be customized in the cluster template.
 In order for the provider integration hetzner to communicate with the Hetzner API ([HCloud API](https://docs.hetzner.cloud/) + [Robot API](https://robot.your-server.de/doc/webservice/en.html#preface)), we need to create a secret with the access data. The secret must be in the same namespace as the other CRs.
 
 ```shell
-export HCLOUD_TOKEN="<YOUR-TOKEN>" \
-export HETZNER_ROBOT_USER="<YOUR-ROBOT-USER>" \
-export HETZNER_ROBOT_PASSWORD="<YOUR-ROBOT-PASSWORD>" \
-export HETZNER_SSH_PUB_PATH="<YOUR-SSH-PUBLIC-PATH>" \
+export HCLOUD_TOKEN="<YOUR-TOKEN>"
+export HETZNER_ROBOT_USER="<YOUR-ROBOT-USER>"
+export HETZNER_ROBOT_PASSWORD="<YOUR-ROBOT-PASSWORD>"
+export HETZNER_SSH_PUB_PATH="<YOUR-SSH-PUBLIC-PATH>"
 export HETZNER_SSH_PRIV_PATH="<YOUR-SSH-PRIVATE-PATH>"
 ```
 

--- a/docs/caph/02-topics/05-baremetal/02-management-cluster.md
+++ b/docs/caph/02-topics/05-baremetal/02-management-cluster.md
@@ -128,11 +128,11 @@ We create two secrets named `hetzner` for Hetzner Cloud and Robot API access and
 The `hetzner` secret contains API token for hcloud token. It also contains username and password that is used to interact with robot API. `robot-ssh` secret contains the public-key, private-key and name of the ssh-key used for baremetal servers.
 
 ```shell
-export HCLOUD_TOKEN="<YOUR-TOKEN>" \
-export HETZNER_ROBOT_USER="<YOUR-ROBOT-USER>" \
-export HETZNER_ROBOT_PASSWORD="<YOUR-ROBOT-PASSWORD>" \
-export SSH_KEY_NAME="<YOUR-SSH-KEY-NAME>" \
-export HETZNER_SSH_PUB_PATH="<YOUR-SSH-PUBLIC-PATH>" \
+export HCLOUD_TOKEN="<YOUR-TOKEN>"
+export HETZNER_ROBOT_USER="<YOUR-ROBOT-USER>"
+export HETZNER_ROBOT_PASSWORD="<YOUR-ROBOT-PASSWORD>"
+export SSH_KEY_NAME="<YOUR-SSH-KEY-NAME>"
+export HETZNER_SSH_PUB_PATH="<YOUR-SSH-PUBLIC-PATH>"
 export HETZNER_SSH_PRIV_PATH="<YOUR-SSH-PRIVATE-PATH>"
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The make target `install-clusterctl` does not exist anymore.
