### PR TITLE
:bug: Fix nil pointer dereference in actionRegistering logging

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -619,7 +619,8 @@ func (s *Service) actionRegistering(_ context.Context) actionResult {
 		if s.scope.HetznerBareMetalHost.Spec.Status.LastUpdated != nil {
 			timeSinceReboot = time.Since(s.scope.HetznerBareMetalHost.Spec.Status.LastUpdated.Time).String()
 		}
-		s.scope.Logger.Info("Could not reach rescue system. Will retry some seconds later.", "stdout", out.StdOut, "stderr", out.StdErr, "err", out.Err.Error(),
+
+		s.scope.Logger.Info("Could not reach rescue system. Will retry some seconds later.", "out", out.String(), "hostName", hostName,
 			"isSSHTimeoutError", isSSHTimeoutError, "isSSHConnectionRefusedError", isSSHConnectionRefusedError, "timeSinceReboot", timeSinceReboot)
 		return actionContinue{delay: 10 * time.Second}
 	}


### PR DESCRIPTION
Fix nil pointer dereference in actionRegistering logging

```
{"level":"INFO","time":"2025-04-02T11:47:05.150Z","file":"controller/controller.go:110","message":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"hetznerbaremetalhost","controllerGroup":"infrastructure.cluster.x-k8s.io","controllerKind":"HetznerBareMetalHost","HetznerBareMetalHost":{"name":"bm-e2e-1670788","namespace":"ci14218540976-6ohc8e"},"namespace":"ci14218540976-6ohc8e","name":"bm-e2e-1670788","reconcileID":"026fa096-3f2e-403c-9c61-bed7ee4496d4"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x19532f5]

goroutine 350 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:111 +0x1da
panic({0x1bbf1c0?, 0x310ac60?})
	runtime/panic.go:791 +0x132
github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*Service).actionRegistering(0xc00040b2e8, {0x46bc83b87ea0fb27?, 0xc000bd7960?})
	github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host/host.go:622 +0x655
github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*hostStateMachine).handleRegistering(0xc0007f4180, {0x217d0c8?, 0xc000c09350?})
	github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host/state_machine.go:268 +0x78
github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*hostStateMachine).ReconcileState(0xc0007f4180, {0x217d0c8, 0xc000c09350})
	github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host/state_machine.go:106 +0xa1f
github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*Service).Reconcile(0xc00040b2e8, {0x217d0c8, 0xc000c09350})
	github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host/host.go:139 +0x346
github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerBareMetalHostReconciler).reconcile(0x21974d8?, {0x217d0c8, 0xc000c09350}, 0xc000c29b90)
	github.com/syself/cluster-api-provider-hetzner/controllers/hetznerbaremetalhost_controller.go:222 +0x71
github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerBareMetalHostReconciler).Reconcile(0xc000464230, {0x217d0c8, 0xc000c08e10}, {{{0xc000865f98?, 0x5?}, {0xc000b40ae0?, 0xc000c15d10?}}})
	github.com/syself/cluster-api-provider-hetzner/controllers/hetznerbaremetalhost_controller.go:215 +0x135f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2181928?, {0x217d0c8?, 0xc000c08e10?}, {{{0xc000865f98?, 0xb?}, {0xc000b40ae0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:114 +0xa5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00058a210, {0x217d100, 0xc0002493b0}, {0x1c9a800, 0xc000e52540})
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:311 +0x39c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00058a210, {0x217d100, 0xc0002493b0})
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:261 +0x19d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:222 +0x73
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 157
	sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:218 +0x46c
```