### PR TITLE
:seedling: Use new ProviderID format for bm in ClusterClass

### DIFF
--- a/templates/cluster-templates/v1beta1/cluster-class.yaml
+++ b/templates/cluster-templates/v1beta1/cluster-class.yaml
@@ -347,6 +347,9 @@ metadata:
   name: quick-start-cluster
 spec:
   template:
+    metadata:
+      annotations:
+        capi.syself.com/use-hrobot-provider-id-for-baremetal: "true"
     spec:
       controlPlaneEndpoint:
         host: ""


### PR DESCRIPTION
Use new ProviderID format for bm in ClusterClass

Extracted from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)