### PR TITLE
:seedling: Add progress=plain to docker build.

### DIFF
--- a/hack/update-operator-dev-deployment.sh
+++ b/hack/update-operator-dev-deployment.sh
@@ -100,7 +100,7 @@ pid_generate=$!
 
 # run in background
 {
-    docker build -f images/caph/Dockerfile -t "$image" .
+    docker build -f images/caph/Dockerfile -t "$image" . --progress=plain
     docker push "$image"
 } &
 pid_docker_push=$!


### PR DESCRIPTION
Otherwise error messages from a second process
running in the background are not visible.
