### PR TITLE
:seedling: ensure-boilerplate: skip modifying files in .git

### DIFF
--- a/.boilerplate.json
+++ b/.boilerplate.json
@@ -11,7 +11,9 @@
     "hack/tools/",
     "vendor",
     ".cache",
-    ".pkg"
+    ".pkg",
+    ".git",
+    "tmp"
   ],
   "not_generated_files_to_skip" : [
     "hack/boilerplate/boilerplate.py"


### PR DESCRIPTION
Error was:

> fatal: bad object refs/remotes/origin/tg/hack/lint-links.sh

The file in the git directory got modified by ensure-boilerplate!

Fixed: skip modifying files .git and tmp.

Created from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)
