### PR TITLE
:seedling: Refactor statusFromHCloudServer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/guettli/check-conditions v0.0.9
 	github.com/hetznercloud/hcloud-go/v2 v2.19.1
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
 	github.com/prometheus/common v0.63.0
@@ -89,7 +90,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -112,7 +112,7 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	s.scope.SetProviderID(server.ID)
 
 	// update HCloudMachineStatus
-	s.scope.HCloudMachine.Status.Addresses = getStatusAddresses(server)
+	s.scope.HCloudMachine.Status.Addresses = statusAddresses(server)
 	s.scope.HCloudMachine.Status.InstanceState = &server.Status
 
 	// validate labels
@@ -736,7 +736,7 @@ func validateLabels(server *hcloud.Server, labels map[string]string) error {
 	return nil
 }
 
-func getStatusAddresses(server *hcloud.Server) []clusterv1.MachineAddress {
+func statusAddresses(server *hcloud.Server) []clusterv1.MachineAddress {
 	// populate addresses
 	addresses := []clusterv1.MachineAddress{}
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"slices"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -754,7 +753,7 @@ func statusAddresses(server *hcloud.Server) []clusterv1.MachineAddress {
 	}
 
 	if unicastIP := server.PublicNet.IPv6.IP; unicastIP.IsGlobalUnicast() {
-		ip := net.IP(slices.Clone(unicastIP))
+		ip := net.IP(unicastIP)
 		ip[15]++ // Hetzner returns the routed /64 base, increment last byte to obtain first usable address
 		addresses = append(
 			addresses,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -18,9 +18,11 @@ limitations under the License.
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -749,7 +751,7 @@ func getStatusAdressesFromHCloudServer(server *hcloud.Server) []clusterv1.Machin
 	}
 
 	if unicastIP := server.PublicNet.IPv6.IP; unicastIP.IsGlobalUnicast() {
-		ip := unicastIP
+		ip := net.IP(bytes.Clone(unicastIP))
 		ip[15]++ // We got a network, but we want the IP. Use the first IP of the network.
 		addresses = append(
 			addresses,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -115,7 +115,7 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	s.scope.HCloudMachine.Status.Addresses = statusAddresses(server)
 
 	// Copy value
-	s.scope.HCloudMachine.Status.InstanceState = ptr.To(hcloud.ServerStatus(server.Status))
+	s.scope.HCloudMachine.Status.InstanceState = ptr.To(server.Status)
 
 	// validate labels
 	if err := validateLabels(server, s.createLabels()); err != nil {
@@ -753,8 +753,12 @@ func statusAddresses(server *hcloud.Server) []clusterv1.MachineAddress {
 	}
 
 	if unicastIP := server.PublicNet.IPv6.IP; unicastIP.IsGlobalUnicast() {
-		ip := net.IP(unicastIP)
-		ip[15]++ // Hetzner returns the routed /64 base, increment last byte to obtain first usable address
+		// create copy
+		ip := append(net.IP(nil), unicastIP...)
+
+		// Hetzner returns the routed /64 base, increment last byte to obtain first usable address
+		ip[15]++
+
 		addresses = append(
 			addresses,
 			clusterv1.MachineAddress{

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -113,7 +114,9 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	// update HCloudMachineStatus
 	s.scope.HCloudMachine.Status.Addresses = statusAddresses(server)
-	s.scope.HCloudMachine.Status.InstanceState = &server.Status
+
+	// Copy value
+	s.scope.HCloudMachine.Status.InstanceState = ptr.To(hcloud.ServerStatus(server.Status))
 
 	// validate labels
 	if err := validateLabels(server, s.createLabels()); err != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -753,10 +753,12 @@ func statusAddresses(server *hcloud.Server) []clusterv1.MachineAddress {
 	}
 
 	if unicastIP := server.PublicNet.IPv6.IP; unicastIP.IsGlobalUnicast() {
-		// create copy
+		// Create a copy. This is important, otherwise we modify the IP of `server`. This could lead
+		// to unexpected behaviour.
 		ip := append(net.IP(nil), unicastIP...)
 
 		// Hetzner returns the routed /64 base, increment last byte to obtain first usable address
+		// The local value gets changed, not the IP of `server`.
 		ip[15]++
 
 		addresses = append(

--- a/pkg/services/hcloud/server/server_suite_test.go
+++ b/pkg/services/hcloud/server/server_suite_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
@@ -188,27 +187,25 @@ const serverJSON = `
 	"volumes": []
 }`
 
-var server *hcloud.Server
-
-const instanceState = hcloud.ServerStatusRunning
-
-var ips = []string{"1.2.3.4", "2001:db8::3", "10.0.0.2"}
-var addressTypes = []clusterv1.MachineAddressType{clusterv1.MachineExternalIP, clusterv1.MachineExternalIP, clusterv1.MachineInternalIP}
-
 func TestServer(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Server Suite")
 }
 
-var _ = BeforeSuite(func() {
+func newTestServer() *hcloud.Server {
 	var serverSchema schema.Server
 	b := []byte(serverJSON)
 	var buffer bytes.Buffer
-	Expect(json.Compact(&buffer, b))
-	Expect(json.Unmarshal(buffer.Bytes(), &serverSchema)).To(Succeed())
-
-	server = hcloud.ServerFromSchema(serverSchema)
-})
+	err := json.Compact(&buffer, b)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(buffer.Bytes(), &serverSchema)
+	if err != nil {
+		panic(err)
+	}
+	return hcloud.ServerFromSchema(serverSchema)
+}
 
 func newTestService(hcloudMachine *infrav1.HCloudMachine, hcloudClient hcloudclient.Client) *Service {
 	return &Service{

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/mitchellh/copystructure"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,13 @@ import (
 )
 
 func Test_getStatusAdressesFromHCloudServer(t *testing.T) {
-	addresses := getStatusAdressesFromHCloudServer(newTestServer())
+	server := newTestServer()
+
+	// Create deep copy.
+	saved, err := copystructure.Copy(server)
+	require.NoError(t, err)
+
+	addresses := getStatusAdressesFromHCloudServer(server)
 
 	// should have three addresses
 	require.Equal(t, 3, len(addresses))
@@ -49,6 +56,9 @@ func Test_getStatusAdressesFromHCloudServer(t *testing.T) {
 	for i, addr := range addresses {
 		require.Equal(t, ips[i], addr.Address)
 	}
+
+	// Check that input was not altered.
+	require.Equal(t, saved, server)
 
 	// should have the right address types
 	addressTypes := []clusterv1.MachineAddressType{clusterv1.MachineExternalIP, clusterv1.MachineExternalIP, clusterv1.MachineInternalIP}

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -39,14 +39,14 @@ import (
 	fakeclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 )
 
-func Test_getStatusAdressesFromHCloudServer(t *testing.T) {
+func Test_getStatusAddresses(t *testing.T) {
 	server := newTestServer()
 
 	// Create deep copy.
 	saved, err := copystructure.Copy(server)
 	require.NoError(t, err)
 
-	addresses := getStatusAdressesFromHCloudServer(server)
+	addresses := getStatusAddresses(server)
 
 	// should have three addresses
 	require.Equal(t, 3, len(addresses))

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -39,14 +39,14 @@ import (
 	fakeclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 )
 
-func Test_getStatusAddresses(t *testing.T) {
+func Test_statusAddresses(t *testing.T) {
 	server := newTestServer()
 
 	// Create deep copy.
 	saved, err := copystructure.Copy(server)
 	require.NoError(t, err)
 
-	addresses := getStatusAddresses(server)
+	addresses := statusAddresses(server)
 
 	// should have three addresses
 	require.Equal(t, 3, len(addresses))


### PR DESCRIPTION
statusFromHCloudServer() overwrote the whole status of a hcloudmachine.

This was refactored to only update Status.Addresses.

Additionally, avoid modifying the input (`server.PublicNet.IPv6.IP`). The existing code already expected a wrong value ("2001:db8::2" instead of "2001:db8::1").

The test was converted to a plain Go test and avoids a global variable now.

Next PR: https://github.com/syself/cluster-api-provider-hetzner/pull/1650
