### PR TITLE
:seedling: Use strict schema validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,10 +93,10 @@ var (
 	sshAfterInstallImage               bool
 )
 
-// strictManager is a ctrl.Manager which creates controller-runtime clients which do strict schema
-// validateion. If the schema of the CRD does not match to the schema of the controller, unexpected
-// things can happen. It is better to get an error instead of updating a resource where only some
-// fields got applied. Related:
+// strictManager is a ctrl.Manager that creates controller-runtime clients that enforce strict
+// schema validation. If a CRD's schema does not match the controller's schema, unexpected behavior
+// can occur. It's better to return an error than to perform a partial update where only some fields
+// are applied.  Related:
 // https://www.reddit.com/r/kubernetes/comments/1oqnn6v/schema_mismatch_between_controller_and_crd/
 type strictManager struct {
 	ctrl.Manager


### PR DESCRIPTION
The new provisioning process (currently on main, not released yet) introduced `hcloudmachine.Status.BootState`.

If you run this new code, but the CRD (OpenAPI Spec) is not updated yet, then updates to `BootState` are lost silently. There is a INFO log, but this is likely to get overlooked.

It is better to fail, if the schema between controller and CRD/api-server do not match.

This PR wraps the Manager, so that calls to `GetClient()` return a wrapped client which uses:

 controller-runtime: [client.WithFieldValidation()](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#WithFieldValidation)

```go
// strictManager is a ctrl.Manager that creates controller-runtime clients that enforce strict
// schema validation. If a CRD's schema does not match the controller's schema, unexpected behavior
// can occur. It's better to return an error than to perform a partial update where only some fields
// are applied. 
```


This will result in a much better error message the next time the CRD spec does not the schema used by the controller.

I got positive feedback about that from #kubebuilder slack: [message](https://kubernetes.slack.com/archives/CAR30FCJZ/p1762934221762919?thread_ts=1762855632.671059&cid=CAR30FCJZ)

> Camila Macedo: Yes, it absolutely makes sense to document this behavior. It prevents silent errors, improves schema reliability, and teaches users to detect API–controller mismatches early.