### PR TITLE
:seedling: More logging in check-disk.sh

### DIFF
--- a/pkg/services/baremetal/client/ssh/check-disk.sh
+++ b/pkg/services/baremetal/client/ssh/check-disk.sh
@@ -88,9 +88,9 @@ for wwn in "$@"; do
         exit 3
     fi
     echo "Checking WWN=$wwn device=$device"
-    smartctl -H "/dev/$device" | { grep -vP '^(smartctl \d+\.\d+.*|Copyright|=+ START OF)' || true; } |
+    { smartctl -H "/dev/$device" || true; } | { grep -vP '^(smartctl \d+\.\d+.*|Copyright|=+ START OF)' || true; } |
         { grep -v '^$' || true; } |
-        sed "s#^#$wwn (/dev/$device): #" >>"$result"
+        { sed "s#^#$wwn (/dev/$device): #" || true; } >>"$result"
 done
 errors=$(grep -v PASSED "$result" || true)
 if [ -n "$errors" ]; then

--- a/pkg/services/baremetal/client/ssh/check-disk.sh
+++ b/pkg/services/baremetal/client/ssh/check-disk.sh
@@ -87,6 +87,7 @@ for wwn in "$@"; do
         echo "Failed to find device for WWN $wwn"
         exit 3
     fi
+    echo "Checking WWN=$wwn device=$device"
     smartctl -H "/dev/$device" | { grep -vP '^(smartctl \d+\.\d+.*|Copyright|=+ START OF)' || true; } |
         { grep -v '^$' || true; } |
         sed "s#^#$wwn (/dev/$device): #" >>"$result"
@@ -98,5 +99,7 @@ if [ -n "$errors" ]; then
     echo "$errors"
     exit 1
 fi
+echo "check-disk passed. Provided WWNs look healthy."
+echo
 cat "$result"
 exit 0

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -573,9 +573,10 @@ chmod a+rx /root/detect-linux-on-another-disk.sh
 }
 
 var (
-	// I found no details about the format. I found these examples
-	// 10:00:00:05:1e:7a:7a:00 eui.00253885910c8cec 0x500a07511bb48b25
-	isValidWWNRegex = regexp.MustCompile(`^[0-9a-zA-Z.:-]{5,64}$`)
+	// I found no details about the format. I found these examples:
+	// 10:00:00:05:1e:7a:7a:00 eui.00253885910c8cec 0x500a07511bb48b25 alias.CDIMS1_A3:20:54:d0:39:ea:3d:b8:74
+	// https://www.reddit.com/r/zfs/comments/1glttvl/validate_wwn/
+	isValidWWNRegex = regexp.MustCompile(`^[0-9a-zA-Z._=:-]{5,64}$`)
 
 	// ErrInvalidWWN indicates that a WWN has an invalid syntax.
 	ErrInvalidWWN = fmt.Errorf("WWN does not match regex %q", isValidWWNRegex.String())


### PR DESCRIPTION
We found a strange issue with the check-disk.sh script. We add more output to the script, so that we can debug that better if it happens again. No fix, just more logging.

And the regex for valid WWNs was extended.
