### PR TITLE
🐛 Remove deprecated --cloud-provider flag from cluster templates

### DIFF
--- a/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
@@ -39,7 +39,6 @@ spec:
           requestheader-username-headers: X-Remote-User
           enable-aggregator-routing: "true"
           # Additional Configuration
-          cloud-provider: external
           authorization-mode: "Node,RBAC"
           kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
           profiling: "false"
@@ -48,7 +47,6 @@ spec:
           default-unreachable-toleration-seconds: "45"
       controllerManager:
         extraArgs:
-          cloud-provider: external
           cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
           cluster-signing-key-file: /etc/kubernetes/pki/ca.key
           cluster-signing-duration: 6h0m0s
@@ -85,7 +83,6 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"
@@ -99,7 +96,6 @@ spec:
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -39,7 +39,6 @@ spec:
           requestheader-username-headers: X-Remote-User
           enable-aggregator-routing: "true"
           # Additional Configuration
-          cloud-provider: external
           authorization-mode: "Node,RBAC"
           kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
           profiling: "false"
@@ -48,7 +47,6 @@ spec:
           default-unreachable-toleration-seconds: "45"
       controllerManager:
         extraArgs:
-          cloud-provider: external
           cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
           cluster-signing-key-file: /etc/kubernetes/pki/ca.key
           cluster-signing-duration: 6h0m0s
@@ -85,7 +83,6 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"
@@ -99,7 +96,6 @@ spec:
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
           kubeconfig: /etc/kubernetes/kubelet.conf
           authentication-token-webhook: "true"

--- a/templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
@@ -8,7 +8,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
             tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
             kubeconfig: /etc/kubernetes/kubelet.conf
             authentication-token-webhook: "true"

--- a/templates/cluster-templates/v1beta1/cluster-class.yaml
+++ b/templates/cluster-templates/v1beta1/cluster-class.yaml
@@ -394,7 +394,6 @@ spec:
             extraArgs:
               authorization-mode: Node,RBAC
               client-ca-file: /etc/kubernetes/pki/ca.crt
-              cloud-provider: external
               default-not-ready-toleration-seconds: "45"
               default-unreachable-toleration-seconds: "45"
               enable-aggregator-routing: "true"
@@ -424,7 +423,6 @@ spec:
               authentication-kubeconfig: /etc/kubernetes/controller-manager.conf
               authorization-kubeconfig: /etc/kubernetes/controller-manager.conf
               bind-address: 0.0.0.0
-              cloud-provider: external
               cluster-signing-cert-file: /etc/kubernetes/pki/ca.crt
               cluster-signing-duration: 6h0m0s
               cluster-signing-key-file: /etc/kubernetes/pki/ca.key
@@ -493,7 +491,6 @@ spec:
               anonymous-auth: "false"
               authentication-token-webhook: "true"
               authorization-mode: Webhook
-              cloud-provider: external
               event-qps: "5"
               kubeconfig: /etc/kubernetes/kubelet.conf
               max-pods: "120"
@@ -507,7 +504,6 @@ spec:
               anonymous-auth: "false"
               authentication-token-webhook: "true"
               authorization-mode: Webhook
-              cloud-provider: external
               event-qps: "5"
               kubeconfig: /etc/kubernetes/kubelet.conf
               max-pods: "120"
@@ -601,7 +597,6 @@ spec:
             anonymous-auth: "false"
             authentication-token-webhook: "true"
             authorization-mode: Webhook
-            cloud-provider: external
             event-qps: "5"
             kubeconfig: /etc/kubernetes/kubelet.conf
             max-pods: "220"
@@ -752,7 +747,6 @@ spec:
             anonymous-auth: "false"
             authentication-token-webhook: "true"
             authorization-mode: Webhook
-            cloud-provider: external
             event-qps: "5"
             kubeconfig: /etc/kubernetes/kubelet.conf
             max-pods: "220"


### PR DESCRIPTION
## Description
This PR removes the deprecated `--cloud-provider=external` flag from all cluster template configurations.

## Background
The `--cloud-provider` flag was completely removed from Kubernetes components in **v1.29** (December 2023):
- Removed from `kube-apiserver`
- Removed from `kube-controller-manager`
- Removed from `kubelet`

This flag is no longer supported in newer (v1.33+) Kubernetes versions and will cause the cloud-init to fail if present because the kube-apiserver isn't able to start.

Fixes #1683 and most likely #1719.

## References
- [Kubernetes v1.29 Release Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md)
- [KEP-2395: Removing In-Tree Cloud Provider Code](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers)