### PR TITLE
🌱Remove unused method ClientConfigWithAPIEndpoint #1687

### DIFF
--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -165,25 +165,6 @@ func (s *ClusterScope) ClientConfig(ctx context.Context) (clientcmd.ClientConfig
 	return clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
 }
 
-// ClientConfigWithAPIEndpoint returns a client config.
-func (s *ClusterScope) ClientConfigWithAPIEndpoint(ctx context.Context, endpoint clusterv1.APIEndpoint) (clientcmd.ClientConfig, error) {
-	c, err := s.ClientConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	raw, err := c.RawConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving rawConfig from clientConfig: %w", err)
-	}
-	// update cluster endpint in config
-	for key := range raw.Clusters {
-		raw.Clusters[key].Server = fmt.Sprintf("https://%s:%d", endpoint.Host, endpoint.Port)
-	}
-
-	return clientcmd.NewDefaultClientConfig(raw, &clientcmd.ConfigOverrides{}), nil
-}
-
 // ListMachines returns HCloudMachines.
 func (s *ClusterScope) ListMachines(ctx context.Context) ([]*clusterv1.Machine, []*infrav1.HCloudMachine, error) {
 	// get and index Machines by HCloudMachine name


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

## 🌱Remove unused method ClientConfigWithAPIEndpoint

**What this PR does / why we need it**:

This PR removes the unused method `ClientConfigWithAPIEndpoint` from the `ClusterScope` struct in `pkg/scope/cluster.go`. The method was not being called anywhere in the codebase and represents dead code that should be cleaned up for better maintainability.

The method was originally designed to return a client config with a modified API endpoint, but comprehensive code analysis shows it has no usages throughout the entire project, including:
- No direct method calls
- No usage in test files
- Not part of any interface requirements


Fixes #1687

**Special notes for your reviewer**:

- This is purely a code cleanup change with no functional impact
- All existing tests continue to pass
- The project builds successfully after the removal
- The change reduces the codebase by 19 lines of unused code

**TODOs**:

- [x] squash commits
- [x] include documentation (N/A - removing code only)
- [x] add unit tests (N/A - no new functionality, existing tests verify no breakage)