### PR TITLE
:seedling: Use CAPH_CONTAINER_TAG, not TAG

### DIFF
--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -8,7 +8,7 @@
 
 # For creating local dev images run make e2e-image from the main CAPH repository
 images:
-  - name: ghcr.io/syself/caph-staging:${TAG}
+  - name: ghcr.io/syself/caph-staging:${CAPH_CONTAINER_TAG}
     loadBehavior: mustLoad
 providers:
   - name: cluster-api
@@ -87,7 +87,7 @@ providers:
         contract: v1beta1
         replacements:
           - old: ghcr.io/syself/caph-staging:latest
-            new: ghcr.io/syself/caph-staging:${TAG}
+            new: ghcr.io/syself/caph-staging:${CAPH_CONTAINER_TAG}
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
           - old: --metrics-bind-addr=localhost:8080
@@ -113,7 +113,7 @@ providers:
       #   contract: v1beta1
       #   replacements:
       #     - old: ghcr.io/syself/caph-staging:latest
-      #       new: ghcr.io/syself/caph-staging:${TAG}
+      #       new: ghcr.io/syself/caph-staging:${CAPH_CONTAINER_TAG}
       #     - old: "imagePullPolicy: Always"
       #       new: "imagePullPolicy: IfNotPresent"
       #     - old: --metrics-bind-addr=localhost:8080


### PR DESCRIPTION
 Use CAPH_CONTAINER_TAG, not TAG
 
 Three places still used TAG and not CAPH_CONTAINER_TAG.

Extracted from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)