### PR TITLE
:seedling: Mark test as flaky

### DIFF
--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -530,7 +530,7 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 				}, timeout, time.Second).Should(BeTrue())
 			})
 
-			It("should take over an existing load balancer with correct name", func() {
+			It("should take over an existing load balancer with correct name (flaky)", func() {
 				By("creating load balancer manually")
 
 				opts := hcloud.LoadBalancerCreateOpts{


### PR DESCRIPTION
> [It] should take over an existing load balancer with correct name

This test fails often. This PR makes it visible by adding `(flaky)` to the name of the test.

Example: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/18494374082/job/52695102261?pr=1659