### PR TITLE
:seedling: Fix nil pointer in hcloud fake client

### DIFF
--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -654,10 +654,12 @@ func (c *cacheHCloudClient) ListNetworks(_ context.Context, opts hcloud.NetworkL
 }
 
 func (c *cacheHCloudClient) DeleteNetwork(_ context.Context, network *hcloud.Network) error {
-	if _, found := c.networkCache.idMap[network.ID]; !found {
+	c.counterMutex.Lock()
+	defer c.counterMutex.Unlock()
+	n, found := c.networkCache.idMap[network.ID]
+	if !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
-	n := c.networkCache.idMap[network.ID]
 	delete(c.networkCache.nameMap, n.Name)
 	delete(c.networkCache.idMap, network.ID)
 	return nil

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -43,7 +43,7 @@ type cacheHCloudClient struct {
 	placementGroupCache     placementGroupCache
 	loadBalancerCache       loadBalancerCache
 	networkCache            networkCache
-	counterMutex            sync.Mutex
+	mutex                   sync.RWMutex
 	serverIDCounter         int64
 	placementGroupIDCounter int64
 	loadBalancerIDCounter   int64
@@ -57,8 +57,8 @@ func (f *cacheHCloudClientFactory) NewClient(string) hcloudclient.Client {
 
 // Reset implements Reset method of hcloud client interface.
 func (c *cacheHCloudClient) Reset() {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	cacheHCloudClientInstance.serverCache = serverCache{}
 	cacheHCloudClientInstance.networkCache = networkCache{}
@@ -151,8 +151,8 @@ var defaultImage = hcloud.Image{
 }
 
 func (c *cacheHCloudClient) CreateLoadBalancer(_ context.Context, opts hcloud.LoadBalancerCreateOpts) (*hcloud.LoadBalancer, error) {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	// cannot have two load balancers with the same name
 	if _, found := c.loadBalancerCache.nameMap[opts.Name]; found {
@@ -189,16 +189,20 @@ func (c *cacheHCloudClient) CreateLoadBalancer(_ context.Context, opts hcloud.Lo
 }
 
 func (c *cacheHCloudClient) DeleteLoadBalancer(_ context.Context, id int64) error {
-	if _, found := c.loadBalancerCache.idMap[id]; !found {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	lb, found := c.loadBalancerCache.idMap[id]
+	if !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
-	lb := c.loadBalancerCache.idMap[id]
 	delete(c.loadBalancerCache.nameMap, lb.Name)
 	delete(c.loadBalancerCache.idMap, id)
 	return nil
 }
 
 func (c *cacheHCloudClient) ListLoadBalancers(_ context.Context, opts hcloud.LoadBalancerListOpts) ([]*hcloud.LoadBalancer, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	lbs := make([]*hcloud.LoadBalancer, 0, len(c.loadBalancerCache.idMap))
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
@@ -229,6 +233,8 @@ func (c *cacheHCloudClient) ListLoadBalancers(_ context.Context, opts hcloud.Loa
 }
 
 func (c *cacheHCloudClient) AttachLoadBalancerToNetwork(_ context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAttachToNetworkOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -256,6 +262,8 @@ func (c *cacheHCloudClient) AttachLoadBalancerToNetwork(_ context.Context, lb *h
 }
 
 func (c *cacheHCloudClient) ChangeLoadBalancerType(_ context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerChangeTypeOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -267,6 +275,8 @@ func (c *cacheHCloudClient) ChangeLoadBalancerType(_ context.Context, lb *hcloud
 }
 
 func (c *cacheHCloudClient) ChangeLoadBalancerAlgorithm(_ context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerChangeAlgorithmOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -278,6 +288,8 @@ func (c *cacheHCloudClient) ChangeLoadBalancerAlgorithm(_ context.Context, lb *h
 }
 
 func (c *cacheHCloudClient) UpdateLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerUpdateOpts) (*hcloud.LoadBalancer, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -297,6 +309,8 @@ func (c *cacheHCloudClient) UpdateLoadBalancer(_ context.Context, lb *hcloud.Loa
 }
 
 func (c *cacheHCloudClient) AddTargetServerToLoadBalancer(_ context.Context, opts hcloud.LoadBalancerAddServerTargetOpts, lb *hcloud.LoadBalancer) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -321,6 +335,8 @@ func (c *cacheHCloudClient) AddTargetServerToLoadBalancer(_ context.Context, opt
 }
 
 func (c *cacheHCloudClient) DeleteTargetServerOfLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, server *hcloud.Server) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -339,6 +355,8 @@ func (c *cacheHCloudClient) DeleteTargetServerOfLoadBalancer(_ context.Context, 
 }
 
 func (c *cacheHCloudClient) AddIPTargetToLoadBalancer(_ context.Context, opts hcloud.LoadBalancerAddIPTargetOpts, lb *hcloud.LoadBalancer) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -363,6 +381,8 @@ func (c *cacheHCloudClient) AddIPTargetToLoadBalancer(_ context.Context, opts hc
 }
 
 func (c *cacheHCloudClient) DeleteIPTargetOfLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, ip net.IP) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -381,6 +401,8 @@ func (c *cacheHCloudClient) DeleteIPTargetOfLoadBalancer(_ context.Context, lb *
 }
 
 func (c *cacheHCloudClient) AddServiceToLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddServiceOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -402,6 +424,8 @@ func (c *cacheHCloudClient) AddServiceToLoadBalancer(_ context.Context, lb *hclo
 }
 
 func (c *cacheHCloudClient) DeleteServiceFromLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, listenPort int) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if loadBalancer exists
 	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -420,6 +444,8 @@ func (c *cacheHCloudClient) DeleteServiceFromLoadBalancer(_ context.Context, lb 
 }
 
 func (c *cacheHCloudClient) ListImages(_ context.Context, opts hcloud.ImageListOpts) ([]*hcloud.Image, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	if opts.Name != "" {
 		return nil, nil
 	}
@@ -444,8 +470,8 @@ func (c *cacheHCloudClient) ListImages(_ context.Context, opts hcloud.ImageListO
 }
 
 func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCreateOpts) (*hcloud.Server, error) {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	if _, found := c.serverCache.nameMap[opts.Name]; found {
 		return nil, fmt.Errorf("already exists")
@@ -478,6 +504,8 @@ func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCr
 }
 
 func (c *cacheHCloudClient) AttachServerToNetwork(_ context.Context, server *hcloud.Server, opts hcloud.ServerAttachToNetworkOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if network exists
 	if _, found := c.networkCache.idMap[opts.Network.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -501,6 +529,8 @@ func (c *cacheHCloudClient) AttachServerToNetwork(_ context.Context, server *hcl
 }
 
 func (c *cacheHCloudClient) ListServers(_ context.Context, opts hcloud.ServerListOpts) ([]*hcloud.Server, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	servers := make([]*hcloud.Server, 0, len(c.serverCache.idMap))
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
@@ -524,10 +554,14 @@ func (c *cacheHCloudClient) ListServers(_ context.Context, opts hcloud.ServerLis
 }
 
 func (c *cacheHCloudClient) GetServer(_ context.Context, id int64) (*hcloud.Server, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	return c.serverCache.idMap[id], nil
 }
 
 func (c *cacheHCloudClient) ShutdownServer(_ context.Context, server *hcloud.Server) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	if _, found := c.serverCache.idMap[server.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
@@ -540,6 +574,8 @@ func (c *cacheHCloudClient) RebootServer(_ context.Context, _ *hcloud.Server) er
 }
 
 func (c *cacheHCloudClient) PowerOnServer(_ context.Context, server *hcloud.Server) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	if _, found := c.serverCache.idMap[server.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
@@ -548,16 +584,22 @@ func (c *cacheHCloudClient) PowerOnServer(_ context.Context, server *hcloud.Serv
 }
 
 func (c *cacheHCloudClient) DeleteServer(_ context.Context, server *hcloud.Server) error {
-	if _, found := c.serverCache.idMap[server.ID]; !found {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	n, found := c.serverCache.idMap[server.ID]
+	if !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
-	n := c.serverCache.idMap[server.ID]
+
 	delete(c.serverCache.nameMap, n.Name)
 	delete(c.serverCache.idMap, server.ID)
 	return nil
 }
 
 func (c *cacheHCloudClient) ListServerTypes(_ context.Context) ([]*hcloud.ServerType, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	return []*hcloud.ServerType{
 		{
 			ID:           1,
@@ -584,6 +626,8 @@ func (c *cacheHCloudClient) ListServerTypes(_ context.Context) ([]*hcloud.Server
 }
 
 func (c *cacheHCloudClient) GetServerType(_ context.Context, name string) (*hcloud.ServerType, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	serverType := &hcloud.ServerType{
 		Cores:        DefaultCPUCores,
 		Memory:       DefaultMemoryInGB,
@@ -607,8 +651,8 @@ func (c *cacheHCloudClient) GetServerType(_ context.Context, name string) (*hclo
 }
 
 func (c *cacheHCloudClient) CreateNetwork(_ context.Context, opts hcloud.NetworkCreateOpts) (*hcloud.Network, error) {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	if _, found := c.networkCache.nameMap[opts.Name]; found {
 		return nil, fmt.Errorf("already exists")
@@ -630,6 +674,8 @@ func (c *cacheHCloudClient) CreateNetwork(_ context.Context, opts hcloud.Network
 }
 
 func (c *cacheHCloudClient) ListNetworks(_ context.Context, opts hcloud.NetworkListOpts) ([]*hcloud.Network, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	networks := make([]*hcloud.Network, 0, len(c.networkCache.idMap))
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
@@ -654,8 +700,8 @@ func (c *cacheHCloudClient) ListNetworks(_ context.Context, opts hcloud.NetworkL
 }
 
 func (c *cacheHCloudClient) DeleteNetwork(_ context.Context, network *hcloud.Network) error {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	n, found := c.networkCache.idMap[network.ID]
 	if !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
@@ -666,12 +712,14 @@ func (c *cacheHCloudClient) DeleteNetwork(_ context.Context, network *hcloud.Net
 }
 
 func (c *cacheHCloudClient) ListSSHKeys(_ context.Context, _ hcloud.SSHKeyListOpts) ([]*hcloud.SSHKey, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	return []*hcloud.SSHKey{&defaultSSHKey}, nil
 }
 
 func (c *cacheHCloudClient) CreatePlacementGroup(_ context.Context, opts hcloud.PlacementGroupCreateOpts) (*hcloud.PlacementGroup, error) {
-	c.counterMutex.Lock()
-	defer c.counterMutex.Unlock()
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
 	if _, found := c.placementGroupCache.nameMap[opts.Name]; found {
 		return nil, fmt.Errorf("already exists")
@@ -692,11 +740,13 @@ func (c *cacheHCloudClient) CreatePlacementGroup(_ context.Context, opts hcloud.
 }
 
 func (c *cacheHCloudClient) DeletePlacementGroup(_ context.Context, id int64) error {
-	if _, found := c.placementGroupCache.idMap[id]; !found {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	n, found := c.placementGroupCache.idMap[id]
+	if !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 	}
-
-	n := c.placementGroupCache.idMap[id]
 
 	delete(c.placementGroupCache.nameMap, n.Name)
 	delete(c.placementGroupCache.idMap, id)
@@ -704,6 +754,8 @@ func (c *cacheHCloudClient) DeletePlacementGroup(_ context.Context, id int64) er
 }
 
 func (c *cacheHCloudClient) ListPlacementGroups(_ context.Context, opts hcloud.PlacementGroupListOpts) ([]*hcloud.PlacementGroup, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	placementGroups := make([]*hcloud.PlacementGroup, 0, len(c.placementGroupCache.idMap))
 
 	labels, err := utils.LabelSelectorToLabels(opts.LabelSelector)
@@ -728,6 +780,8 @@ func (c *cacheHCloudClient) ListPlacementGroups(_ context.Context, opts hcloud.P
 }
 
 func (c *cacheHCloudClient) AddServerToPlacementGroup(_ context.Context, server *hcloud.Server, pg *hcloud.PlacementGroup) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	// Check if placement group exists
 	if _, found := c.placementGroupCache.idMap[pg.ID]; !found {
 		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}


### PR DESCRIPTION
`func (c *cacheHCloudClient) DeleteNetwork()`  did panic (on main).


[:seedling: Upgrade builder image to Go 1.23 (#1562) · syself/cluster-api-provider-hetzner@5b9c8aa](https://github.com/syself/cluster-api-provider-hetzner/actions/runs/13919667606/job/38949746367#step:7:1048)

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1a7e422]

goroutine 492 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x1d3b920?, 0x33f23c0?})
	/opt/hostedtoolcache/go/1.22.6/x64/src/runtime/panic.go:770 +0x132
github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake.(*cacheHCloudClient).DeleteNetwork(0x34484e0, {0x203ed37?, 0x15?}, 0xc001984c80)
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake/hcloud_client.go:661 +0x62
github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/network.(*Service).Delete(0xc001195870, {0x234d108, 0xc001b1ce70})
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/pkg/services/hcloud/network/network.go:142 +0xaf
github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerClusterReconciler).reconcileDelete(0xc0005ed1f0, {0x234d108, 0xc001b1ce70}, 0xc00001e230)
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hetznercluster_controller.go:348 +0x525
github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerClusterReconciler).Reconcile(0xc0005ed1f0, {0x234d108, 0xc001b1cdb0}, {{{0xc000c1c150?, 0x0?}, {0xc001667660?, 0xc001195d10?}}})
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hetznercluster_controller.go:169 +0xbfa
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x23521d8?, {0x234d108?, 0xc001b1cdb0?}, {{{0xc000c1c150?, 0xb?}, {0xc001667660?, 0x0?}}})
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002ac370, {0x234d140, 0xc000428500}, {0x1e10940, 0xc000fdc740})
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002ac370, {0x234d140, 0xc000428500})
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261 +0x1be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 288
	/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:218 +0x486
```

This PR uses a RWMutex, so that every method creates a read/write lock to serialize the access.

Background: The tests run one after the other, but the envTest Reconciler runs concurrently. This means there are two goroutines accessing the same data structure.