### PR TITLE
:seedling: e2e: fail fast when a HetznerBareMetalHost has a permanent error

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -610,10 +610,7 @@ func logBareMetalHostStatus(ctx context.Context, c client.Client) error {
 		if eMsg != "" {
 			log("  Error: " + eMsg)
 			if hbmh.Spec.Status.ErrorType == infrav1.PermanentError {
-				return &permanentHBMHError{
-					name:    hbmh.Name,
-					message: eMsg,
-				}
+				return fmt.Errorf("%w on HetznerBareMetalHost %q: %s", errPermanentHBMH, hbmh.Name, eMsg)
 			}
 		}
 
@@ -629,19 +626,6 @@ func logBareMetalHostStatus(ctx context.Context, c client.Client) error {
 		log("  ProvisioningState: " + string(hbmh.Spec.Status.ProvisioningState) + " | Ready Condition: " + state + " " + reason + " " + msg)
 	}
 	return nil
-}
-
-type permanentHBMHError struct {
-	name    string
-	message string
-}
-
-func (e *permanentHBMHError) Error() string {
-	return fmt.Sprintf("permanent error on HetznerBareMetalHost %q: %s", e.name, e.message)
-}
-
-func (e *permanentHBMHError) Is(target error) bool {
-	return target == errPermanentHBMH
 }
 
 func initBootstrapCluster(ctx context.Context, bootstrapClusterProxy framework.ClusterProxy, config *clusterctl.E2EConfig, clusterctlConfig, artifactFolder string) {


### PR DESCRIPTION
## Summary
- stop the background e2e status loop immediately when any HetznerBareMetalHost reports `ErrorType=permanent error`
- fail the running spec via Ginkgo instead of only logging and waiting for the full control-plane timeout
- keep normal logging behavior for non-permanent status/logging errors

## Why
When a host enters a permanent error state (for example a rescue-system hostname mismatch), the current e2e run keeps waiting until the long timeout (often ~20 minutes). This change terminates the test early with the actual permanent error.

## Testing
- `go test ./test/e2e -run TestDoesNotExist -count=1`