### PR TITLE
:seedling: Use logger instead of by to avoid e2e test failure.

### DIFF
--- a/test/e2e/basic_baremetal_test.go
+++ b/test/e2e/basic_baremetal_test.go
@@ -28,6 +28,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 )
@@ -41,7 +42,8 @@ func logBareMetalHostStatusContinously(ctx context.Context, c client.Client) {
 		case <-t:
 			err := logBareMetalHostStatus(ctx, c)
 			if err != nil {
-				By(fmt.Sprintf("Error logging BareMetalHost status: %v", err))
+				log := log.FromContext(ctx)
+				log.Info("Error logging BareMetalHost status", "error", err)
 			}
 		}
 	}

--- a/test/e2e/caph.go
+++ b/test/e2e/caph.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 )
@@ -61,7 +62,8 @@ func logHCloudMachineStatusContinously(ctx context.Context, c client.Client) {
 		case <-t:
 			err := logHCloudMachineStatus(ctx, c)
 			if err != nil {
-				ginkgo.By(fmt.Sprintf("Error logging HCloudMachine status: %v", err))
+				logger := log.FromContext(ctx)
+				logger.Info("Error logging HCloudMachine status", "error", err)
 			}
 		}
 	}


### PR DESCRIPTION
Use logger instead of by to avoid e2e test failure.