### PR TITLE
:seedling: e2e: update baremetal host pools and v1beta1 kustomizations

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -2,6 +2,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
   name: "bm-e2e-1670788"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1670788
 spec:
   serverID: 1670788
   rootDeviceHints:
@@ -9,60 +12,76 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# Does not reach rescue system
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1716772"
-# spec:
-#   serverID: 1716772
-#   rootDeviceHints:
-#     wwn: "0x5000cca22de4ef84"
-#   maintenanceMode: false
-#   description: Test Machine 1716772
-# ---
-
+# Feb 2026: worked.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1716772"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1716772
+spec:
+  serverID: 1716772
+  rootDeviceHints:
+    wwn: "0x5002538d41d70a46"
+  maintenanceMode: false
+  description: Test Machine 1716772
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
   name: "bm-e2e-1724024"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1724024
 spec:
   serverID: 1724024
   rootDeviceHints:
     wwn: "0x500a075111968d25"
   maintenanceMode: false
   description: Test Machine 1724024
-# --- We deactived 1731561 since it can't reach the rescue system.
-#     We enable it again, if we solved the issue.
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1731561"
-# spec:
-#   serverID: 1731561
-#   rootDeviceHints:
-#     wwn: "0x500a075119615dc2"
-#   maintenanceMode: false
-#   description: Test Machine 1731561
-# ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1751550"
-# spec:
-#   serverID: 1751550
-#   rootDeviceHints:
-#     wwn: "0x500a075119549dcf"
-#   maintenanceMode: false
-#   description: Test Machine 1751550
-# ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1763731"
-# spec:
-#   serverID: 1763731
-#   rootDeviceHints:
-#     wwn: "0x500a07511756c36d"
-#   maintenanceMode: false
-#   description: Test Machine 1751550
+---
+# Feb 2026: works
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1731561"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1731561
+spec:
+  serverID: 1731561
+  rootDeviceHints:
+    wwn: "0x500a075119615dc2"
+  maintenanceMode: false
+  description: Test Machine 1731561
+---
+# Had issues: Feb 2026.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1751550"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1751550
+spec:
+  serverID: 1751550
+  rootDeviceHints:
+    wwn: "0x500a075119549dcf"
+  maintenanceMode: true #### < --- set to false, when ok.
+  description: Test Machine 1751550
+---
+# Worked Feb 2026
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1763731"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1763731
+spec:
+  serverID: 1763731
+  rootDeviceHints:
+    wwn: "0x500a07511756c36d"
+  maintenanceMode: false
+  description: Test Machine 1751550

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-load-balancer-extra-services/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-load-balancer-extra-services/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-loadbalancer-off/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-loadbalancer-off/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-placement-groups/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hcloud-feature-placement-groups/kustomization.yaml
@@ -1,16 +1,16 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml
 patchesStrategicMerge:
   - ../patches/cluster_patch.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster-placementGroup_patch.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-placementGroup_patch.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-placementGroup_patch.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-placementGroup_patch.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-placementGroup_patch.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-placementGroup_patch.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal-feature-raid-setup/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal-feature-raid-setup/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetzner-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-md-1-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetzner-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-md-1-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm-hetzner.yaml
   - ../bases/hetzner-secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal-feature-raid-setup/md-1/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal-feature-raid-setup/md-1/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - ../../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
 
 patches:
   - patch: |-

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetzner-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-md-1-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetzner-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-md-1-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm-hetzner.yaml
   - ../bases/hetzner-secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal/md-1/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-baremetal/md-1/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-  - ../../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
 
 patches:
   - patch: |-

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-k8s-upgrade-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-k8s-upgrade-kcp-scale-in/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/hcloud-mt-control-plane-upgrade-to.yaml
   - ../bases/hcloud-mt-md-0-upgrade-to.yaml
   - ../bases/crs-cni.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-k8s-upgrade/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-k8s-upgrade/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/hcloud-mt-control-plane-upgrade-to.yaml
   - ../bases/hcloud-mt-md-0-upgrade-to.yaml
   - ../bases/crs-cni.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,11 +1,11 @@
 resources:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -1,11 +1,11 @@
 resources:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-network/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-network/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster-network.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-network.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm-network.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template-node-drain/kustomization.yaml
@@ -1,11 +1,11 @@
 resources:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/cluster-template/kustomization.yaml
@@ -1,11 +1,11 @@
 bases:
-  - ../../../../../../templates/cluster-templates/bases/capi-cluster-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-hetznerCluster.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-kcp-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-control-plane-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-md-0-kubeadm.yaml
-  - ../../../../../../templates/cluster-templates/bases/kct-md-0-ubuntu.yaml
-  - ../../../../../../templates/cluster-templates/bases/hcloud-mt-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/capi-cluster-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-control-plane-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-md-0-kubeadm.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/kct-md-0-ubuntu.yaml
+  - ../../../../../../templates/cluster-templates/v1beta1/bases/hcloud-mt-md-0-ubuntu.yaml
   - ../bases/crs-cni.yaml
   - ../bases/crs-ccm.yaml
   - ../bases/secret.yaml


### PR DESCRIPTION
test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml:
- use baremetal-pool labels (ci-pool/free-pool), re-enable checked servers, add comments.

test/e2e/data/infrastructure-hetzner/v1beta1/*/kustomization.yaml:
- update paths to include v1beta1 for v1beta2 prep.