### PR TITLE
:seedling: Fix flaky tests 2

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
 
@@ -44,10 +45,10 @@ const (
 )
 
 var (
-	testEnv *helpers.TestEnvironment
-	ctx     = ctrl.SetupSignalHandler()
-	wg      sync.WaitGroup
-
+	testEnv                   *helpers.TestEnvironment
+	hcloudClient              hcloudclient.Client
+	ctx                       = ctrl.SetupSignalHandler()
+	wg                        sync.WaitGroup
 	defaultPlacementGroupName = "caph-placement-group"
 	defaultFailureDomain      = "fsn1"
 )
@@ -62,7 +63,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 
 	testEnv = helpers.NewTestEnvironment()
-
+	hcloudClient = testEnv.HCloudClientFactory.NewClient("")
 	wg.Add(1)
 
 	Expect((&HetznerClusterReconciler{

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
 
@@ -241,6 +240,8 @@ var _ = Describe("HCloudMachineReconciler", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
+
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachine-reconciler")
 		Expect(err).NotTo(HaveOccurred())
@@ -319,10 +320,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 
 	Context("Basic test", func() {
 		Context("correct server", func() {
-			var hcloudClient hcloudclient.Client
-
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				// remove bootstrap infos
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{}
 				Expect(testEnv.Create(ctx, capiMachine)).To(Succeed())
@@ -516,10 +514,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("without network", func() {
-			var hcloudClient hcloudclient.Client
-
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hetznerCluster.Spec.HCloudNetwork.Enabled = false
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 				Expect(testEnv.Create(ctx, hcloudMachine)).To(Succeed())
@@ -545,10 +540,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("without placement groups", func() {
-			var hcloudClient hcloudclient.Client
-
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hetznerCluster.Spec.HCloudPlacementGroups = nil
 				Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 
@@ -614,9 +606,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 		})
 
 		Context("with public network specs", func() {
-			var hcloudClient hcloudclient.Client
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				hcloudMachine.Spec.PublicNetwork = &infrav1.PublicNetworkSpec{
 					EnableIPv4: false,
 					EnableIPv6: false,
@@ -664,6 +654,7 @@ var _ = Describe("Hetzner secret", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachine-validation")
 		Expect(err).NotTo(HaveOccurred())
@@ -813,6 +804,8 @@ var _ = Describe("HCloudMachine validation", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
+
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachine-validation")
 		Expect(err).NotTo(HaveOccurred())
@@ -870,6 +863,8 @@ var _ = Describe("IgnoreInsignificantHetznerClusterUpdates Predicate", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
+
 		predicate = IgnoreInsignificantHetznerClusterUpdates(klog.Background())
 
 		oldCluster = &infrav1.HetznerCluster{

--- a/controllers/hcloudmachinetemplate_controller_test.go
+++ b/controllers/hcloudmachinetemplate_controller_test.go
@@ -38,6 +38,7 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
 		Expect(err).NotTo(HaveOccurred())

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
@@ -55,6 +54,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
 		Expect(err).NotTo(HaveOccurred())
@@ -187,11 +187,6 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 	})
 
 	Context("Basic test", func() {
-		var hcloudClient hcloudclient.Client
-		BeforeEach(func() {
-			hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
-		})
-
 		It("creates the hcloudRemediation successfully", func() {
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
@@ -271,6 +270,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			hetznerClusterName string
 		)
 		BeforeEach(func() {
+			hcloudClient.Reset()
 			testNs, err = testEnv.CreateNamespace(ctx, "cluster-tests")
 			Expect(err).NotTo(HaveOccurred())
 			namespace = testNs.Name
@@ -334,12 +334,6 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 		})
 
 		Context("load balancer", func() {
-			var hcloudClient hcloudclient.Client
-
-			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
-			})
-
 			It("should create load balancer and update it accordingly", func() {
 				Expect(testEnv.Create(ctx, instance)).To(Succeed())
 
@@ -742,10 +736,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 
 		Context("HetznerMachines belonging to the cluster", func() {
 			var bootstrapSecret *corev1.Secret
-			var hcloudClient hcloudclient.Client
-
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())
 			})
@@ -782,10 +773,8 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 
 		Context("Placement groups", func() {
 			var bootstrapSecret *corev1.Secret
-			var hcloudClient hcloudclient.Client
 
 			BeforeEach(func() {
-				hcloudClient = testEnv.ResetAndGetGlobalHCloudClient()
 				// Create the bootstrap secret
 				bootstrapSecret = getDefaultBootstrapSecret(namespace)
 				Expect(testEnv.Create(ctx, bootstrapSecret)).To(Succeed())
@@ -957,6 +946,7 @@ var _ = Describe("Hetzner secret", func() {
 	)
 
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hetzner-secret")
 		Expect(err).NotTo(HaveOccurred())
@@ -1054,6 +1044,7 @@ var _ = Describe("HetznerCluster validation", func() {
 		testNs         *corev1.Namespace
 	)
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		var err error
 		testNs, err = testEnv.CreateNamespace(ctx, "hcloudmachine-validation")
 		Expect(err).NotTo(HaveOccurred())
@@ -1139,6 +1130,7 @@ var _ = Describe("HetznerCluster validation", func() {
 var _ = Describe("reconcileRateLimit", func() {
 	var hetznerCluster *infrav1.HetznerCluster
 	BeforeEach(func() {
+		hcloudClient.Reset()
 		hetznerCluster = &infrav1.HetznerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "rate-limit-cluster",

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -41,7 +41,7 @@ var ErrUnauthorized = fmt.Errorf("unauthorized")
 // Client collects all methods used by the controller in the hcloud cloud API.
 type Client interface {
 	// Reset resets the local cache. Only implemented in the fake client.
-	Reset() Client
+	Reset()
 
 	CreateLoadBalancer(context.Context, hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error)
 	DeleteLoadBalancer(context.Context, int64) error
@@ -144,8 +144,8 @@ type realClient struct {
 }
 
 // Reset implements the Reset method of the HCloudClient interface.
-func (c *realClient) Reset() Client {
-	return c
+func (c *realClient) Reset() {
+	return
 }
 
 func (c *realClient) CreateLoadBalancer(ctx context.Context, opts hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error) {

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -145,7 +145,6 @@ type realClient struct {
 
 // Reset implements the Reset method of the HCloudClient interface.
 func (c *realClient) Reset() {
-	return
 }
 
 func (c *realClient) CreateLoadBalancer(ctx context.Context, opts hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error) {

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -56,7 +56,7 @@ func (f *cacheHCloudClientFactory) NewClient(string) hcloudclient.Client {
 }
 
 // Reset implements Reset method of hcloud client interface.
-func (c *cacheHCloudClient) Reset() hcloudclient.Client {
+func (c *cacheHCloudClient) Reset() {
 	c.counterMutex.Lock()
 	defer c.counterMutex.Unlock()
 
@@ -86,7 +86,6 @@ func (c *cacheHCloudClient) Reset() hcloudclient.Client {
 	cacheHCloudClientInstance.placementGroupIDCounter = 0
 	cacheHCloudClientInstance.loadBalancerIDCounter = 0
 	cacheHCloudClientInstance.networkIDCounter = 0
-	return c
 }
 
 type cacheHCloudClientFactory struct{}

--- a/pkg/services/hcloud/client/fake/hcloud_client_test.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 )
 
@@ -76,13 +75,13 @@ var _ = Describe("Load balancer", func() {
 		Subnets: []hcloud.NetworkSubnet{{IPRange: &net.IPNet{IP: net.IP("1.2.3.6")}}},
 	}
 
-	var client hcloudclient.Client
+	client := factory.NewClient("")
 
 	var lb *hcloud.LoadBalancer
 	var network *hcloud.Network
 
 	BeforeEach(func() {
-		client = factory.NewClient("").Reset()
+		client.Reset()
 		_, err := client.CreateLoadBalancer(ctx, opts)
 		Expect(err).To(Succeed())
 
@@ -424,11 +423,10 @@ var _ = Describe("Load balancer", func() {
 
 var _ = Describe("Images", func() {
 	var listOpts hcloud.ImageListOpts
-	var client hcloudclient.Client
+	client := factory.NewClient("")
 
 	BeforeEach(func() {
-		client = factory.NewClient("").Reset()
-
+		client.Reset()
 		listOpts.LabelSelector = "caph-image-name==fedora-control-plane"
 	})
 	It("lists at least one image", func() {
@@ -442,7 +440,7 @@ var _ = Describe("Server", func() {
 	var listOpts hcloud.ServerListOpts
 	listOpts.LabelSelector = labelSelector
 
-	var client hcloudclient.Client
+	client := factory.NewClient("")
 
 	opts := hcloud.ServerCreateOpts{
 		Name: "test-server",
@@ -465,9 +463,8 @@ var _ = Describe("Server", func() {
 	var network *hcloud.Network
 
 	BeforeEach(func() {
+		client.Reset()
 		var err error
-		client = factory.NewClient("").Reset()
-
 		server, err = client.CreateServer(ctx, opts)
 		Expect(err).To(Succeed())
 
@@ -610,7 +607,7 @@ var _ = Describe("Network", func() {
 	var listOpts hcloud.NetworkListOpts
 	listOpts.LabelSelector = labelSelector
 
-	var client hcloudclient.Client
+	client := factory.NewClient("")
 
 	opts := hcloud.NetworkCreateOpts{
 		Name: "test-network",
@@ -625,8 +622,8 @@ var _ = Describe("Network", func() {
 	var network *hcloud.Network
 
 	BeforeEach(func() {
+		client.Reset()
 		var err error
-		client = factory.NewClient("").Reset()
 		network, err = client.CreateNetwork(ctx, opts)
 		Expect(err).To(Succeed())
 	})
@@ -674,13 +671,13 @@ var _ = Describe("Placement groups", func() {
 		Type: "stream",
 	}
 
-	var client hcloudclient.Client
+	client := factory.NewClient("")
 	var server *hcloud.Server
 	var placementGroup *hcloud.PlacementGroup
 
 	BeforeEach(func() {
+		client.Reset()
 		var err error
-		client = factory.NewClient("").Reset()
 		server, err = client.CreateServer(ctx, hcloud.ServerCreateOpts{
 			Name: "test-server",
 			Labels: map[string]string{

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -6,7 +6,6 @@ import (
 	context "context"
 
 	hcloud "github.com/hetznercloud/hcloud-go/v2/hcloud"
-	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -715,23 +714,8 @@ func (_m *Client) RebootServer(_a0 context.Context, _a1 *hcloud.Server) error {
 }
 
 // Reset provides a mock function with given fields:
-func (_m *Client) Reset() hcloudclient.Client {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Reset")
-	}
-
-	var r0 hcloudclient.Client
-	if rf, ok := ret.Get(0).(func() hcloudclient.Client); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(hcloudclient.Client)
-		}
-	}
-
-	return r0
+func (_m *Client) Reset() {
+	_m.Called()
 }
 
 // ShutdownServer provides a mock function with given fields: _a0, _a1

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -257,11 +257,6 @@ func (t *TestEnvironment) CreateKubeconfigSecret(ctx context.Context, cluster *c
 	return t.Create(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(t.Config, cluster)))
 }
 
-// ResetAndGetGlobalHCloudClient resets the cache of the fake Client and returns it.
-func (t *TestEnvironment) ResetAndGetGlobalHCloudClient() hcloudclient.Client {
-	return t.HCloudClientFactory.NewClient("").Reset()
-}
-
 func getFilePathToCAPICRDs(root string) string {
 	mod, err := newMod(filepath.Join(root, "go.mod"))
 	if err != nil {


### PR DESCRIPTION
After the firs "fix flaky tests" PR was merged, there were still flaky tests.

This PR moves the Reset into upper most BeforeEach and introduces the global variable again.