### PR TITLE
:seedling: Avoid warning: Waited for due to client-side throttling,

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -290,6 +290,7 @@ func logStatus(ctx context.Context, restConfig *restclient.Config, c client.Clie
 }
 
 func logConditions(ctx context.Context, restConfig *restclient.Config) error {
+	restConfig.QPS = -1 // Since Kubernetes 1.29 "API Priority and Fairness" handles that.
 	counter, err := checkconditions.RunAndGetCounter(ctx, restConfig, checkconditions.Arguments{})
 	if err != nil {
 		return fmt.Errorf("failed to get check conditions: %w", err)


### PR DESCRIPTION
> I0829 08:31:00.251753   17515 request.go:697]
> Waited for 1.993332996s due to client-side
> throttling, not priority and fairness, request:
> GET:https://127.0.0.1:39499/apis/cluster.x-k8s.io/v1beta1/machines

This warning is repeated again and again in the output of e2e tests.

We use current api-servers, no need for client-side throttling.

Example output: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/17318175493/job/49165317653#step:3:1661


