### PR TITLE
:seedling: templates: drop api-server cloud-provider external arg

### DIFF
--- a/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
@@ -39,7 +39,6 @@ spec:
           requestheader-username-headers: X-Remote-User
           enable-aggregator-routing: "true"
           # Additional Configuration
-          cloud-provider: external
           authorization-mode: "Node,RBAC"
           kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
           profiling: "false"

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -39,7 +39,6 @@ spec:
           requestheader-username-headers: X-Remote-User
           enable-aggregator-routing: "true"
           # Additional Configuration
-          cloud-provider: external
           authorization-mode: "Node,RBAC"
           kubelet-preferred-address-types: ExternalIP,Hostname,InternalDNS,ExternalDNS
           profiling: "false"

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   template:
     spec:
+      hostSelector:
+        matchLabels:
+          baremetal-pool: "${BAREMETAL_POOL}"
       installImage:
         image:
           path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   template:
     spec:
+      hostSelector:
+        matchLabels:
+          baremetal-pool: "${BAREMETAL_POOL}"
       installImage:
         image:
           path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz

--- a/templates/cluster-templates/v1beta1/cluster-class.yaml
+++ b/templates/cluster-templates/v1beta1/cluster-class.yaml
@@ -394,7 +394,6 @@ spec:
             extraArgs:
               authorization-mode: Node,RBAC
               client-ca-file: /etc/kubernetes/pki/ca.crt
-              cloud-provider: external
               default-not-ready-toleration-seconds: "45"
               default-unreachable-toleration-seconds: "45"
               enable-aggregator-routing: "true"


### PR DESCRIPTION
templates/cluster-templates/v1beta1/bases/*-kcp-*.yaml:
- removed cloud-provider: external from kube-apiserver args (kept kubeadm/kubelet settings).