### PR TITLE
:seedling: Make concurrent execution of `make test-unit` possible.

### DIFF
--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -145,6 +146,10 @@ func NewTestEnvironment() *TestEnvironment {
 				Host:    "localhost",
 			},
 		),
+		Metrics: metricsserver.Options{
+			// Disable MetricsServer, so that two tests processes can run concurrently
+			BindAddress: "0",
+		},
 	})
 	if err != nil {
 		klog.Fatalf("unable to create manager: %s", err)

--- a/test/helpers/webhook.go
+++ b/test/helpers/webhook.go
@@ -95,8 +95,14 @@ func initializeWebhookInEnvironment() {
 		klog.Fatalf("Failed to append core controller webhook config: %v", err)
 	}
 
+	// Two tests processes should be able ro run concurrently. Each needs an own port:
+	port, err := getFreePort()
+	if err != nil {
+		klog.Fatalf("Failed to get a free port for webhook: %v", err)
+	}
+
 	env.WebhookInstallOptions = envtest.WebhookInstallOptions{
-		LocalServingPort:   9443,
+		LocalServingPort:   port,
 		LocalServingHost:   "localhost",
 		MaxTime:            20 * time.Second,
 		PollInterval:       time.Second,
@@ -125,4 +131,14 @@ func (t *TestEnvironment) WaitForWebhooks() {
 		klog.V(2).Info("Webhook port is now open. Continuing with tests...")
 		return
 	}
+}
+
+func getFreePort() (port int, err error) {
+	ln, err := net.Listen("tcp", "[::]:0")
+	if err != nil {
+		return 0, err
+	}
+	port = ln.Addr().(*net.TCPAddr).Port
+	err = ln.Close()
+	return
 }


### PR DESCRIPTION
Sometimes I run `make test-unit´ concurrently: two git clones, two branches, two editor processes.

Currently, this fails because the port number is fixed.

This PR chooses a random port, so that `make test-unit` can be executed twice at the same time.

Error message, when port is already used:

```

  [FAILED] Expected success, but got an error:
      <*net.OpError | 0xc000400cd0>: 
      listen tcp 127.0.0.1:9444: bind: address already in use
      {
          Op: "listen",
          Net: "tcp",
          Source: nil,
          Addr: <*net.TCPAddr | 0xc000f81980>{IP: [127, 0, 0, 1], Port: 9443, Zone: ""},
          Err: <*os.SyscallError | 0xc0004da1e0>{
              Syscall: "bind",
              Err: <syscall.Errno>0x62,
          },
      }
  In [BeforeSuite] at: /home/guettli/syself/caph3/controllers/controllers_suite_test.go:121 @ 09/15/25 17:03:19.213
------------------------------

Summarizing 1 Failure:
  [FAIL] [BeforeSuite] 
  /home/guettli/syself/caph3/controllers/controllers_suite_test.go:121

Ran 0 of 114 Specs in 5.164 seconds
FAIL! -- A BeforeSuite node failed so all tests were skipped.
```