### PR TITLE
🐛 Update metadata.yaml to include kind property

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 1
     minor: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Initializing a cluster using v1.0.6 with the following command fails with the included error.
```
clusterctl init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure hetzner
Fetching providers
Error: failed to fetch metadata for provider "infrastructure-hetzner" (version v1.0.6). Check that the release tag exists and the repository URL is correct — the project may have moved or the tag may be missing metadata.yaml: invalid provider metadata: unexpected kind "" for provider infrastructure-hetzner (expected "Metadata")
```
Adding the kind property with the value `Metadata` fixes the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

