### PR TITLE
:seedling: Handle rate-limits carefully

### DIFF
--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -116,6 +116,14 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	// update the machine
 	if err := s.update(ctx); err != nil {
+		if apierrors.IsNotFound(err) {
+			err := fmt.Errorf("host not found for machine %q. Setting Failure, remediation will start: %w", s.scope.Machine.Name, err)
+			s.scope.BareMetalMachine.SetFailure(capierrors.UpdateMachineError, err.Error())
+
+			// returning error as nil here because otherwise it will lead continuous reconcile loop.
+			return reconcile.Result{}, nil
+		}
+
 		return checkForRequeueError(err, "failed to update machine")
 	}
 
@@ -207,11 +215,6 @@ func (s *Service) Delete(ctx context.Context) (res reconcile.Result, err error) 
 func (s *Service) update(ctx context.Context) error {
 	host, helper, err := s.getAssociatedHost(ctx)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			err := fmt.Errorf("host not found for machine %q. Setting Failure, remediation will start: %w", s.scope.Machine.Name, err)
-			s.scope.BareMetalMachine.SetFailure(capierrors.UpdateMachineError, err.Error())
-			return err
-		}
 		return fmt.Errorf("failed to get host: %w", err)
 	}
 	if host == nil {

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -33,7 +33,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -362,7 +361,7 @@ var _ = Describe("chooseHost", func() {
 })
 
 var _ = Describe("Service.update", func() {
-	It("marks BareMetalMachine as failed when the associated host no longer exists", func() {
+	It("returns a not-found error when the associated host no longer exists", func() {
 		const namespace = "default"
 
 		scheme := runtime.NewScheme()
@@ -399,10 +398,6 @@ var _ = Describe("Service.update", func() {
 		err := service.update(context.Background())
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
-		Expect(bmMachine.Status.FailureReason).ToNot(BeNil())
-		Expect(*bmMachine.Status.FailureReason).To(Equal(capierrors.UpdateMachineError))
-		Expect(bmMachine.Status.FailureMessage).ToNot(BeNil())
-		Expect(*bmMachine.Status.FailureMessage).To(ContainSubstring("host not found for machine \"test-machine\""))
 	})
 })
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -90,26 +91,75 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.BootstrapReadyCondition)
 
-	// try to find an existing server
+	// try to find an existing server.
 	server, err := s.findServer(ctx)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get server: %w", err)
+		// if it is not a rate limit exceeded error, set ServerNotFound condition on HCloudMachine.
+		if !hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+			conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.ServerAvailableCondition,
+				infrav1.ServerNotFoundReason,
+				clusterv1.ConditionSeverityError,
+				"failed to find server: %s",
+				err.Error(),
+			)
+
+			return reconcile.Result{}, fmt.Errorf("failed to find server: %w", err)
+		}
+
+		// We have a rate limit exceeded error. However, if the HCloudMachine is ready,
+		// indicating that the server has been created previously and was ready, then we don't want to
+		// set the rate limit exceeded error in the status because it is misleading.
+		if !s.scope.HCloudMachine.Status.Ready {
+			hcloudutil.HandleRateLimitExceeded(s.scope.HCloudMachine, err, "findServer")
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		}
+
+		// If HCloudMachine is ready, stop reconciling.
+		return reconcile.Result{}, nil
 	}
 
-	// if no server is found we have to create one
+	// if no server is found we have to create one.
 	if server == nil {
+		// If ProviderID is set, it indicates that a server was created earlier,
+		// but it no longer exists. Mark the machine as failed and stop further reconciliation.
+		if s.scope.HCloudMachine.Spec.ProviderID != nil {
+			s.scope.SetError(fmt.Sprintf("server with providerID %s not found", *s.scope.HCloudMachine.Spec.ProviderID), capierrors.UpdateMachineError)
+
+			conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.ServerAvailableCondition,
+				infrav1.ServerNotFoundReason,
+				clusterv1.ConditionSeverityError,
+				"server with providerID %s no longer exists",
+				*s.scope.HCloudMachine.Spec.ProviderID,
+			)
+
+			return reconcile.Result{}, nil
+		}
+
+		// otherwise create server.
 		server, err = s.createServer(ctx)
 		if err != nil {
 			if errors.Is(err, errServerCreateNotPossible) {
 				return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 			}
+
 			return reconcile.Result{}, fmt.Errorf("failed to create server: %w", err)
+		}
+
+		if server == nil {
+			return reconcile.Result{}, fmt.Errorf("createServer returned nil server without error")
 		}
 	}
 
-	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)
-
 	s.scope.SetProviderID(server.ID)
+
+	// Server found, so clear any previous errors.
+	s.scope.HCloudMachine.Status.FailureReason = nil
+	s.scope.HCloudMachine.Status.FailureMessage = nil
+	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)
 
 	// update HCloudMachineStatus
 	c := s.scope.HCloudMachine.Status.Conditions.DeepCopy()
@@ -193,7 +243,7 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 }
 
 // implements setting rate limit on hcloudmachine.
-func handleRateLimit(hm *infrav1.HCloudMachine, err error, functionName string, errMsg string) error {
+func handleRateLimit(hm *infrav1.HCloudMachine, err error, functionName string, errMsg string, log logr.Logger) error {
 	// returns error if not a rate limit exceeded error
 	if !hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 		return fmt.Errorf("%s: %w", errMsg, err)
@@ -201,6 +251,7 @@ func handleRateLimit(hm *infrav1.HCloudMachine, err error, functionName string, 
 
 	// does not return error if machine is running and does not have a deletion timestamp
 	if hm.Status.Ready && hm.DeletionTimestamp.IsZero() {
+		log.Info("Skipping rate limit condition: rate limit exceeded but machine is ready and not being deleted", "namespace", hm.Namespace, "name", hm.Name)
 		return nil
 	}
 
@@ -213,7 +264,7 @@ func handleRateLimit(hm *infrav1.HCloudMachine, err error, functionName string, 
 func (s *Service) Delete(ctx context.Context) (res reconcile.Result, err error) {
 	server, err := s.findServer(ctx)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to find server: %w", err)
+		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "findServer", "failed to find server for deletion", s.scope.Logger)
 	}
 
 	// if no server has been found, then nothing can be deleted
@@ -268,7 +319,7 @@ func (s *Service) reconcileNetworkAttachment(ctx context.Context, server *hcloud
 		if hcloud.IsError(err, hcloud.ErrorCodeServerAlreadyAttached) {
 			return nil
 		}
-		return handleRateLimit(s.scope.HCloudMachine, err, "AttachServerToNetwork", "failed to attach server to network")
+		return handleRateLimit(s.scope.HCloudMachine, err, "AttachServerToNetwork", "failed to attach server to network", s.scope.Logger)
 	}
 
 	return nil
@@ -332,7 +383,7 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 			return reconcile.Result{}, nil
 		}
 		errMsg := fmt.Sprintf("failed to add server %s with ID %d as target to load balancer", server.Name, server.ID)
-		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "AddTargetServerToLoadBalancer", errMsg)
+		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "AddTargetServerToLoadBalancer", errMsg, s.scope.Logger)
 	}
 
 	record.Eventf(
@@ -359,6 +410,10 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 	image, err := s.getServerImage(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server image: %w", err)
+	}
+
+	if image == nil {
+		return nil, fmt.Errorf("getServerImage returned nil image without error")
 	}
 
 	automount := false
@@ -438,7 +493,7 @@ func (s *Service) createServer(ctx context.Context) (*hcloud.Server, error) {
 	// get all ssh keys that are stored in HCloud API
 	sshKeysAPI, err := s.scope.HCloudClient.ListSSHKeys(ctx, hcloud.SSHKeyListOpts{})
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListSSHKeys", "failed listing ssh keys from hcloud")
+		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListSSHKeys", "failed listing ssh keys from hcloud", s.scope.Logger)
 	}
 
 	// find matching keys and store them
@@ -507,7 +562,7 @@ func (s *Service) getServerImage(ctx context.Context) (*hcloud.Image, error) {
 	// Get server type so we can filter for images with correct architecture
 	serverType, err := s.scope.HCloudClient.GetServerType(ctx, string(s.scope.HCloudMachine.Spec.Type))
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "GetServerType", "failed to get server type in HCloud")
+		return nil, handleRateLimit(s.scope.HCloudMachine, err, "GetServerType", "failed to get server type in HCloud", s.scope.Logger)
 	}
 	if serverType == nil {
 		conditions.MarkFalse(
@@ -531,7 +586,7 @@ func (s *Service) getServerImage(ctx context.Context) (*hcloud.Image, error) {
 
 	images, err := s.scope.HCloudClient.ListImages(ctx, listOpts)
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListImages", "failed to list images by label in HCloud")
+		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListImages", "failed to list images by label in HCloud", s.scope.Logger)
 	}
 
 	// query for an existing image by name.
@@ -541,7 +596,7 @@ func (s *Service) getServerImage(ctx context.Context) (*hcloud.Image, error) {
 	}
 	imagesByName, err := s.scope.HCloudClient.ListImages(ctx, listOpts)
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListImages", "failed to list images by name in HCloud")
+		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListImages", "failed to list images by name in HCloud", s.scope.Logger)
 	}
 
 	images = append(images, imagesByName...)
@@ -590,7 +645,7 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 					// if server is locked, we just retry again
 					return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 				}
-				return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "PowerOnServer", "failed to power on server")
+				return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "PowerOnServer", "failed to power on server", s.scope.Logger)
 			}
 		} else {
 			// Timed out. Set failure reason
@@ -604,7 +659,7 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 				// if server is locked, we just retry again
 				return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 			}
-			return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "PowerOnServer", "failed to power on server")
+			return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "PowerOnServer", "failed to power on server", s.scope.Logger)
 		}
 		conditions.MarkFalse(
 			s.scope.HCloudMachine,
@@ -626,7 +681,7 @@ func (s *Service) handleDeleteServerStatusRunning(ctx context.Context, server *h
 
 	if s.scope.HasServerAvailableCondition() {
 		if err := s.scope.HCloudClient.ShutdownServer(ctx, server); err != nil {
-			return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "ShutdownServer", "failed to shutdown server")
+			return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "ShutdownServer", "failed to shutdown server", s.scope.Logger)
 		}
 
 		conditions.MarkFalse(s.scope.HCloudMachine,
@@ -642,7 +697,7 @@ func (s *Service) handleDeleteServerStatusRunning(ctx context.Context, server *h
 	// timeout for shutdown has been reached - delete server
 	if err := s.scope.HCloudClient.DeleteServer(ctx, server); err != nil {
 		record.Warnf(s.scope.HCloudMachine, "FailedDeleteHCloudServer", "Failed to delete HCloud server %s", s.scope.Name())
-		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "DeleteServer", "failed to delete server")
+		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "DeleteServer", "failed to delete server", s.scope.Logger)
 	}
 
 	record.Eventf(s.scope.HCloudMachine, "HCloudServerDeleted", "HCloud server %s deleted", s.scope.Name())
@@ -653,7 +708,7 @@ func (s *Service) handleDeleteServerStatusOff(ctx context.Context, server *hclou
 	// server is off and can be deleted
 	if err := s.scope.HCloudClient.DeleteServer(ctx, server); err != nil {
 		record.Warnf(s.scope.HCloudMachine, "FailedDeleteHCloudServer", "Failed to delete HCloud server %s", s.scope.Name())
-		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "DeleteServer", "failed to delete server")
+		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "DeleteServer", "failed to delete server", s.scope.Logger)
 	}
 
 	record.Eventf(s.scope.HCloudMachine, "HCloudServerDeleted", "HCloud server %s deleted", s.scope.Name())
@@ -674,7 +729,7 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 		}
 
 		errMsg := fmt.Sprintf("failed to delete server %s with ID %d as target of load balancer %s with ID %d", server.Name, server.ID, lb.Name, lb.ID)
-		return handleRateLimit(s.scope.HCloudMachine, err, "DeleteTargetServerOfLoadBalancer", errMsg)
+		return handleRateLimit(s.scope.HCloudMachine, err, "DeleteTargetServerOfLoadBalancer", errMsg, s.scope.Logger)
 	}
 	record.Eventf(
 		s.scope.HetznerCluster,
@@ -694,8 +749,7 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	if err == nil {
 		server, err = s.scope.HCloudClient.GetServer(ctx, serverID)
 		if err != nil {
-			errMsg := fmt.Sprintf("failed to get server %d", serverID)
-			return nil, handleRateLimit(s.scope.HCloudMachine, err, "GetServer", errMsg)
+			return nil, fmt.Errorf("failed to get server %d: %w", serverID, err)
 		}
 
 		// if server has been found, return it
@@ -711,7 +765,7 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 
 	servers, err := s.scope.HCloudClient.ListServers(ctx, opts)
 	if err != nil {
-		return nil, handleRateLimit(s.scope.HCloudMachine, err, "ListServers", "failed to list servers")
+		return nil, fmt.Errorf("failed to list servers: %w", err)
 	}
 
 	if len(servers) > 1 {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -33,6 +34,7 @@ import (
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
+	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	fakeclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 )
 
@@ -354,7 +356,8 @@ var _ = Describe("Test handleRateLimit", func() {
 
 	DescribeTable("Test handleRateLimit",
 		func(tc testCaseHandleRateLimit) {
-			err := handleRateLimit(tc.hm, tc.err, tc.functionName, tc.errMsg)
+			log := klog.Background()
+			err := handleRateLimit(tc.hm, tc.err, tc.functionName, tc.errMsg, log)
 			if tc.expectError != nil {
 				Expect(err).To(MatchError(tc.expectError))
 			} else {
@@ -433,6 +436,155 @@ var _ = Describe("Test handleRateLimit", func() {
 			expectCondition: false,
 		}),
 	)
+})
+
+var _ = Describe("findServer", func() {
+	var (
+		hcloudMachine  *infrav1.HCloudMachine
+		hetznerCluster *infrav1.HetznerCluster
+		capiMachine    *clusterv1.Machine
+		client         hcloudclient.Client
+		service        *Service
+	)
+
+	BeforeEach(func() {
+		hcloudMachine = &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.HCloudMachineSpec{
+				ImageName: "my-image",
+				Type:      "cpx31",
+			},
+		}
+
+		hetznerCluster = &infrav1.HetznerCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cluster",
+			},
+		}
+
+		capiMachine = &clusterv1.Machine{}
+
+		client = fakeclient.NewHCloudClientFactory().NewClient("")
+	})
+
+	It("should find the server by provider ID when server exists and provider ID is set", func() {
+		By("creating a server")
+		createdServer, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{
+			Name: "test-server-providerid",
+		})
+		Expect(err).To(BeNil())
+
+		hcloudMachine.Spec.ProviderID = ptr.To(fmt.Sprintf("hcloud://%d", createdServer.ID))
+
+		service = newTestService(hcloudMachine, client)
+		service.scope.Machine = capiMachine
+		service.scope.HetznerCluster = hetznerCluster
+
+		By("finding the server")
+		server, err := service.findServer(context.Background())
+		Expect(err).To(BeNil())
+		Expect(server).ToNot(BeNil())
+		Expect(server.ID).To(Equal(createdServer.ID))
+
+		// teardown: remove the created server otherwise it will pollute the subsequent tests.
+		err = client.DeleteServer(context.Background(), createdServer)
+		Expect(err).To(BeNil())
+	})
+
+	It("should find the server by matching labels if server exists but provider ID is not set", func() {
+		service = newTestService(hcloudMachine, client)
+		service.scope.Machine = capiMachine
+		service.scope.HetznerCluster = hetznerCluster
+
+		By("creating a server with matching labels")
+		labels := service.createLabels()
+		createdServer, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{
+			Name:   "test-server-labels",
+			Labels: labels,
+		})
+		Expect(err).To(Succeed())
+
+		By("finding the server via label selector")
+		server, err := service.findServer(context.Background())
+		Expect(err).To(Succeed())
+		Expect(server).ToNot(BeNil())
+		Expect(server.ID).To(Equal(createdServer.ID))
+
+		// teardown: remove the created server otherwise it will pollute the subsequent tests.
+		err = client.DeleteServer(context.Background(), createdServer)
+		Expect(err).To(BeNil())
+	})
+
+	It("should return nil without error when no server is found", func() {
+		service = newTestService(hcloudMachine, client)
+		service.scope.Machine = capiMachine
+		service.scope.HetznerCluster = hetznerCluster
+
+		By("finding server")
+		server, err := service.findServer(context.Background())
+		Expect(err).To(Succeed())
+		Expect(server).To(BeNil())
+	})
+
+	It("should fall back to label search when provider ID is set but server no longer exists", func() {
+		hcloudMachine.Spec.ProviderID = ptr.To("hcloud://99999")
+
+		service = newTestService(hcloudMachine, client)
+		service.scope.Machine = capiMachine
+		service.scope.HetznerCluster = hetznerCluster
+
+		By("creating a server with matching labels")
+		labels := service.createLabels()
+		createdServer, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{
+			Name:   "test-server-fallback",
+			Labels: labels,
+		})
+		Expect(err).To(Succeed())
+
+		By("not finding server by ID, falling back to labels")
+		server, err := service.findServer(context.Background())
+		Expect(err).To(Succeed())
+		Expect(server).ToNot(BeNil())
+		Expect(server.ID).To(Equal(createdServer.ID))
+
+		// teardown: remove the created server otherwise it will pollute the subsequent tests.
+		err = client.DeleteServer(context.Background(), createdServer)
+		Expect(err).To(BeNil())
+	})
+
+	It("should return an error when multiple servers match labels", func() {
+		service = newTestService(hcloudMachine, client)
+		service.scope.Machine = capiMachine
+		service.scope.HetznerCluster = hetznerCluster
+
+		By("creating two servers with matching labels")
+		labels := service.createLabels()
+		s1, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{
+			Name:   "test-server-multi-1",
+			Labels: labels,
+		})
+		Expect(err).To(Succeed())
+
+		s2, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{
+			Name:   "test-server-multi-2",
+			Labels: labels,
+		})
+		Expect(err).To(Succeed())
+
+		By("expecting an error for multiple instances")
+		server, err := service.findServer(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(server).To(BeNil())
+
+		// teardown: remove the created server otherwise it will pollute the subsequent tests.
+		err = client.DeleteServer(context.Background(), s1)
+		Expect(err).To(BeNil())
+		err = client.DeleteServer(context.Background(), s2)
+		Expect(err).To(BeNil())
+	})
 })
 
 func isPresentAndFalseWithReason(getter conditions.Getter, condition clusterv1.ConditionType, reason string) bool {


### PR DESCRIPTION

<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In some of the cases, function `handleRateLimit()` returns both server and error is nil. When server as nil is used at other places (which expects it to be non-nil) it causes errors.

We need to handle the cases where variable server is used and is nil carefully.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
