### PR TITLE
:seedling: No longer use outdated hcloud machine types.

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 export CLUSTER_NAME=caph-${USER}
 export KUBECONFIG=$PWD/.mgt-cluster-kubeconfig.yaml
 export HCLOUD_TOKEN=...
@@ -6,8 +7,8 @@ export HCLOUD_REGION=fsn1
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export KUBERNETES_VERSION=v1.33.6
-export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx31
-export HCLOUD_WORKER_MACHINE_TYPE=cpx31
+export HCLOUD_CONTROL_PLANE_MACHINE_TYPE=cpx32
+export HCLOUD_WORKER_MACHINE_TYPE=cpx32
 export SSH_KEY=$HOME/.ssh/my-caph-ssh-key.pub
 export HETZNER_SSH_PUB_PATH=$HOME/.ssh/my-caph-ssh-key.pub
 export HETZNER_SSH_PRIV_PATH=$HOME/.ssh/my-caph-ssh-key

--- a/hack/ensure-env-variables.sh
+++ b/hack/ensure-env-variables.sh
@@ -30,3 +30,17 @@ if [ ${#missing_vars[@]} -gt 0 ]; then
   echo "Missing or empty environment variables: ${missing_vars[*]}"
   exit 1
 fi
+
+# Ensure that no outdated hcloud machine types get used.
+for varname in "$@"; do
+  if [ "$varname" = "HCLOUD_CONTROL_PLANE_MACHINE_TYPE" ] || [ "$varname" = "HCLOUD_WORKER_MACHINE_TYPE" ]; then
+    deprecated_types=(cx22 cx32 cx42 cx52 cpx11 cpx21 cpx31 cpx41 cpx51)
+    for deprecated in "${deprecated_types[@]}"; do
+      if [[ "${!varname}" == *"$deprecated"* ]]; then
+        echo "$varname contains deprecated type '$deprecated'."
+        echo "Deprecated types: ${deprecated_types[*]}"
+        exit 1
+      fi
+    done
+  fi
+done


### PR DESCRIPTION
No longer use outdated hcloud machine types.

Extracted from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)