### PR TITLE
:seedling: Avoid printing a nil error.

### DIFF
--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -542,10 +542,9 @@ func reconcileTargetSecret(ctx context.Context, clusterScope *scope.ClusterScope
 
 		hetznerToken, keyExists := tokenSecret.Data[clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HCloudToken]
 		if !keyExists {
-			return fmt.Errorf("error key %s does not exist in secret/%s: %w",
+			return fmt.Errorf("key %q does not exist in secret/%s",
 				clusterScope.HetznerCluster.Spec.HetznerSecret.Key.HCloudToken,
 				tokenSecretName,
-				err,
 			)
 		}
 


### PR DESCRIPTION
 Avoid printing a nil error.
 
 Extracted from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)