### PR TITLE
:seedling: Update hack dir

### DIFF
--- a/hack/output-for-watch.sh
+++ b/hack/output-for-watch.sh
@@ -42,7 +42,7 @@ kubectl get hetznerbaremetalhost -A
 
 print_heading events:
 
-kubectl get events -A --sort-by=lastTimestamp | grep -vP 'LeaderElection' | tail -8
+kubectl get events -A --sort-by=lastTimestamp | grep -vP 'LeaderElection' | tail -6
 
 print_heading caph:
 
@@ -54,7 +54,8 @@ regex='^I\d\d\d\d|\
 .*failed to retrieve Spec.ProviderID|\
 .*failed to patch Machine default
 '
-capi_logs=$(kubectl logs -n capi-system deployments/capi-controller-manager --since 7m | grep -vP "$(echo "$regex" | tr -d '\n')" | tail -5)
+capi_ns=$(kubectl get deployments -A | grep capi-con | cut -d' ' -f1)
+capi_logs=$(kubectl logs -n "$capi_ns" deployments/capi-controller-manager --since 10m | grep -vP "$(echo "$regex" | tr -d '\n')" | tail -5)
 if [ -n "$capi_logs" ]; then
     print_heading capi
     echo "$capi_logs"
@@ -62,7 +63,7 @@ fi
 
 echo
 
-if [ $(kubectl get machine -l cluster.x-k8s.io/control-plane 2>/dev/null | wc -l) -eq 0 ]; then
+if [[ $(kubectl get machine -l cluster.x-k8s.io/control-plane 2>/dev/null | wc -l) -eq 0 ]]; then
     echo "❌ no control-plane machine exists."
     exit 1
 fi

--- a/hack/tail-controller-logs.sh
+++ b/hack/tail-controller-logs.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pod=$(kubectl -n caph-system get pods | grep caph-controller-manager | cut -d' ' -f1)
+ns=$(kubectl get deployments.apps -A | grep caph-controller-manager | cut -d' ' -f1)
+pod=$(kubectl -n "$ns" get pods | grep caph-controller-manager | cut -d' ' -f1)
 
 if [ -z "$pod" ]; then
     echo "failed to find caph-controller-manager pod"
     exit 1
 fi
 
-kubectl -n caph-system logs "$pod" --tail 200 | \
-	   ./hack/filter-caph-controller-manager-logs.py - | \
-        tail -n 20
+kubectl -n "$ns" logs "$pod" --tail 200 |
+    ./hack/filter-caph-controller-manager-logs.py - |
+    tail -n 10

--- a/hack/update-operator-dev-deployment.sh
+++ b/hack/update-operator-dev-deployment.sh
@@ -25,6 +25,12 @@
 trap 'echo "Warning: A command has failed. Exiting the script. Line was ($0:$LINENO): $(sed -n "${LINENO}p" "$0")"; exit 3' ERR
 set -Eeuo pipefail
 
+if [[ $(kubectl config current-context) == *oidc@* ]]; then
+    echo "found oidc@ in the current kubectl context. It is likely that you are connected"
+    echo "to the wrong cluster"
+    exit 1
+fi
+
 image_path="ghcr.io/syself"
 
 while [[ "$#" -gt 0 ]]; do

--- a/hack/upgrade-builder-image.sh
+++ b/hack/upgrade-builder-image.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 # This script is executed in the Update-Bot container.
+# Call it via `make builder-image-push`.
 # It checks if the Dockerfile for the build container has changed.
 # If so, it uses the version of the main branch as the basis for creating a new image tag.
 # The script also checks if the image tag for the build image exists in the main branch.


### PR DESCRIPTION
Update output-for-watch.sh and tail-controller-logs.sh: support caph running in a different namespace (not fix to capi-system).

update-operator-dev-deployment.sh: Be sure to not update the cluster, if connected via oidc (avoid accidentally changing a non-test system)
