### PR TITLE
:sparkles: make existing subnet logic more robust

### DIFF
--- a/pkg/services/hcloud/network/network.go
+++ b/pkg/services/hcloud/network/network.go
@@ -172,14 +172,35 @@ func (s *Service) findNetwork(ctx context.Context) (*hcloud.Network, error) {
 		return nil, nil
 	}
 
-	if len(networks[0].Subnets) > 1 {
-		configuredSubnet := s.scope.HetznerCluster.Spec.HCloudNetwork.SubnetCIDRBlock
-		firstSubnet := networks[0].Subnets[0]
+	if len(networks[0].Subnets) >= 1 {
+		// Allow existing subnets, but validate them
 
-		// Allow multiple subnets only if the first subnet matches the configured one. On attaching a server to a
-		// network the first subnet is used.
-		if firstSubnet.IPRange.String() != configuredSubnet {
-			return nil, fmt.Errorf("multiple subnets found and first subnet %s doesn't match the configured %s", firstSubnet.IPRange.String(), configuredSubnet)
+		// When multiple subnets of type "cloud" are present,
+		// there currently is no guarantee that resources will be created in the correct subnet
+		// The current solution is to allow only one subnet of type "cloud" and any subnet of type "vswitch" (technically limited to 1 though)
+		// Official support for multiple "cloud" subnets can be added when using hcloud-go version >= 2.30.0
+		// where ServerAttachToNetworkOpts allows to specify an "IPRange"
+		// ref: https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2@v2.30.0/hcloud#ServerAttachToNetworkOpts
+
+		// Create a new slice with only "cloud" typed subnet
+		cloudSubnets := slices.Clone(networks[0].Subnets)
+		cloudSubnets = slices.DeleteFunc(cloudSubnets, func(s hcloud.NetworkSubnet) bool {
+			return s.Type == hcloud.NetworkSubnetTypeVSwitch
+		})
+
+		switch c := len(cloudSubnets); {
+		case c > 1:
+			return nil, fmt.Errorf("multiple subnet of type 'cloud' are currently not allowed")
+		case c == 0:
+			return nil, fmt.Errorf("a subnet of type 'cloud' is missing")
+		case c == 1:
+			configuredSubnet := s.scope.HetznerCluster.Spec.HCloudNetwork.SubnetCIDRBlock
+			gotSubnet := cloudSubnets[0].IPRange.String()
+
+			// Make sure the configured subnet CIDR matches the one available in the network
+			if gotSubnet != configuredSubnet {
+				return nil, fmt.Errorf("the subnet %s does not match the configured %s", gotSubnet, configuredSubnet)
+			}
 		}
 	}
 

--- a/pkg/services/hcloud/network/network_test.go
+++ b/pkg/services/hcloud/network/network_test.go
@@ -96,13 +96,13 @@ var _ = Describe("Test findNetwork", func() {
 		Expect(network).To(BeNil())
 	})
 
-	It("outputs the correct network if there are multiple subnets but the first one matches the configured one on the HetznerCluster", func() {
+	It("outputs the correct network if there is one existing subnet of type cloud and one existing subnet of type vswitch", func() {
 		_, createErr := hcloudClient.CreateNetwork(context.Background(), hcloud.NetworkCreateOpts{
 			Name:    "test-network",
 			IPRange: networkCidr,
 			Subnets: []hcloud.NetworkSubnet{
 				{IPRange: subnetCidr, Type: hcloud.NetworkSubnetTypeCloud},
-				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeCloud},
+				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeVSwitch},
 			},
 			Labels: map[string]string{"caph-cluster-hetzner-cluster": "owned"},
 		})
@@ -114,7 +114,7 @@ var _ = Describe("Test findNetwork", func() {
 			IPRange: networkCidr,
 			Subnets: []hcloud.NetworkSubnet{
 				{IPRange: subnetCidr, Type: hcloud.NetworkSubnetTypeCloud},
-				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeCloud},
+				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeVSwitch},
 			},
 			Labels: map[string]string{"caph-cluster-hetzner-cluster": "owned"},
 		}
@@ -124,13 +124,31 @@ var _ = Describe("Test findNetwork", func() {
 		Expect(network).To(Equal(expectedNetwork))
 	})
 
-	It("gives an error if there there are multiple subnet and the first one doesn't match the configure one on the HetznerCluster", func() {
+	It("gives an error if an existing subnet of type cloud does not match the configured one on the HetznerCluster", func() {
 		_, createErr := hcloudClient.CreateNetwork(context.Background(), hcloud.NetworkCreateOpts{
 			Name:    "test-network",
 			IPRange: networkCidr,
 			Subnets: []hcloud.NetworkSubnet{
 				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeCloud},
+			},
+			Labels: map[string]string{"caph-cluster-hetzner-cluster": "owned"},
+		})
+		Expect(createErr).To(BeNil())
+
+		println("createErr", createErr)
+
+		network, err := service.findNetwork(context.Background())
+		Expect(network).To(BeNil())
+		Expect(err).To(Equal(fmt.Errorf("the subnet 10.0.1.0/24 does not match the configured 10.0.0.0/24")))
+	})
+
+	It("gives an error if there are multiple subnet of type cloud", func() {
+		_, createErr := hcloudClient.CreateNetwork(context.Background(), hcloud.NetworkCreateOpts{
+			Name:    "test-network",
+			IPRange: networkCidr,
+			Subnets: []hcloud.NetworkSubnet{
 				{IPRange: subnetCidr, Type: hcloud.NetworkSubnetTypeCloud},
+				{IPRange: subnet2Cidr, Type: hcloud.NetworkSubnetTypeCloud},
 			},
 			Labels: map[string]string{"caph-cluster-hetzner-cluster": "owned"},
 		})
@@ -138,7 +156,23 @@ var _ = Describe("Test findNetwork", func() {
 
 		network, err := service.findNetwork(context.Background())
 		Expect(network).To(BeNil())
-		Expect(err).To(Equal(fmt.Errorf("multiple subnets found and first subnet 10.0.1.0/24 doesn't match the configured 10.0.0.0/24")))
+		Expect(err).To(Equal(fmt.Errorf("multiple subnet of type 'cloud' are currently not allowed")))
+	})
+
+	It("gives an error if there is a subnet of type vswitch but no subnet of type cloud", func() {
+		_, createErr := hcloudClient.CreateNetwork(context.Background(), hcloud.NetworkCreateOpts{
+			Name:    "test-network",
+			IPRange: networkCidr,
+			Subnets: []hcloud.NetworkSubnet{
+				{IPRange: subnetCidr, Type: hcloud.NetworkSubnetTypeVSwitch},
+			},
+			Labels: map[string]string{"caph-cluster-hetzner-cluster": "owned"},
+		})
+		Expect(createErr).To(BeNil())
+
+		network, err := service.findNetwork(context.Background())
+		Expect(network).To(BeNil())
+		Expect(err).To(Equal(fmt.Errorf("a subnet of type 'cloud' is missing")))
 	})
 
 	It("gives an error if there are multiple networks with the same label", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

I saw that https://github.com/syself/cluster-api-provider-hetzner/pull/1633 got merged although there where still some open concerns in the comments about it's implementation.

- the list of subnet returned from HCloud API is unstable, so validating against the first [subnets IPRange](https://github.com/syself/cluster-api-provider-hetzner/pull/1633/changes#diff-05e1ae5363dcc702c1b1f13e95187ee1c642b973f2c440a6f28f1e1fcaaa9b35R177) is unstable
- if we have multiple subnet of type `cloud`, there is no guarantee that created resources are being applied to the correct subnet by HCloud

This PR is my take in making that logic more robust. It:

- allows only **one** existing subnet of type `cloud`
- allows any additional number of subnets with type `vswitch` (although HCloud is limited to one vswitch subnet per network)
- validates the subnet CIDR of an existing subnet of type `cloud` against the configured subnet CIDR

So, in detail it explicitly fails if:

- there are two or more subnet of type `cloud`
- there is one subnet of type `vswitch` but no subnet of type `cloud`
- there is one subnet of type `cloud` but it does not match the configured CIDR

**Special notes for your reviewer**:

- I explicitly changed the logic from `len(networks[0].Subnets) > 1` to `len(networks[0].Subnets) >= 1` (line 175) so that we can always validate the configured subnets CIDR
- I decided to only "ignore" subnets of type `NetworkSubnetTypeVSwitch` and not `NetworkSubnetTypeServer`, as those are deprecated and AFAIK unavailable anyways.
- This subnet logic can be improved once upgrading to `hcloud-go` version `>= 2.30.0`, as it then allows to specify the correct `IPRange` via `ServerAttachToNetworkOpts` to target the correct subnet even if there are multiple subnet of type `cloud`
- I modified and extended the network tests. Test output:
```shell
hack/tools/bin/ginkgo run  ./pkg/services/hcloud/network | ./hack/filter-caph-controller-manager-logs.py -

2026/03/12 09:58:24 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Running Suite: Network Suite - /home/sk/git/github/skuethe/cluster-api-provider-hetzner/pkg/services/hcloud/network
===================================================================================================================

Will run 10 of 10 specs
•••••••createErr (0x0,0x0)
•••

Ran 10 of 10 Specs in 0.000 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 966.672615ms
Test Suite Passed
```

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [x] add unit tests
