### PR TITLE
:seedling: Show conflicts in SaveHostAndReturn in logs

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -160,7 +160,7 @@ func SaveHostAndReturn(ctx context.Context, cl client.Client, host *infrav1.Hetz
 	if err := cl.Update(ctx, host); err != nil {
 		if apierrors.IsConflict(err) {
 			log := ctrl.LoggerFrom(ctx)
-			log.V(1).Info("conflict error. Retrying", "err", err)
+			log.Info("conflict error. Retrying", "err", err)
 			return reconcile.Result{Requeue: true}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to update host object: %w", err)


### PR DESCRIPTION
Conflict Errors should be visible as loglevel=info, so they are visible by default.

Otherwise, it is hard to understand why a second Reconcile happens again which seem to not see the changes made by the first Reconcile.