### PR TITLE
✨Add flag to disable default CSR controller

### DIFF
--- a/docs/caph/02-topics/06-advanced/01-csr-controller.md
+++ b/docs/caph/02-topics/06-advanced/01-csr-controller.md
@@ -4,7 +4,11 @@ title: CSR controller
 
 For the secure operation of Kubernetes, it is necessary to sign the kubelet serving certificates. By default, these are self-signed by kubeadm. By using the kubelet flag `rotate-server-certificates: "true"`, which can be found in initConfiguration/joinConfiguration.nodeRegistration.kubeletExtraArgs, the kubelet will do a certificate signing request (CSR) to the certificates API of Kubernetes.
 
-These CSRs are not approved by default for security reasons. As described in the docs, this should be done manually by the cloud provider or with a custom approval controller. Since the provider integration is the responsible cloud provider in a way, it makes sense to implement such a controller directly here. The CSR controller that we implemented checks the DNS name and the IP address and thus ensures that only those nodes receive the signed certificate that are supposed to.
+These CSRs are not approved by default for security reasons. As described in the docs, this should be done manually by the cloud provider or with a custom approval controller.
+
+## Default CSR controller
+
+Since the provider integration is the responsible cloud provider in a way, it makes sense to implement such a controller directly here. The CSR controller that we implemented checks the DNS name and the IP address and thus ensures that only those nodes receive the signed certificate that are supposed to.
 
 For error-free operation, the following kubelet flags should not be set:
 
@@ -17,3 +21,16 @@ For more information, see:
 
 - [https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/)
 - [https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#client-and-serving-certificates)
+
+## Custom CSR controller
+
+It is possible to disable the CSR controller using the flag `--disable-csr-approval`. However, this flag disables this feature globally, for all `HetznerCluster` objects in the management cluster. There is currently no way to toggle this on or off for just a single cluster.
+
+This is useful for cases where the validation or approval logic of the default CSR controller is insufficient for your use cases.
+
+If you disable the default CSR controller, you'll need to deploy an equivalent controller that can validate and approve CSRs securely. This is a security critical process and needs to be handled with care.
+
+For more information, see:
+
+- [https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/)
+- [https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation](https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation)

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func init() {
 var (
 	metricsAddr                        string
 	enableLeaderElection               bool
+	disableCSRApproval                 bool
 	leaderElectionNamespace            string
 	probeAddr                          string
 	watchFilterValue                   string
@@ -83,6 +84,7 @@ func main() {
 	fs.StringVar(&metricsAddr, "metrics-bind-address", "localhost:8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":9440", "The address the probe endpoint binds to.")
 	fs.BoolVar(&enableLeaderElection, "leader-elect", true, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	fs.BoolVar(&disableCSRApproval, "disable-csr-approval", false, "Disables builtin workload cluster CSR validation and approval.")
 	fs.StringVar(&leaderElectionNamespace, "leader-elect-namespace", "", "Namespace that the controller performs leader election in. If unspecified, the controller will discover which namespace it is running in.")
 	fs.StringVar(&watchFilterValue, "watch-filter", "", fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
 	fs.StringVar(&watchNamespace, "namespace", "", "Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
@@ -147,6 +149,7 @@ func main() {
 		RateLimitWaitTime:              rateLimitWaitTime,
 		HCloudClientFactory:            hcloudClientFactory,
 		WatchFilterValue:               watchFilterValue,
+		DisableCSRApproval:             disableCSRApproval,
 		TargetClusterManagersWaitGroup: &wg,
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: hetznerClusterConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HetznerCluster")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a flag that disables the `GuestCSRReconciler` for all workload clusters. This allows users to implement the CSR validation/approval logic themselves, making caph able to manage Kubernetes clusters that do not rely on Hetzner External/Internal IPs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1478

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [x] include documentation
- [ ] add unit tests
