### PR TITLE
:seedling: Fix hcloud ccm secret key ref.

### DIFF
--- a/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
+++ b/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
@@ -100,11 +100,11 @@ For a cluster without a private network, use the following command:
 helm repo add hcloud https://charts.hetzner.cloud
 helm repo update hcloud
 
-KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install hccm hcloud/hcloud-cloud-controller-manager --version 1.20.0 \
-	--namespace kube-system \
-	--set secret.name=hetzner \
-	--set secret.tokenKeyName=hcloud \
-	--set privateNetwork.enabled=false
+KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install hccm hcloud/hcloud-cloud-controller-manager \
+        --namespace kube-system \
+        --set env.HCLOUD_TOKEN.valueFrom.secretKeyRef.name=hetzner \
+        --set env.HCLOUD_TOKEN.valueFrom.secretKeyRef.key=hcloud \
+        --set privateNetwork.enabled=false
 ```
 
 ## Deploying the CSI (optional)


### PR DESCRIPTION
If you only use hcloud (not bare-metal) and you use the hcloud ccm, then the docs contained outdated values for the `helm` command to install the ccm.

Fixes #1444 Thank you @timkrase for reporting and providing a solution.
