### PR TITLE
:seedling: e2e, improve machine log collector fallback and diagnostics

### DIFF
--- a/test/e2e/log_collector.go
+++ b/test/e2e/log_collector.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -214,7 +213,7 @@ func infrastructureMachineExternalIP(ctx context.Context, c client.Client, m *cl
 	}
 
 	key := client.ObjectKey{
-		Namespace: infrastructureRefNamespace(m.Spec.InfrastructureRef, m.Namespace),
+		Namespace: m.Namespace,
 		Name:      m.Spec.InfrastructureRef.Name,
 	}
 
@@ -302,13 +301,6 @@ func associatedHostFromHBMM(ctx context.Context, c client.Client, hbmm *infrav1.
 	}
 
 	return host, hostKey, nil
-}
-
-func infrastructureRefNamespace(ref corev1.ObjectReference, defaultNamespace string) string {
-	if ref.Namespace != "" {
-		return ref.Namespace
-	}
-	return defaultNamespace
 }
 
 func externalIPFromAddresses(addresses []clusterv1.MachineAddress) string {


### PR DESCRIPTION
## Summary
- make machine log collection resolve `MachineExternalIP` via infrastructure machine fallback when machine status is missing it
- improve diagnostics for infrastructure lookup failures and unsupported infra kinds
- avoid the creating empty log files.

Background: We want to get the logs from the pods of the wl-cluster. Especially CCM.

