### PR TITLE
✨ Backwards compatible support for containerd 2

### DIFF
--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -164,9 +164,36 @@ spec:
           nameserver 1.1.1.1
           nameserver 1.0.0.1
           nameserver 2606:4700:4700::1111
+      - content: |
+          [Unit]
+          Description=containerd container runtime
+          Documentation=https://containerd.io
+          After=network.target local-fs.target dbus.service
+
+          [Service]
+          ExecStartPre=-/sbin/modprobe overlay
+          ExecStart=/usr/local/bin/containerd
+
+          Type=notify
+          Delegate=yes
+          KillMode=process
+          Restart=always
+          RestartSec=5
+          LimitNPROC=infinity
+          LimitCORE=infinity
+          LimitNOFILE=infinity
+          TasksMax=infinity
+          OOMScoreAdjust=-999
+
+          [Install]
+          WantedBy=multi-user.target
+        owner: root:root
+        path: /etc/systemd/system/containerd.service
+        permissions: "0744"
     preKubeadmCommands:
       - set -x
       - export CONTAINERD=1.7.24 # update: datasource=github-tags depName=containerd/containerd extractVersion=^v(?<version>.*)$ versioning=semver
+      - export RUNC=1.2.3
       - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
       - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
       - ARCH=amd64
@@ -178,12 +205,17 @@ spec:
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
       - modprobe overlay && modprobe br_netfilter && sysctl --system
-      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz
-      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-      - sha256sum --check cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-      - tar --no-overwrite-dir -C / -xzf cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz
-      - rm -f cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-      - chmod -R 644 /etc/cni && chown -R root:root /etc/cni
+      - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.$ARCH
+      - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.sha256sum
+      - sha256sum --check --ignore-missing runc.sha256sum
+      - install runc.$ARCH /usr/local/sbin/runc
+      - rm -f runc.$ARCH runc.sha256sum
+      - chmod a+x /usr/local/sbin/runc
+      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
+      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+      - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+      - tar -zxf containerd-$CONTAINERD-linux-$ARCH.tar.gz -C /usr/local
+      - rm -f containerd-$CONTAINERD-linux-$ARCH.tar.gz containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
       - mkdir -p /etc/containerd
       - containerd config default > /etc/containerd/config.toml
       - sed -i  "s/SystemdCgroup = false/SystemdCgroup = true/" /etc/containerd/config.toml

--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -196,8 +196,7 @@ spec:
       - export RUNC=1.2.3
       - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
       - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
-      - ARCH=amd64
-      - if [ "$(uname -m)" = "aarch64" ]; then ARCH=arm64; fi
+      - ARCH="$(dpkg --print-architecture)"
       - localectl set-locale LANG=en_US.UTF-8
       - localectl set-locale LANGUAGE=en_US.UTF-8
       - apt-get update -y

--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -165,6 +165,22 @@ spec:
           nameserver 1.0.0.1
           nameserver 2606:4700:4700::1111
       - content: |
+          # Copyright The containerd Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+          # https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+
           [Unit]
           Description=containerd container runtime
           Documentation=https://containerd.io
@@ -179,9 +195,14 @@ spec:
           KillMode=process
           Restart=always
           RestartSec=5
+
+          # Having non-zero Limit*s causes performance problems due to accounting overhead
+          # in the kernel. We recommend using cgroups to do container-local accounting.
           LimitNPROC=infinity
           LimitCORE=infinity
-          LimitNOFILE=infinity
+
+          # Comment TasksMax if your systemd version does not supports it.
+          # Only systemd 226 and above support this version.
           TasksMax=infinity
           OOMScoreAdjust=-999
 

--- a/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
@@ -210,7 +210,6 @@ spec:
       - sha256sum --check --ignore-missing runc.sha256sum
       - install runc.$ARCH /usr/local/sbin/runc
       - rm -f runc.$ARCH runc.sha256sum
-      - chmod a+x /usr/local/sbin/runc
       - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
       - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
       - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -227,7 +227,6 @@ spec:
       - sha256sum --check --ignore-missing runc.sha256sum
       - install runc.$ARCH /usr/local/sbin/runc
       - rm -f runc.$ARCH runc.sha256sum
-      - chmod a+x /usr/local/sbin/runc
       - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
       - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
       - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -183,9 +183,36 @@ spec:
           nameserver 1.1.1.1
           nameserver 1.0.0.1
           nameserver 2606:4700:4700::1111
+      - content: |
+          [Unit]
+          Description=containerd container runtime
+          Documentation=https://containerd.io
+          After=network.target local-fs.target dbus.service
+
+          [Service]
+          ExecStartPre=-/sbin/modprobe overlay
+          ExecStart=/usr/local/bin/containerd
+
+          Type=notify
+          Delegate=yes
+          KillMode=process
+          Restart=always
+          RestartSec=5
+          LimitNPROC=infinity
+          LimitCORE=infinity
+          LimitNOFILE=infinity
+          TasksMax=infinity
+          OOMScoreAdjust=-999
+
+          [Install]
+          WantedBy=multi-user.target
+        owner: root:root
+        path: /etc/systemd/system/containerd.service
+        permissions: "0744"
     preKubeadmCommands:
       - set -x
       - export CONTAINERD=1.7.24 # update: datasource=github-tags depName=containerd/containerd extractVersion=^v(?<version>.*)$ versioning=semver
+      - export RUNC=1.2.3
       - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
       - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
       - localectl set-locale LANG=en_US.UTF-8
@@ -195,12 +222,17 @@ spec:
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
       - modprobe overlay && modprobe br_netfilter && sysctl --system
-      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz
-      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
-      - sha256sum --check cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
-      - tar --no-overwrite-dir -C / -xzf cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz
-      - rm -f cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz cri-containerd-cni-$CONTAINERD-linux-amd64.tar.gz.sha256sum
-      - chmod -R 644 /etc/cni && chown -R root:root /etc/cni
+      - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.$ARCH
+      - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.sha256sum
+      - sha256sum --check --ignore-missing runc.sha256sum
+      - install runc.$ARCH /usr/local/sbin/runc
+      - rm -f runc.$ARCH runc.sha256sum
+      - chmod a+x /usr/local/sbin/runc
+      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
+      - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+      - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+      - tar -zxf containerd-$CONTAINERD-linux-$ARCH.tar.gz -C /usr/local
+      - rm -f containerd-$CONTAINERD-linux-$ARCH.tar.gz containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
       - mkdir -p /etc/containerd
       - containerd config default > /etc/containerd/config.toml
       - sed -i  "s/SystemdCgroup = false/SystemdCgroup = true/" /etc/containerd/config.toml

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -184,6 +184,22 @@ spec:
           nameserver 1.0.0.1
           nameserver 2606:4700:4700::1111
       - content: |
+          # Copyright The containerd Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+          # https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+
           [Unit]
           Description=containerd container runtime
           Documentation=https://containerd.io
@@ -198,9 +214,14 @@ spec:
           KillMode=process
           Restart=always
           RestartSec=5
+
+          # Having non-zero Limit*s causes performance problems due to accounting overhead
+          # in the kernel. We recommend using cgroups to do container-local accounting.
           LimitNPROC=infinity
           LimitCORE=infinity
-          LimitNOFILE=infinity
+
+          # Comment TasksMax if your systemd version does not supports it.
+          # Only systemd 226 and above support this version.
           TasksMax=infinity
           OOMScoreAdjust=-999
 

--- a/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -215,6 +215,7 @@ spec:
       - export RUNC=1.2.3
       - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
       - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
+      - ARCH="$(dpkg --print-architecture)"
       - localectl set-locale LANG=en_US.UTF-8
       - localectl set-locale LANGUAGE=en_US.UTF-8
       - apt-get update -y

--- a/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
@@ -53,6 +53,22 @@ spec:
             nameserver 1.0.0.1
             nameserver 2606:4700:4700::1111
         - content: |
+          # Copyright The containerd Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+          #
+          # https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+
           [Unit]
           Description=containerd container runtime
           Documentation=https://containerd.io
@@ -67,9 +83,14 @@ spec:
           KillMode=process
           Restart=always
           RestartSec=5
+
+          # Having non-zero Limit*s causes performance problems due to accounting overhead
+          # in the kernel. We recommend using cgroups to do container-local accounting.
           LimitNPROC=infinity
           LimitCORE=infinity
-          LimitNOFILE=infinity
+
+          # Comment TasksMax if your systemd version does not supports it.
+          # Only systemd 226 and above support this version.
           TasksMax=infinity
           OOMScoreAdjust=-999
 

--- a/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
@@ -85,8 +85,7 @@ spec:
         - export RUNC=1.2.3
         - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
         - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
-        - ARCH=amd64
-        - if [ "$(uname -m)" = "aarch64" ]; then ARCH=arm64; fi
+        - ARCH="$(dpkg --print-architecture)"
         - localectl set-locale LANG=en_US.UTF-8
         - localectl set-locale LANGUAGE=en_US.UTF-8
         - apt-get update -y

--- a/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
@@ -52,10 +52,37 @@ spec:
             nameserver 1.1.1.1
             nameserver 1.0.0.1
             nameserver 2606:4700:4700::1111
+        - content: |
+          [Unit]
+          Description=containerd container runtime
+          Documentation=https://containerd.io
+          After=network.target local-fs.target dbus.service
+
+          [Service]
+          ExecStartPre=-/sbin/modprobe overlay
+          ExecStart=/usr/local/bin/containerd
+
+          Type=notify
+          Delegate=yes
+          KillMode=process
+          Restart=always
+          RestartSec=5
+          LimitNPROC=infinity
+          LimitCORE=infinity
+          LimitNOFILE=infinity
+          TasksMax=infinity
+          OOMScoreAdjust=-999
+
+          [Install]
+          WantedBy=multi-user.target
+        owner: root:root
+        path: /etc/systemd/system/containerd.service
+        permissions: "0744"
       preKubeadmCommands:
         - set -x
         - grep VERSION= /etc/os-release; uname -a
         - export CONTAINERD=1.7.24 # update: datasource=github-tags depName=containerd/containerd extractVersion=^v(?<version>.*)$ versioning=semver
+        - export RUNC=1.2.3
         - export KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//')
         - export TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/^v//' | awk -F . '{print $1 "." $2}')
         - ARCH=amd64
@@ -67,12 +94,17 @@ spec:
         - sed -i '/swap/d' /etc/fstab
         - swapoff -a
         - modprobe overlay && modprobe br_netfilter && sysctl --system
-        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz
-        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-        - sha256sum --check cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-        - tar --no-overwrite-dir -C / -xzf cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz
-        - rm -f cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz cri-containerd-cni-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
-        - chmod -R 644 /etc/cni && chown -R root:root /etc/cni
+        - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.$ARCH
+        - wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.sha256sum
+        - sha256sum --check --ignore-missing runc.sha256sum
+        - install runc.$ARCH /usr/local/sbin/runc
+        - rm -f runc.$ARCH runc.sha256sum
+        - chmod a+x /usr/local/sbin/runc
+        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
+        - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+        - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+        - tar -zxf containerd-$CONTAINERD-linux-$ARCH.tar.gz -C /usr/local
+        - rm -f containerd-$CONTAINERD-linux-$ARCH.tar.gz containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
         - mkdir -p /etc/containerd
         - containerd config default > /etc/containerd/config.toml
         - sed -i  "s/SystemdCgroup = false/SystemdCgroup = true/" /etc/containerd/config.toml

--- a/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
@@ -99,7 +99,6 @@ spec:
         - sha256sum --check --ignore-missing runc.sha256sum
         - install runc.$ARCH /usr/local/sbin/runc
         - rm -f runc.$ARCH runc.sha256sum
-        - chmod a+x /usr/local/sbin/runc
         - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
         - wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
         - sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum

--- a/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/cri.sh
+++ b/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/cri.sh
@@ -47,25 +47,53 @@ kernel.panic=10
 kernel.panic_on_oops=1
 EOF
 
+# Create containerd systemd unit
+cat >/etc/systemd/system/containerd.service <<'EOF'
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target dbus.service
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/containerd
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 # Apply sysctl params without reboot
 sysctl --system
 
+ARCH="$(dpkg --print-architecture)"
 CONTAINERD=1.7.16 # https://github.com/containerd/containerd/releases
+RUNC=1.2.3 # https://github.com/opencontainers/runc/releases
+
+# Install runc
+wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.$ARCH
+wget https://github.com/opencontainers/runc/releases/download/v$RUNC/runc.sha256sum
+sha256sum --check --ignore-missing runc.sha256sum
+install runc.$ARCH /usr/local/sbin/runc
 
 # Install containerd
-wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD}/cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz
-wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD}/cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz.sha256sum
-sha256sum --check cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz.sha256sum
-tar --no-overwrite-dir -C / -xzf cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz
+wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz
+wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD/containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+sha256sum --check containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
+tar -zxf containerd-$CONTAINERD-linux-$ARCH.tar.gz -C /usr/local
 
 # Cleanup
-rm -f cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz cri-containerd-cni-${CONTAINERD}-linux-${PACKER_ARCH}.tar.gz.sha256sum
-
-mkdir -p /etc/containerd
-
-# Sets permission accordingly to CIS Benchmark
-chmod -R 644 /etc/cni
-chown -R root:root /etc/cni
+rm -f runc.$ARCH runc.sha256sum
+rm -f containerd-$CONTAINERD-linux-$ARCH.tar.gz containerd-$CONTAINERD-linux-$ARCH.tar.gz.sha256sum
 
 mkdir -p /etc/containerd
 containerd config default >/etc/containerd/config.toml

--- a/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/cri.sh
+++ b/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/cri.sh
@@ -49,6 +49,22 @@ EOF
 
 # Create containerd systemd unit
 cat >/etc/systemd/system/containerd.service <<'EOF'
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
@@ -57,14 +73,20 @@ After=network.target local-fs.target dbus.service
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
+
 Type=notify
 Delegate=yes
 KillMode=process
 Restart=always
 RestartSec=5
+
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=infinity
+
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
 TasksMax=infinity
 OOMScoreAdjust=-999
 

--- a/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -36,6 +36,7 @@ kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
 # Sets permission accordingly to CIS Benchmark
 chmod -R 644 /etc/cni
+chown -R root:root /etc/cni
 
 # enable completion
 echo 'source <(kubectl completion bash)' >>/root/.bashrc

--- a/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.28.9-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -34,6 +34,9 @@ systemctl enable kubelet
 
 kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
+# Sets permission accordingly to CIS Benchmark
+chmod -R 644 /etc/cni
+
 # enable completion
 echo 'source <(kubectl completion bash)' >>/root/.bashrc
 

--- a/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/cri.sh
+++ b/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/cri.sh
@@ -49,6 +49,22 @@ EOF
 
 # Create containerd systemd unit
 cat >/etc/systemd/system/containerd.service <<'EOF'
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
@@ -57,14 +73,20 @@ After=network.target local-fs.target dbus.service
 [Service]
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/containerd
+
 Type=notify
 Delegate=yes
 KillMode=process
 Restart=always
 RestartSec=5
+
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=infinity
+
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
 TasksMax=infinity
 OOMScoreAdjust=-999
 

--- a/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -36,6 +36,7 @@ kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
 # Sets permission accordingly to CIS Benchmark
 chmod -R 644 /etc/cni
+chown -R root:root /etc/cni
 
 # enable completion
 echo 'source <(kubectl completion bash)' >>/root/.bashrc

--- a/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
+++ b/templates/node-image/1.29.4-ubuntu-22-04-containerd/scripts/kubernetes.sh
@@ -34,6 +34,9 @@ systemctl enable kubelet
 
 kubeadm config images pull --kubernetes-version $KUBERNETES_VERSION
 
+# Sets permission accordingly to CIS Benchmark
+chmod -R 644 /etc/cni
+
 # enable completion
 echo 'source <(kubectl completion bash)' >>/root/.bashrc
 


### PR DESCRIPTION
**What this PR does / why we need it**: Backwards compatible support for containerd 2

**Fixes**: https://github.com/syself/cluster-api-provider-hetzner/issues/1522

**Special notes for your reviewer**: I used a variation of this over the holidays while testing CAPH. The support for the 'batteries included' containerd release was deprecated a while ago and removed in containerd 2.0. This change updates the Ubuntu quickstart templates and packer templates to use the supported packaging for containerd and separately installs runc. This was tested with containerd 1.7.24 and containerd 2.0.1. 

One subtle change to make note of is moving the hardening of /etc/cni permissions into kubernetes.sh for the packer templates. Previously the containerd 'batteries included' package included kubernetes-cni as well as being installed as a dependency of kubelet (from the Kubernetes apt repo). Now that kubernetes-cni is solely being installed as part of the kubernetes apt packaging I've moved the permissions change out of cri.sh and into kubernetes.sh.

Lastly I simplified setting ARCH to use dpkg instead of uname as, at least for Ubuntu and Debian, it's a much cleaner approach.

Feedback is greatly appreciated. One question I had is what is the purpose of the structed comment on the existing CONTAINERD version line (see following). It seems like the RUNC version might want something similar?

`export CONTAINERD=1.7.24 # update: datasource=github-tags depName=containerd/containerd extractVersion=^v(?<version>.*)$ versioning=semver`
