### PR TITLE
:seedling: update e2e hetznerbaremetalhosts.yaml file

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -2,6 +2,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
   name: "bm-e2e-1670788"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1670788
 spec:
   serverID: 1670788
   rootDeviceHints:
@@ -9,60 +12,76 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# Does not reach rescue system
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1716772"
-# spec:
-#   serverID: 1716772
-#   rootDeviceHints:
-#     wwn: "0x5000cca22de4ef84"
-#   maintenanceMode: false
-#   description: Test Machine 1716772
-# ---
-
+# Feb 2026: worked.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1716772"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1716772
+spec:
+  serverID: 1716772
+  rootDeviceHints:
+    wwn: "0x5002538d41d70a46"
+  maintenanceMode: false
+  description: Test Machine 1716772
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
   name: "bm-e2e-1724024"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1724024
 spec:
   serverID: 1724024
   rootDeviceHints:
     wwn: "0x500a075111968d25"
   maintenanceMode: false
   description: Test Machine 1724024
-# --- We deactived 1731561 since it can't reach the rescue system.
-#     We enable it again, if we solved the issue.
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1731561"
-# spec:
-#   serverID: 1731561
-#   rootDeviceHints:
-#     wwn: "0x500a075119615dc2"
-#   maintenanceMode: false
-#   description: Test Machine 1731561
-# ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1751550"
-# spec:
-#   serverID: 1751550
-#   rootDeviceHints:
-#     wwn: "0x500a075119549dcf"
-#   maintenanceMode: false
-#   description: Test Machine 1751550
-# ---
-# apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-# kind: HetznerBareMetalHost
-# metadata:
-#   name: "bm-e2e-1763731"
-# spec:
-#   serverID: 1763731
-#   rootDeviceHints:
-#     wwn: "0x500a07511756c36d"
-#   maintenanceMode: false
-#   description: Test Machine 1751550
+---
+# Feb 2026: works
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1731561"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1731561
+spec:
+  serverID: 1731561
+  rootDeviceHints:
+    wwn: "0x500a075119615dc2"
+  maintenanceMode: false
+  description: Test Machine 1731561
+---
+# Had issues: Feb 2026.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1751550"
+  labels:
+    baremetal-pool: free-pool
+    name: bm-e2e-1751550
+spec:
+  serverID: 1751550
+  rootDeviceHints:
+    wwn: "0x500a075119549dcf"
+  maintenanceMode: true #### < --- set to false, when ok.
+  description: Test Machine 1751550
+---
+# Worked Feb 2026
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HetznerBareMetalHost
+metadata:
+  name: "bm-e2e-1763731"
+  labels:
+    baremetal-pool: ci-pool
+    name: bm-e2e-1763731
+spec:
+  serverID: 1763731
+  rootDeviceHints:
+    wwn: "0x500a07511756c36d"
+  maintenanceMode: false
+  description: Test Machine 1751550


### PR DESCRIPTION
Same servers are working again. For one the WWN was wrong.

Additionally: set labels: ci-pool or free-pool. Will be used by future PRs.


Created from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)
