### PR TITLE
:bug: Dev env bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ install-cilium-in-wl-cluster: $(HELM)
 	# Deploy cilium
 	$(HELM) repo add cilium https://helm.cilium.io/
 	$(HELM) repo update cilium
-	KUBECONFIG=$(WORKER_CLUSTER_KUBECONFIG) $(HELM) upgrade --install cilium cilium/cilium --version 1.14.4 \
+	KUBECONFIG=$(WORKER_CLUSTER_KUBECONFIG) $(HELM) upgrade --install cilium cilium/cilium \
   		--namespace kube-system \
 		-f templates/cilium/cilium.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ wait-and-get-secret:
 install-cilium-in-wl-cluster: $(HELM)
 	# Deploy cilium
 	$(HELM) repo add cilium https://helm.cilium.io/
-	$(HELM) repo update cilium \
+	$(HELM) repo update cilium
+	KUBECONFIG=$(WORKER_CLUSTER_KUBECONFIG) $(HELM) upgrade --install cilium cilium/cilium --version 1.14.4 \
   		--namespace kube-system \
 		-f templates/cilium/cilium.yaml
 

--- a/hack/kind-dev.sh
+++ b/hack/kind-dev.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o pipefail
 set -x
 
-K8S_VERSION=v1.31.6
+K8S_VERSION=v1.31.5
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}" || exit 1

--- a/hack/kind-dev.sh
+++ b/hack/kind-dev.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o pipefail
 set -x
 
+# See `crane ls ghcr.io/fluxcd/kindest/node` for available versions
 K8S_VERSION=v1.31.5
 
 REPO_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Hello! I wanted to run Tilt locally and noticed that it tries to download 1.35.6 image which is not exist here: https://github.com/fluxcd/flux-benchmark/pkgs/container/kindest%2Fnode/versions?filters%5Bversion_type%5D=tagged

and I noticed that there was a line deleted by accident in cillium install step.
