### PR TITLE
:seedling: Fix nil-pointer after createServer

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -105,6 +105,11 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 			}
 			return reconcile.Result{}, fmt.Errorf("failed to create server: %w", err)
 		}
+		if server == nil {
+			return reconcile.Result{
+				RequeueAfter: 30 * time.Second,
+			}, errors.New("createServer returned no error and nil server")
+		}
 	}
 
 	s.scope.SetProviderID(server.ID)
@@ -436,7 +441,11 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 	// get all ssh keys that are stored in HCloud API
 	sshKeysAPI, err := s.scope.HCloudClient.ListSSHKeys(ctx, hcloud.SSHKeyListOpts{})
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListSSHKeys", "failed listing ssh keys from hcloud")
+		rateLimitErr := handleRateLimit(s.scope.HCloudMachine, err, "ListSSHKeys", "failed listing ssh keys from hcloud")
+		if rateLimitErr == nil {
+			s.scope.Logger.Error(err, "This error was set to nil by handleRateLimit")
+		}
+		return nil, rateLimitErr
 	}
 
 	// find matching keys and store them
@@ -488,7 +497,11 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 			err,
 		)
 		errMsg := fmt.Sprintf("failed to create HCloud server %s", s.scope.HCloudMachine.Name)
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "CreateServer", errMsg)
+		rateLimitErr := handleRateLimit(s.scope.HCloudMachine, err, "CreateServer", errMsg)
+		if rateLimitErr == nil {
+			s.scope.Logger.Error(err, "This error was set to nil by handleRateLimit")
+		}
+		return nil, rateLimitErr
 	}
 
 	// set ssh keys to status


### PR DESCRIPTION
createServer() can return no error and a nil server, which leads to this panic.

This PR solves it.


```text 
goroutine 690 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:111 +0x1da
panic({0x1bc01a0?, 0x310cc60?})
    runtime/panic.go:791 +0x132
github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/server.(*Service).Reconcile(0xc008b4d820, {0x217ed48, 0xc00a9efb00})
    github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/server/server.go:110 +0x25c
github.com/syself/cluster-api-provider-hetzner/controllers.(*HCloudMachineReconciler).reconcileNormal(0x21994d0?, {0x217ed48, 0xc00a9efb00}, 0xc0089fd980)
    github.com/syself/cluster-api-provider-hetzner/controllers/hcloudmachine_controller.go:206 +0xdf
github.com/syself/cluster-api-provider-hetzner/controllers.(*HCloudMachineReconciler).Reconcile(0xc0002922d0, {0x217ed48, 0xc00a9ef650}, {{{0xc005d669c0?, 0x5?}, {0xc005d6c510?, 0xc008b4dd10?}}})
    github.com/syself/cluster-api-provider-hetzner/controllers/hcloudmachine_controller.go:171 +0xe0d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x21835a8?, {0x217ed48?, 0xc00a9ef650?}, {{{0xc005d669c0?, 0xb?}, {0xc005d6c510?, 0x0?}}})
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:114 +0xa5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000398000, {0x217ed80, 0xc000292140}, {0x1c9b840, 0xc004019ce0})
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:311 +0x39c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000398000, {0x217ed80, 0xc000292140})
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:261 +0x19d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:222 +0x73
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 262
    sigs.k8s.io/controller-runtime@v0.18.7/pkg/internal/controller/controller.go:218 +0x46c
```