### PR TITLE
:seedling: Mark test as flaky

### DIFF
--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -204,7 +204,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 			})
 		})
 
-		It("checks that no remediation is tried if HCloud server does not exist anymore", func() {
+		It("checks that no remediation is tried if HCloud server does not exist anymore (flaky)", func() {
 			By("ensuring if hcloudMachine is provisioned")
 			Eventually(func() error {
 				if err := testEnv.Get(ctx, hcloudMachineKey, hcloudMachine); err != nil {
@@ -212,7 +212,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				}
 
 				if !hcloudMachine.Status.Ready {
-					return fmt.Errorf("hcloudMachine.Status.Ready is not true (yet)")
+					return fmt.Errorf("hcloudMachine.Status.Ready is not true (yet) (flaky)")
 				}
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())


### PR DESCRIPTION
> It("checks that no remediation is tried if HCloud server does not exist anymore

Example:

failed: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/19070358536/job/54471283442

re-run is fine: https://github.com/syself/cluster-api-provider-hetzner/actions/runs/19070358536