### PR TITLE
:seedling: e2e: use SSH_KEY_NAME in cluster template script

### DIFF
--- a/test/e2e/cluster-templates-v1beta1.sh
+++ b/test/e2e/cluster-templates-v1beta1.sh
@@ -25,24 +25,9 @@ fi
 
 rm -f "$HETZNER_TEMPLATES"/v1beta1/cluster-template*.yaml
 
-if [ -z "${HETZNER_ROBOT_USER:-}" ]; then
-
-    if [ -n "${HETZNER_SSH_PUB:-}" ] ||
-        [ -n "${HETZNER_SSH_PRIV:-}" ] ||
-        [ -n "${HETZNER_ROBOT_PASSWORD:-}" ]; then
-        echo "Environment variables HETZNER_SSH_PUB HETZNER_SSH_PRIV HETZNER_ROBOT_PASSWORD should not be set."
-        exit 1
-    fi
-    echo "No HETZNER_ROBOT_USER set, setting values to dummy values"
-    HETZNER_ROBOT_USER="dummy-HETZNER_ROBOT_USER"
-    HETZNER_ROBOT_PASSWORD="dummy-HETZNER_ROBOT_PASSWORD"
-    HETZNER_SSH_PUB=$(echo -n "dummy-HETZNER_SSH_PUB" | base64 -w0)
-    HETZNER_SSH_PRIV=$(echo -n "dummy-HETZNER_SSH_PRIV" | base64 -w0)
-fi
-
-echo -n "$HETZNER_SSH_PUB" | base64 -d >tmp_ssh_pub_enc
-echo -n "$HETZNER_SSH_PRIV" | base64 -d >tmp_ssh_priv_enc
-kubectl create secret generic robot-ssh --from-literal=sshkey-name=shared-2024-07-08 --from-file=ssh-privatekey=tmp_ssh_priv_enc --from-file=ssh-publickey=tmp_ssh_pub_enc --dry-run=client -o yaml >data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-secret.yaml
+echo "$HETZNER_SSH_PUB" >tmp_ssh_pub_enc
+echo "$HETZNER_SSH_PRIV" >tmp_ssh_priv_enc
+kubectl create secret generic robot-ssh --from-literal=sshkey-name="$SSH_KEY_NAME" --from-file=ssh-privatekey=tmp_ssh_priv_enc --from-file=ssh-publickey=tmp_ssh_pub_enc --dry-run=client -o yaml >data/infrastructure-hetzner/v1beta1/cluster-template-hetzner-secret.yaml
 rm tmp_ssh_pub_enc tmp_ssh_priv_enc
 
 kustomize build "$HETZNER_TEMPLATES"/v1beta1/cluster-template --load-restrictor LoadRestrictionsNone >"$HETZNER_TEMPLATES"/v1beta1/cluster-template.yaml


### PR DESCRIPTION
test/e2e/cluster-templates-v1beta1.sh:
- stop using hard-coded shared-2024-07-08 key, use SSH_KEY_NAME.