### PR TITLE
:seedling: Use newest hetznercloud/tps-action

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -63,7 +63,7 @@ runs:
         TAG: ${{ steps.meta.outputs.version }}
 
     - name: Get HCLOUD_TOKEN # sets env.HCLOUD_TOKEN
-      uses: hetznercloud/tps-action@dee5dd2546322c28ed8f74b910189066e8b6f31a # main
+      uses: hetznercloud/tps-action@769ba703ee3ec4e5cca5f8d37d60c3f721b08335 # main
 
     - name: "e2e-${{ inputs.e2e_name }}"
       shell: bash


### PR DESCRIPTION
I hope this fixes the failing e2e tests.

Failing e2e since several days, example: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/18501260257/job/52718665669#step:3:490