### PR TITLE
:seedling: Update condition while updating the provisioning state

### DIFF
--- a/pkg/services/baremetal/host/state_machine.go
+++ b/pkg/services/baremetal/host/state_machine.go
@@ -72,6 +72,11 @@ func (hsm *hostStateMachine) ReconcileState(ctx context.Context) (actionRes acti
 		if hsm.nextState != initialState {
 			hsm.log.V(1).Info("changing provisioning state", "old", initialState, "new", hsm.nextState)
 			hsm.host.Spec.Status.ProvisioningState = hsm.nextState
+
+			cond := conditions.Get(hsm.host, infrav1.ProvisionSucceededCondition)
+			if cond != nil && cond.Reason == infrav1.StillProvisioningReason {
+				markProvisionPending(hsm.host, hsm.nextState)
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: hetzner baremetal host's condition should be updated when the provisioning state is updated, this removes the time lag between the provisioning state and condition while provisioning the bare metal server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1541 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

