### PR TITLE
:seedling: test(e2e): update HBMH list with IPs and maintenance state

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -6,7 +6,7 @@ metadata:
     baremetal-pool: ci-pool
     name: bm-e2e-1670788
 spec:
-  serverID: 1670788
+  serverID: 1670788 # ip: 136.243.69.167
   rootDeviceHints:
     wwn: "0x5002538c0004413f"
   maintenanceMode: false
@@ -21,7 +21,7 @@ metadata:
     baremetal-pool: free-pool
     name: bm-e2e-1716772
 spec:
-  serverID: 1716772
+  serverID: 1716772 # ip: 136.243.69.24
   rootDeviceHints:
     wwn: "0x5002538d41d70a46"
   maintenanceMode: false
@@ -35,7 +35,7 @@ metadata:
     baremetal-pool: ci-pool
     name: bm-e2e-1724024
 spec:
-  serverID: 1724024
+  serverID: 1724024 # ip: 136.243.69.253
   rootDeviceHints:
     wwn: "0x500a075111968d25"
   maintenanceMode: false
@@ -50,7 +50,7 @@ metadata:
     baremetal-pool: free-pool
     name: bm-e2e-1731561
 spec:
-  serverID: 1731561
+  serverID: 1731561 # ip: 144.76.92.247
   rootDeviceHints:
     wwn: "0x500a075119615dc2"
   maintenanceMode: false
@@ -65,13 +65,13 @@ metadata:
     baremetal-pool: free-pool
     name: bm-e2e-1751550
 spec:
-  serverID: 1751550
+  serverID: 1751550 # ip: 144.76.74.13
   rootDeviceHints:
     wwn: "0x500a075119549dcf"
   maintenanceMode: true #### < --- set to false, when ok.
   description: Test Machine 1751550
 ---
-# Worked Feb 2026
+# Failed 2026-03-12: does not reach rescue system
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -80,8 +80,8 @@ metadata:
     baremetal-pool: ci-pool
     name: bm-e2e-1763731
 spec:
-  serverID: 1763731
+  serverID: 1763731 # ip: 144.76.101.50
   rootDeviceHints:
     wwn: "0x500a07511756c36d"
-  maintenanceMode: false
+  maintenanceMode: true
   description: Test Machine 1751550


### PR DESCRIPTION
## Summary
- annotate `serverID` entries in the baremetal host fixture with the corresponding public IP
- mark host `1763731` as `maintenanceMode: true`
- update the note for that host to indicate the 2026-03-12 rescue-system failure

## Context
Extracted from #1863 as the first small PR in the split sequence.