### PR TITLE
:seedling: When Robot API reaches a timeout, retry later.

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1403,6 +1403,14 @@ func (s *Service) actionImageInstallingFinished(ctx context.Context, sshClient s
 
 	// Update name in robot API
 	if _, err := s.scope.RobotClient.SetBMServerName(s.scope.HetznerBareMetalHost.Spec.ServerID, s.scope.Hostname()); err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			// If the Hetzner API returns this, we just want to retry later:
+			// failed to get bare metal server: Get "https://robot-ws.your-server.de/server/1234": net/http: TLS handshake timeout
+			s.scope.Logger.Info("SetBMServerName timed out, will retry later", "error", err)
+			return actionContinue{
+				delay: 10 * time.Second,
+			}
+		}
 		record.Warn(s.scope.HetznerBareMetalHost, "SetBMServerNameFailed", err.Error())
 		s.handleRobotRateLimitExceeded(err, "SetBMServerName")
 		return actionError{err: fmt.Errorf("failed to update name of host in robot API: %w", err)}


### PR DESCRIPTION
# When Robot API reaches a timeout, retry later

The Robot API of Hetzner returned this:

> failed to get bare metal server: Get "https://robot-ws.your-server.de/server/1234": net/http: TLS handshake timeout

We do want to retry N seconds later. Up to now the provisioning process was stopped and started from scratch.

