### PR TITLE
:seedling: allow CAPH controller to list/watch namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,18 +18,20 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
   - list
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/controllers/namespace_skip.go
+++ b/controllers/namespace_skip.go
@@ -27,7 +27,7 @@ import (
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 )
 
-//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 func shouldSkipReconciliationForNamespace(ctx context.Context, c client.Reader, namespace string) (bool, error) {
 	if namespace == "" {


### PR DESCRIPTION
## Summary
- grant `namespaces` `list` and `watch` in manager RBAC markers
- regenerate `config/rbac/role.yaml`

## Why
CAPH controller-runtime cache attempts to watch/list `Namespace` objects. With only `get`, controller startup fails with:

`Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden ... cannot list resource "namespaces" at the cluster scope`.

## Verification
- `make generate-manifests`
- `go test ./controllers -run Test_shouldSkipReconciliationForNamespace -count=1`
