### PR TITLE
:seedling: Clarify baremetal flavor remediation and node types

### DIFF
--- a/docs/caph/02-topics/05-baremetal/01-introduction.md
+++ b/docs/caph/02-topics/05-baremetal/01-introduction.md
@@ -26,10 +26,10 @@ To use bare metal servers for your deployment, you can choose one of the followi
 | `hetzner-baremetal-control-planes`             | Uses bare metal servers for control plane nodes and worker nodes, with normal remediation (unprovision and recreate failed machines). |
 | `hetzner-hcloud-control-planes`                | Uses hcloud servers for control plane nodes and bare metal servers for worker nodes.                         |
 
-In Cluster API terms, remediation is the automatic recovery behavior for failed or unhealthy machines.
-For bare metal control planes, `custom remediation` tries a reboot first and only falls back to replacement if needed.
-`Normal remediation` directly replaces the failed machine by unprovisioning and recreating it.
-Choose custom remediation if you want to prioritize less disruptive recovery attempts; choose normal remediation if you prefer direct replacement behavior.
+In Cluster API terms, remediation is the automatic recovery behavior for failed or unhealthy
+machines. For bare metal control planes, `custom remediation` tries a reboot first and only falls
+back to replacement if needed. `Normal remediation` directly replaces the failed machine by
+unprovisioning and recreating it.
 
 {% callout %}
 


### PR DESCRIPTION
## Summary
- clarify what remediation means in the bare metal flavor introduction
- explain the practical difference between custom and normal remediation
- make flavor descriptions consistent by explicitly stating both control plane and worker node types

Fixes #1821