### PR TITLE
:seedling: Refactor SSH client error handling to remove redundant error definition and improve exit status checks in CloudInitLogsForSigTerm method.

### DIFF
--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -63,8 +63,6 @@ var downloadFromOciShellScript string
 var (
 	// ErrCommandExitedWithoutExitSignal means the ssh command exited unplanned.
 	ErrCommandExitedWithoutExitSignal = errors.New("wait: remote command exited without exit status or exit signal")
-	// ErrCommandExitedWithStatusOne means the ssh command exited with sttatus 1.
-	ErrCommandExitedWithStatusOne = errors.New("process exited with status 1")
 
 	// ErrAuthenticationFailed means ssh was unable to authenticate.
 	ErrAuthenticationFailed = errors.New("ssh: unable to authenticate")
@@ -445,8 +443,13 @@ func (c *sshClient) CloudInitStatus() Output {
 // CheckCloudInitLogsForSigTerm implements the CheckCloudInitLogsForSigTerm method of the SSHClient interface.
 func (c *sshClient) CheckCloudInitLogsForSigTerm() Output {
 	out := c.runSSH(`cat /var/log/cloud-init.log | grep "SIGTERM"`)
-	if out.Err != nil && strings.Contains(out.Err.Error(), ErrCommandExitedWithStatusOne.Error()) {
-		return Output{}
+	if out.Err != nil {
+		exitStatus, err := out.ExitStatus()
+		if err == nil && exitStatus == 1 {
+			// grep exits with status 1 when no matching line is found.
+			// That's expected in this check and should not fail reconciliation.
+			return Output{}
+		}
 	}
 	return out
 }


### PR DESCRIPTION
Refactor SSH client error handling to remove redundant error definition and improve exit status checks in CloudInitLogsForSigTerm method.