### PR TITLE
:seedling: Look for different error code while deleting server of lb

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -666,8 +665,9 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 		// Do not return an error in case the target server was not found.
 		// In case the target server was not found we will get an error similar to
 		// "server with ID xxxxx not found (invalid_input, xxxxxxx)".
-		// Therefore, if error code is "invalid_input" or "load_balancer_not_found" don't do anything.
-		if strings.Contains(err.Error(), "invalid_input") || strings.Contains(err.Error(), "load_balancer_not_found") {
+		// If the load balancer itself was not found then we will get a "not_found" error.
+		// In both cases, don't do anything.
+		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
 			return nil
 		}
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -663,10 +663,10 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 	lb := &hcloud.LoadBalancer{ID: s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID}
 
 	if err := s.scope.HCloudClient.DeleteTargetServerOfLoadBalancer(ctx, lb, server); err != nil {
-		// Do not return an error in case the target was not found.
+		// Do not return an error in case the target server was not found.
 		// In case the target server was not found we will get an error similar to
 		// "server with ID xxxxx not found (invalid_input, xxxxxxx)".
-		// Therefor, if error code is "invalid_input" or "load_balancer_not_found" don't do anything.
+		// Therefore, if error code is "invalid_input" or "load_balancer_not_found" don't do anything.
 		if strings.Contains(err.Error(), "invalid_input") || strings.Contains(err.Error(), "load_balancer_not_found") {
 			return nil
 		}

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -663,7 +663,10 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 	lb := &hcloud.LoadBalancer{ID: s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID}
 
 	if err := s.scope.HCloudClient.DeleteTargetServerOfLoadBalancer(ctx, lb, server); err != nil {
-		// do not return an error in case the target was not found
+		// Do not return an error in case the target was not found.
+		// In case the target server was not found we will get an error similar to
+		// "server with ID xxxxx not found (invalid_input, xxxxxxx)".
+		// Therefor, if error code is "invalid_input" or "load_balancer_not_found" don't do anything.
 		if strings.Contains(err.Error(), "invalid_input") || strings.Contains(err.Error(), "load_balancer_not_found") {
 			return nil
 		}

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -664,9 +664,10 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 
 	if err := s.scope.HCloudClient.DeleteTargetServerOfLoadBalancer(ctx, lb, server); err != nil {
 		// do not return an error in case the target was not found
-		if strings.Contains(err.Error(), "load_balancer_target_not_found") {
+		if strings.Contains(err.Error(), "invalid_input") || strings.Contains(err.Error(), "load_balancer_not_found") {
 			return nil
 		}
+
 		errMsg := fmt.Sprintf("failed to delete server %s with ID %d as target of load balancer %s with ID %d", server.Name, server.ID, lb.Name, lb.ID)
 		return handleRateLimit(s.scope.HCloudMachine, err, "DeleteTargetServerOfLoadBalancer", errMsg)
 	}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We no longer get the error `load_balancer_not_found` if the target server was not found, instead we should check for the error `invalid_input`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1630 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

