### PR TITLE
:seedling: e2e: refresh generated CRDs and suite lint fixes

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -258,7 +258,7 @@ func dumpMetrics() error {
 	if err != nil {
 		return fmt.Errorf("Error creating file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Encode the metrics into text format
 	encoder := expfmt.NewEncoder(f, expfmt.NewFormat(expfmt.TypeTextPlain))


### PR DESCRIPTION
config/crd/bases/*.yaml:
- update to controller-gen v0.20

controllers/controllers_suite_test.go:
- close file handle in deferred func
- simplify hcloudTokenErrorResult() argument usage.