### PR TITLE
:seedling: Add --skip-webhooks, show logs in envTests

### DIFF
--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -99,7 +99,7 @@ func (s *Service) createNetwork(ctx context.Context) (*hcloud.Network, error) {
 		return nil, fmt.Errorf("failed to create network: %w", err)
 	}
 
-	record.Eventf(s.scope.HetznerCluster, "NetworkCreated", "Created network with opts %s", opts)
+	record.Eventf(s.scope.HetznerCluster, "NetworkCreated", "Created network with opts %+v", opts)
 	return resp, nil
 }
 

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -42,6 +42,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ import (
 
 func init() {
 	klog.InitFlags(nil)
-	logger := textlogger.NewLogger(textlogger.NewConfig())
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(4)))
 
 	// use klog as the internal logger for this envtest environment.
 	log.SetLogger(logger)
@@ -148,6 +149,8 @@ func NewTestEnvironment() *TestEnvironment {
 	if err != nil {
 		klog.Fatalf("unable to create manager: %s", err)
 	}
+
+	record.InitFromRecorder(mgr.GetEventRecorderFor("hetzner-controller"))
 
 	if err := (&infrav1.HetznerCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("failed to set up webhook with manager for HetznerCluster: %s", err)


### PR DESCRIPTION
This is a small PR which:

* Adds --skip-webhooks: Together with --leader-elect=false, you can use `go run main.go` to run CAPH in a cluster connected via KUBECONFIG. You should scale down the caph deployment to 0 before doing that. This is only for testing!
* Increases LogLevel to DEBUG for envTests, and configures the EventRecorder to log when events get created. Helpful for debugging envTests.
* Fixes a small typo in the Event created in createNetwork().