### PR TITLE
:seedling: Use ubuntu 24.04

### DIFF
--- a/api/v1beta1/hcloudmachine_validation_test.go
+++ b/api/v1beta1/hcloudmachine_validation_test.go
@@ -50,7 +50,7 @@ func TestValidateHCloudMachineSpec(t *testing.T) {
 			name: "Immutable ImageName",
 			args: args{
 				oldSpec: HCloudMachineSpec{
-					ImageName: "ubuntu-20.04",
+					ImageName: "ubuntu-24.04",
 				},
 				newSpec: HCloudMachineSpec{
 					ImageName: "centos-7",
@@ -110,13 +110,13 @@ func TestValidateHCloudMachineSpec(t *testing.T) {
 			args: args{
 				oldSpec: HCloudMachineSpec{
 					Type:               "cpx11",
-					ImageName:          "ubuntu-20.04",
+					ImageName:          "ubuntu-24.04",
 					SSHKeys:            []SSHKey{{Name: "ssh-key-1"}},
 					PlacementGroupName: createPlacementGroupName("placement-group-1"),
 				},
 				newSpec: HCloudMachineSpec{
 					Type:               "cpx11",
-					ImageName:          "ubuntu-20.04",
+					ImageName:          "ubuntu-24.04",
 					SSHKeys:            []SSHKey{{Name: "ssh-key-1"}},
 					PlacementGroupName: createPlacementGroupName("placement-group-1"),
 				},

--- a/api/v1beta1/hetznerbaremetalmachine_types_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types_test.go
@@ -253,11 +253,11 @@ func Test_Image_String(t *testing.T) {
 		},
 		{
 			Image{
-				URL:  "https://user:pwd@example.com/images/Ubuntu-2204-jammy-amd64-custom.tar.gz",
-				Name: "Ubuntu-2204",
+				URL:  "https://user:pwd@example.com/images/Ubuntu-2404-noble-amd64-custom.tar.gz",
+				Name: "Ubuntu-2404-noble",
 				Path: "",
 			},
-			"Ubuntu-2204 (https://user:xxxxx@example.com/images/Ubuntu-2204-jammy-amd64-custom.tar.gz)",
+			"Ubuntu-2404-noble (https://user:xxxxx@example.com/images/Ubuntu-2404-noble-amd64-custom.tar.gz)",
 		},
 		{
 			Image{
@@ -277,9 +277,9 @@ func Test_Image_String(t *testing.T) {
 		{
 			Image{
 				Name: "nfs",
-				Path: "/root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz",
+				Path: "/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz",
 			},
-			"nfs (/root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz)",
+			"nfs (/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz)",
 		},
 	} {
 		require.Equal(t, row.expected, row.image.String())

--- a/api/v1beta1/hetznerbaremetalmachine_validation_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_validation_test.go
@@ -39,8 +39,8 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 				},
@@ -77,13 +77,13 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.invalid",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.invalid",
 						},
 					},
 				},
 			},
-			want: field.Invalid(field.NewPath("spec", "installImage", "image", "url"), "https://example.com/ubuntu-20.04.invalid", "unknown image type in URL"),
+			want: field.Invalid(field.NewPath("spec", "installImage", "image", "url"), "https://example.com/ubuntu-24.04.invalid", "unknown image type in URL"),
 		},
 		{
 			name: "Valid HostSelector MatchLabels",
@@ -91,8 +91,8 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					HostSelector: HostSelector{
@@ -110,8 +110,8 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					HostSelector: HostSelector{
@@ -133,8 +133,8 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					HostSelector: HostSelector{
@@ -166,8 +166,8 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 				spec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					HostSelector: HostSelector{
@@ -232,8 +232,8 @@ func TestValidateHetznerBareMetalMachineSpecUpdate(t *testing.T) {
 				oldSpec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 				},
@@ -349,8 +349,8 @@ func TestValidateHetznerBareMetalMachineSpecUpdate(t *testing.T) {
 				oldSpec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					SSHSpec: SSHSpec{
@@ -381,8 +381,8 @@ func TestValidateHetznerBareMetalMachineSpecUpdate(t *testing.T) {
 				newSpec: HetznerBareMetalMachineSpec{
 					InstallImage: InstallImage{
 						Image: Image{
-							Name: "ubuntu-20.04",
-							URL:  "https://example.com/ubuntu-20.04.tar.gz",
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 					SSHSpec: SSHSpec{

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -698,7 +698,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 			})
 
 			It("should fail updating installImage", func() {
-				bmMachine.Spec.InstallImage.Image.Name = "ubuntu-2204"
+				bmMachine.Spec.InstallImage.Image.Name = "ubuntu-2404-noble"
 				Expect(testEnv.Update(ctx, bmMachine)).NotTo(Succeed())
 			})
 
@@ -758,8 +758,8 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 						Spec: infrav1.HetznerBareMetalMachineSpec{
 							InstallImage: infrav1.InstallImage{
 								Image: infrav1.Image{
-									Name: "ubuntu-20.04",
-									URL:  "https://example.com/ubuntu-20.04.tar.gz",
+									Name: "ubuntu-24.04",
+									URL:  "https://example.com/ubuntu-24.04.tar.gz",
 								},
 								Partitions: []infrav1.Partition{
 									{

--- a/docs/caph/03-reference/06-hetzner-bare-metal-machine-template.md
+++ b/docs/caph/03-reference/06-hetzner-bare-metal-machine-template.md
@@ -89,7 +89,7 @@ Example of an image provided by Hetzner via NFS:
 
 ```yaml
 image:
-  path: /root/.oldroot/nfs//images/Ubuntu-2204-jammy-amd64-base.tar.gz
+  path: /root/.oldroot/nfs//images/Ubuntu-2404-noble-amd64-base.tar.gz
 ```
 
 Example of an image provided by you via https. The script installimage of Hetzner parses the name to detect the version. It is
@@ -97,16 +97,16 @@ recommended to follow their naming pattern.
 
 ```yaml
 image:
-  name: Ubuntu-2204-jammy-amd64-custom
-  url: https://user:pwd@example.com/images/Ubuntu-2204-jammy-amd64-custom.tar.gz
+  name: Ubuntu-2404-noble-amd64-custom
+  url: https://user:pwd@example.com/images/Ubuntu-2404-noble-amd64-custom.tar.gz
 ```
 
 Example of pulling an image from an oci-registry:
 
 ```yaml
 image:
-  name: Ubuntu-2204-jammy-amd64-custom
-  url: oci://ghcr.io/myorg/images/Ubuntu-2204-jammy-amd64-custom:1.0.1
+  name: Ubuntu-2404-noble-amd64-custom
+  url: oci://ghcr.io/myorg/images/Ubuntu-2404-noble-amd64-custom:1.0.1
 ```
 
 If you need credentials to pull the image, then provide the environment variable `OCI_REGISTRY_AUTH_TOKEN` to the controller.
@@ -138,6 +138,6 @@ spec:
 You can push an image to an oci-registry with a tool like [oras](https://oras.land):
 
 ```shell
-oras push ghcr.io/myorg/images/Ubuntu-2204-jammy-amd64-custom:1.0.1 \
-    --artifact-type application/vnd.myorg.machine-image.v1 Ubuntu-2204-jammy-amd64-custom.tar.gz
+oras push ghcr.io/myorg/images/Ubuntu-2404-noble-amd64-custom:1.0.1 \
+    --artifact-type application/vnd.myorg.machine-image.v1 Ubuntu-2404-noble-amd64-custom.tar.gz
 ```

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1947,7 +1947,7 @@ func markProvisionPending(host *infrav1.HetznerBareMetalHost, state infrav1.Prov
 		infrav1.ProvisionSucceededCondition,
 		infrav1.StillProvisioningReason,
 		clusterv1.ConditionSeverityInfo,
-		"host is still provisioning - state %q", state,
+		"host (%s) is still provisioning - state %q", host.Name, state,
 	)
 }
 

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       installImage:
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi

--- a/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       installImage:
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi

--- a/templates/cluster-templates/cluster-class.yaml
+++ b/templates/cluster-templates/cluster-class.yaml
@@ -656,7 +656,7 @@ spec:
         swraid: 0
         swraidLevel: 1
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2204-jammy-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
         partitions:
           - fileSystem: esp
             mount: /boot/efi

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -20,17 +20,21 @@ spec:
 #     wwn: "0x5000cca22de4ef84"
 #   maintenanceMode: false
 #   description: Test Machine 1716772
+
 # ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HetznerBareMetalHost
-metadata:
-  name: "bm-e2e-1724024"
-spec:
-  serverID: 1724024
-  rootDeviceHints:
-    wwn: "0x500a075111968d25"
-  maintenanceMode: false
-  description: Test Machine 1724024
+# Disable, because it failed twice in e2e
+# https://github.com/syself/cluster-api-provider-hetzner/actions/runs/15517483689/job/43872103343?pr=1613
+# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+# kind: HetznerBareMetalHost
+# metadata:
+#   name: "bm-e2e-1724024"
+# spec:
+#   serverID: 1724024
+#   rootDeviceHints:
+#     wwn: "0x500a075111968d25"
+#   maintenanceMode: false
+#   description: Test Machine 1724024
+
 # --- We deactived 1731561 since it can't reach the rescue system.
 #     We enable it again, if we solved the issue.
 # apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Use Ubuntu 24.04.

baremetal machines were hanging in "ensure-provisioned". This mean ssh was not reachable after installing the tgz.

Maybe something in cloud-init changed in Hetzner, which needs a newer version.