### PR TITLE
:seedling: set terminationMessagePolicy FallbackToLogsOnError.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,6 +60,7 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:


### PR DESCRIPTION


**What this PR does / why we need it**:
This advice was found in the CAPI Upgrade Guide (1.7 to 1.8).

