### PR TITLE
:seedling: Ensure KUBERNETES env var is not outdated.

### DIFF
--- a/hack/ensure-env-variables.sh
+++ b/hack/ensure-env-variables.sh
@@ -31,6 +31,22 @@ if [ ${#missing_vars[@]} -gt 0 ]; then
   exit 1
 fi
 
+# Ensure env var KUBERNETES_VERSION is not outdated.
+if [[ -n "${KUBERNETES_VERSION:-}" ]]; then
+  min_kubernetes_version="1.33.6"
+  kubernetes_version="${KUBERNETES_VERSION#v}"
+
+  if [[ ! "$kubernetes_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "env var KUBERNETES_VERSION should look like v<major>.<minor>.<patch> or <major>.<minor>.<patch>, got '$KUBERNETES_VERSION'."
+    exit 1
+  fi
+
+  if [[ "$(printf '%s\n%s\n' "$min_kubernetes_version" "$kubernetes_version" | sort -V | head -n 1)" != "$min_kubernetes_version" ]]; then
+    echo "KUBERNETES_VERSION must be >= v${min_kubernetes_version}, got '$KUBERNETES_VERSION'."
+    exit 1
+  fi
+fi
+
 # Ensure that no outdated hcloud machine types get used.
 for varname in "$@"; do
   if [ "$varname" = "HCLOUD_CONTROL_PLANE_MACHINE_TYPE" ] || [ "$varname" = "HCLOUD_WORKER_MACHINE_TYPE" ]; then


### PR DESCRIPTION
Ensure KUBERNETES env var is not outdated.

Extracted from: [:seedling: Get e2e tests working again. by guettli · Pull Request #1783 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/1783)