### PR TITLE
Strip subnet mask from HetznerBareMetalHost IP Address

### DIFF
--- a/pkg/services/baremetal/client/ssh/nic-info.sh
+++ b/pkg/services/baremetal/client/ssh/nic-info.sh
@@ -42,10 +42,10 @@ for idir in $(echo /sys/class/net/* | sort); do
         MODEL=$(lspci -s "$BUSINFO" | cut -d ' ' -f3- | tr '"' "'")
     fi
 
-    for ipv4 in $(ip -4 addr show dev "$iname" | awk '/inet /{print $2}'); do
+    for ipv4 in $(ip -4 addr show dev "$iname" | awk '/inet /{print $2}' | cut -d'/' -f1); do
         echo "name=\"$iname\" model=\"$MODEL\" mac=\"$MAC\" ip=\"$ipv4\" speedMbps=\"$SPEED\""
     done
-    for ipv6 in $(ip -6 addr show dev "$iname" | awk '/inet6 /{print $2}'); do
+    for ipv6 in $(ip -6 addr show dev "$iname" | awk '/inet6 /{print $2}' | cut -d'/' -f1); do
         if [[ "$ipv6" == fe80:* ]]; then
             continue
         fi


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
It basically strips subnet mask suffix from the NIC IP for BaremetalHost, so it became correctly recognized as IP by other providers of ClusterAPI ecosystem.

Previously IP was a string like: `37.27.255.255/16`

After this changes IP will become a string `37.27.255.255`

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

