### PR TITLE
:seedling: e2e: improve suite logging and log collector reliability

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -66,7 +68,7 @@ var (
 	// kubetestConfigFilePath is the path to the kubetest configuration file.
 	kubetestConfigFilePath string
 
-	// alsoLogToFile enables additional logging to the 'ginkgo-log.txt' file in the artifact folder.
+	// alsoLogToFile enables additional logging to a timestamped 'ginkgo-log-MM-DD_HH-MM-SS.txt' file in the artifact folder.
 	// These logs also contain timestamps.
 	alsoLogToFile bool
 
@@ -96,7 +98,7 @@ var (
 func init() {
 	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
 	flag.StringVar(&artifactFolder, "e2e.artifacts-folder", "", "folder where e2e test artifact should be stored")
-	flag.BoolVar(&alsoLogToFile, "e2e.also-log-to-file", true, "if true, ginkgo logs are additionally written to the `ginkgo-log.txt` file in the artifacts folder (including timestamps)")
+	flag.BoolVar(&alsoLogToFile, "e2e.also-log-to-file", true, "if true, ginkgo logs are additionally written to a `ginkgo-log-MM-DD_HH-MM-SS.txt` file in the artifacts folder (including timestamps)")
 	flag.BoolVar(&skipCleanup, "e2e.skip-resource-cleanup", false, "if true, the resource cleanup after tests will be skipped")
 	flag.StringVar(&clusterctlConfig, "e2e.clusterctl-config", "", "file which tests will use as a clusterctl config. If it is not set, a local clusterctl repository (including a clusterctl config) will be created automatically.")
 	flag.BoolVar(&useExistingCluster, "e2e.use-existing-cluster", false, "if true, the test uses the current cluster instead of creating a new one (default discovery rules apply)")
@@ -114,9 +116,10 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	if alsoLogToFile {
-		w, err := ginkgoextensions.EnableFileLogging(filepath.Join(artifactFolder, "ginkgo-log.txt"))
+		logFileName := fmt.Sprintf("ginkgo-log-%s.txt", time.Now().Format("01-02_15-04-05"))
+		w, err := ginkgoextensions.EnableFileLogging(filepath.Join(artifactFolder, logFileName))
 		Expect(err).ToNot(HaveOccurred())
-		defer w.Close()
+		defer func() { _ = w.Close() }()
 	}
 
 	RunSpecs(t, "caph-e2e")
@@ -337,6 +340,17 @@ func logStatus(ctx context.Context, restConfig *restclient.Config, c client.Clie
 			log(fmt.Sprintf("Failed to log Conditions %s/%s: %v", cluster.Namespace, secretName, err))
 			continue
 		}
+		err = logNodes(ctx, "wl-cluster "+cluster.Name, restConfig)
+		if err != nil {
+			log(fmt.Sprintf("Failed to log Nodes %s/%s: %v", cluster.Namespace, secretName, err))
+			continue
+		}
+		err = logCCMDeployments(ctx, "wl-cluster "+cluster.Name, restConfig)
+		if err != nil {
+			log(fmt.Sprintf("Failed to log CCM deployment %s/%s: %v", cluster.Namespace, secretName, err))
+			continue
+		}
+
 	}
 
 	log(fmt.Sprintf("≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡ %s End logging status >>>", time.Now().Format("2006-01-02 15:04:05")))
@@ -358,6 +372,115 @@ func logConditions(ctx context.Context, clusterName string, restConfig *restclie
 		log(line)
 	}
 	return nil
+}
+
+func logNodes(ctx context.Context, clusterName string, restConfig *restclient.Config) error {
+	cfg := restclient.CopyConfig(restConfig)
+	cfg.QPS = -1 // Since Kubernetes 1.29 "API Priority and Fairness" handles that.
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("create kubernetes client from restConfig: %w", err)
+	}
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list nodes: %w", err)
+	}
+
+	sort.Slice(nodes.Items, func(i, j int) bool {
+		return nodes.Items[i].Name < nodes.Items[j].Name
+	})
+
+	log(fmt.Sprintf("----------------------------------------------- %s ---- Nodes: %d",
+		clusterName, len(nodes.Items)))
+
+	for _, node := range nodes.Items {
+		addresses := make([]string, 0, len(node.Status.Addresses))
+		for _, address := range node.Status.Addresses {
+			addresses = append(addresses, fmt.Sprintf("%s=%s", address.Type, address.Address))
+		}
+		sort.Strings(addresses)
+
+		addressText := "<none>"
+		if len(addresses) > 0 {
+			addressText = strings.Join(addresses, ", ")
+		}
+
+		log(fmt.Sprintf("Node: %s providerID=%q addresses=[%s]",
+			node.Name,
+			node.Spec.ProviderID,
+			addressText,
+		))
+		if node.Spec.ProviderID == "" {
+			log(fmt.Sprintf("  !!! WARNING !!! Node %s has empty providerID (check ccm)", node.Name))
+		}
+	}
+
+	return nil
+}
+
+func logCCMDeployments(ctx context.Context, clusterName string, restConfig *restclient.Config) error {
+	cfg := restclient.CopyConfig(restConfig)
+	cfg.QPS = -1 // Since Kubernetes 1.29 "API Priority and Fairness" handles that.
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("create kubernetes client from restConfig: %w", err)
+	}
+
+	deployments, err := kubeClient.AppsV1().Deployments(metav1.NamespaceSystem).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list deployments: %w", err)
+	}
+
+	ccmDeployments := make([]appsv1.Deployment, 0, len(deployments.Items))
+	ccmDeploymentNameSuffixes := []string{
+		"ccm",
+		"cloud-controller-manager",
+		"ccm-hetzner",
+		"ccm-hcloud",
+	}
+	for _, deployment := range deployments.Items {
+		for _, suffix := range ccmDeploymentNameSuffixes {
+			if strings.HasSuffix(deployment.Name, suffix) {
+				ccmDeployments = append(ccmDeployments, deployment)
+				break
+			}
+		}
+	}
+
+	log(fmt.Sprintf("----------------------------------------------- %s ---- CCM Deployment: %d",
+		clusterName, len(ccmDeployments)))
+
+	if len(ccmDeployments) == 0 {
+		log("  !!! WARNING !!! Expected exactly 1 CCM deployment, found none")
+	}
+	if len(ccmDeployments) > 1 {
+		log(fmt.Sprintf("  !!! WARNING !!! Expected exactly 1 CCM deployment, found %d", len(ccmDeployments)))
+	}
+
+	if len(ccmDeployments) == 0 {
+		return nil
+	}
+
+	for _, deployment := range ccmDeployments {
+		log(fmt.Sprintf("Deployment: %s/%s", deployment.Namespace, deployment.Name))
+		logDeploymentContainerImages("initContainer", deployment.Spec.Template.Spec.InitContainers)
+		logDeploymentContainerImages("container", deployment.Spec.Template.Spec.Containers)
+	}
+
+	return nil
+}
+
+func logDeploymentContainerImages(containerType string, containers []corev1.Container) {
+	for _, container := range containers {
+		log(fmt.Sprintf("  %s %s image=%s",
+			containerType,
+			container.Name,
+			container.Image,
+		))
+	}
 }
 
 func logHCloudMachineStatus(ctx context.Context, c client.Client) error {
@@ -510,5 +633,5 @@ func tearDown(ctx context.Context, bootstrapClusterProvider bootstrap.ClusterPro
 }
 
 func log(msg string) {
-	fmt.Fprintln(GinkgoWriter, msg)
+	_, _ = fmt.Fprintln(GinkgoWriter, msg)
 }

--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -25,8 +25,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,10 +36,39 @@ import (
 )
 
 const (
-	hetznerPrivateKeyFilePath = "SSH_KEY_PATH"
+	HetznerPrivateKeyContent = "HETZNER_SSH_PRIV"
 )
 
 type logCollector struct{}
+
+// CollectMachineLogByExternalIP provides a minimal entrypoint for ad-hoc log collection.
+func CollectMachineLogByExternalIP(ctx context.Context, machineName, externalIP, outputPath string) error {
+	if machineName == "" {
+		return fmt.Errorf("machine name must not be empty")
+	}
+	if externalIP == "" {
+		return fmt.Errorf("external IP must not be empty")
+	}
+	if outputPath == "" {
+		return fmt.Errorf("output path must not be empty")
+	}
+
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: machineName,
+		},
+		Status: clusterv1.MachineStatus{
+			Addresses: []clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineExternalIP,
+					Address: externalIP,
+				},
+			},
+		},
+	}
+
+	return logCollector{}.CollectMachineLog(ctx, nil, m, outputPath)
+}
 
 // CollectMachinePoolLog implements the CollectMachinePoolLog method of the LogCollector interface.
 func (collector logCollector) CollectMachinePoolLog(_ context.Context, _ client.Client, _ *expv1.MachinePool, _ string) error {
@@ -60,30 +91,35 @@ func (collector logCollector) CollectMachineLog(_ context.Context, _ client.Clie
 		break
 	}
 
+	if hostIPAddr == "" {
+		return fmt.Errorf("machine %q has no ExternalIP: machine.status.addresses: %+v", m.Name, m.Status.Addresses)
+	}
+
 	execToPathFn := func(hostFileName, command string, args ...string) func() error {
 		return func() error {
 			f, err := createOutputFile(filepath.Join(outputPath, hostFileName))
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 			return executeRemoteCommand(f, hostIPAddr, command, args...)
 		}
 	}
 
 	copyDirFn := func(pathToDir, dirName string) func() error {
 		return func() error {
-			f, err := os.Create("/tmp/" + m.Name) // #nosec
+			f, err := os.CreateTemp("/tmp", m.Name+"-*.tar") // #nosec
 			if err != nil {
 				return err
 			}
+			defer func() { _ = f.Close() }()
 
 			tempfileName := f.Name()
 			outputDir := filepath.Join(outputPath, dirName)
 
-			defer os.Remove(tempfileName)
+			defer func() { _ = os.Remove(tempfileName) }()
 
-			if err := executeRemoteCommand(
+			if err := executeRemoteCommandStdoutOnly(
 				f, hostIPAddr,
 				"tar", "--hard-dereference", "-hcf", "-", pathToDir); err != nil {
 				return fmt.Errorf("failed to tar dir %s: %w", pathToDir, err)
@@ -94,9 +130,14 @@ func (collector logCollector) CollectMachineLog(_ context.Context, _ client.Clie
 				return err
 			}
 
-			cmd := exec.Command("tar", "--extract", "--file", tempfileName, "--directory", outputDir) // #nosec
-			if err := cmd.Run(); err != nil {
-				return fmt.Errorf("failed to run command: %w", err)
+			cmd := exec.CommandContext(context.Background(), "tar", "--extract", "--file", tempfileName, "--directory", outputDir) // #nosec
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				outputForError := formatOutputForError(string(output))
+				if outputForError != "" {
+					return fmt.Errorf("failed to extract dir %s: %w; output: %s", pathToDir, err, outputForError)
+				}
+				return fmt.Errorf("failed to extract dir %s: %w", pathToDir, err)
 			}
 
 			return nil
@@ -105,13 +146,15 @@ func (collector logCollector) CollectMachineLog(_ context.Context, _ client.Clie
 
 	return kinderrors.AggregateConcurrent([]func() error{
 		execToPathFn("kern.log",
-			"sudo journalctl", "--no-pager", "--output=short-precise", "-k"),
+			"journalctl", "--no-pager", "--output=short-precise", "-k"),
 		execToPathFn("kubelet.log",
-			"sudo journalctl", "--no-pager", "--output=short-precise", "-u", "kubelet.service"),
+			"journalctl", "--no-pager", "--output=short-precise", "-u", "kubelet.service"),
 		execToPathFn("kubelet-version.txt",
 			"kubelet", "--version"),
 		execToPathFn("containerd.log",
-			"sudo journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service"),
+			"journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service"),
+		execToPathFn("var-log-k8s-ls.log",
+			"ls", "-lah", "/var/log/containers", "/var/log/pods"),
 		execToPathFn("cloud-init.log",
 			"cat", "/var/log/cloud-init.log"),
 		execToPathFn("cloud-init-output.log",
@@ -135,32 +178,120 @@ func executeRemoteCommand(f io.StringWriter, hostIPAddr, command string, args ..
 	}
 	port := "22"
 
-	hostClient, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", hostIPAddr, port), config)
-	if err != nil {
-		return fmt.Errorf("dialing host IP address at %s: %w", hostIPAddr, err)
+	var hostClient *ssh.Client
+	for attempt := 1; attempt <= 3; attempt++ {
+		hostClient, err = ssh.Dial("tcp", fmt.Sprintf("%s:%s", hostIPAddr, port), config)
+		if err != nil {
+			if attempt < 3 && isRetryableSSHError(err) {
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			return fmt.Errorf("dialing host IP address at %s: %w", hostIPAddr, err)
+		}
+		break
 	}
-	defer hostClient.Close()
+	defer func() { _ = hostClient.Close() }()
 
 	session, err := hostClient.NewSession()
 	if err != nil {
 		return fmt.Errorf("opening SSH session: %w", err)
 	}
-	defer session.Close()
+	defer func() { _ = session.Close() }()
 
-	// Run the command and write the captured stdout to the file
+	// Capture both stdout and stderr to keep useful failure details.
 	var stdoutBuf bytes.Buffer
-	session.Stdout = &stdoutBuf
+	var stderrBuf bytes.Buffer
+	var combinedOutputBuf bytes.Buffer
+	session.Stdout = io.MultiWriter(&combinedOutputBuf, &stdoutBuf)
+	session.Stderr = io.MultiWriter(&combinedOutputBuf, &stderrBuf)
 	if len(args) > 0 {
 		command += " " + strings.Join(args, " ")
 	}
 	if err = session.Run(command); err != nil {
+		output := combinedOutputBuf.String()
+		if _, writeErr := f.WriteString(output); writeErr != nil {
+			return fmt.Errorf("running command %q: %w (writing output to file: %v)", command, err, writeErr)
+		}
+		stdoutForError := formatOutputForError(stdoutBuf.String())
+		stderrForError := formatOutputForError(stderrBuf.String())
+		if stdoutForError != "" || stderrForError != "" {
+			return fmt.Errorf("running command %q: %w; stdout: %q; stderr: %q", command, err, stdoutForError, stderrForError)
+		}
 		return fmt.Errorf("running command %q: %w", command, err)
 	}
-	if _, err = f.WriteString(stdoutBuf.String()); err != nil {
+	if _, err = f.WriteString(combinedOutputBuf.String()); err != nil {
 		return fmt.Errorf("writing output to file: %w", err)
 	}
 
 	return nil
+}
+
+func executeRemoteCommandStdoutOnly(w io.Writer, hostIPAddr, command string, args ...string) error {
+	config, err := newSSHConfig()
+	if err != nil {
+		return err
+	}
+	port := "22"
+
+	var hostClient *ssh.Client
+	for attempt := 1; attempt <= 3; attempt++ {
+		hostClient, err = ssh.Dial("tcp", fmt.Sprintf("%s:%s", hostIPAddr, port), config)
+		if err != nil {
+			if attempt < 3 && isRetryableSSHError(err) {
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			return fmt.Errorf("dialing host IP address at %s: %w", hostIPAddr, err)
+		}
+		break
+	}
+	defer func() { _ = hostClient.Close() }()
+
+	session, err := hostClient.NewSession()
+	if err != nil {
+		return fmt.Errorf("opening SSH session: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	var stderrBuf bytes.Buffer
+	session.Stdout = w
+	session.Stderr = &stderrBuf
+	if len(args) > 0 {
+		command += " " + strings.Join(args, " ")
+	}
+	if err = session.Run(command); err != nil {
+		stderrForError := formatOutputForError(stderrBuf.String())
+		if stderrForError != "" {
+			return fmt.Errorf("running command %q: %w; stderr: %q", command, err, stderrForError)
+		}
+		return fmt.Errorf("running command %q: %w", command, err)
+	}
+
+	return nil
+}
+
+func isRetryableSSHError(err error) bool {
+	message := strings.ToLower(err.Error())
+
+	return strings.Contains(message, "handshake failed") ||
+		strings.Contains(message, "connection reset by peer") ||
+		strings.Contains(message, "connection refused") ||
+		strings.Contains(message, "i/o timeout")
+}
+
+func formatOutputForError(output string) string {
+	const maxOutputLength = 3000
+
+	formatted := strings.TrimSpace(strings.ToValidUTF8(output, "?"))
+	if formatted == "" {
+		return ""
+	}
+
+	if len(formatted) > maxOutputLength {
+		return formatted[:maxOutputLength] + "..."
+	}
+
+	return formatted
 }
 
 // newSSHConfig returns a configuration to use for SSH connections to remote machines.
@@ -177,7 +308,7 @@ func newSSHConfig() (*ssh.ClientConfig, error) {
 
 	config := &ssh.ClientConfig{
 		User:            "root",
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // #nosec G106
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
@@ -187,10 +318,9 @@ func newSSHConfig() (*ssh.ClientConfig, error) {
 }
 
 func readPrivateKey() ([]byte, error) {
-	privateKeyFilePath := os.Getenv(hetznerPrivateKeyFilePath)
-	if privateKeyFilePath == "" {
-		return nil, fmt.Errorf("private key information missing. Please set %s environment variable", hetznerPrivateKeyFilePath)
+	privateKeyContent := os.Getenv(HetznerPrivateKeyContent)
+	if privateKeyContent == "" {
+		return nil, fmt.Errorf("private key information missing. Please set %s environment variable", HetznerPrivateKeyContent)
 	}
-
-	return os.ReadFile(privateKeyFilePath) // #nosec
+	return []byte(privateKeyContent), nil
 }


### PR DESCRIPTION
test/e2e/e2e_suite_test.go:
- make ginkgo log filename timestamped.
- add more continuous verbose logging (ccm version, providerID checks).

test/e2e/log_collector.go:
- drop SSH_KEY_PATH usage, rely on HETZNER_SSH_PRIV.
- fix pod log retrieval and add ssh retries when feasible.