### PR TITLE
:seedling: use exit status for cloud-init SIGTERM grep handling

### DIFF
--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -64,8 +64,6 @@ var downloadFromOciShellScript string
 var (
 	// ErrCommandExitedWithoutExitSignal means the ssh command exited unplanned.
 	ErrCommandExitedWithoutExitSignal = errors.New("wait: remote command exited without exit status or exit signal")
-	// ErrCommandExitedWithStatusOne means the ssh command exited with sttatus 1.
-	ErrCommandExitedWithStatusOne = errors.New("process exited with status 1")
 
 	// ErrAuthenticationFailed means ssh was unable to authenticate.
 	ErrAuthenticationFailed = errors.New("ssh: unable to authenticate")
@@ -446,8 +444,13 @@ func (c *sshClient) CloudInitStatus() Output {
 // CheckCloudInitLogsForSigTerm implements the CheckCloudInitLogsForSigTerm method of the SSHClient interface.
 func (c *sshClient) CheckCloudInitLogsForSigTerm() Output {
 	out := c.runSSH(`cat /var/log/cloud-init.log | grep "SIGTERM"`)
-	if out.Err != nil && strings.Contains(out.Err.Error(), ErrCommandExitedWithStatusOne.Error()) {
-		return Output{}
+	if out.Err != nil {
+		exitStatus, err := out.ExitStatus()
+		if err == nil && exitStatus == 1 {
+			// grep exits with status 1 when no matching line is found.
+			// That's expected in this check and should not fail reconciliation.
+			return Output{}
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- make `CheckCloudInitLogsForSigTerm` rely on SSH exit status instead of string matching
- treat `grep` exit status `1` as expected "no SIGTERM found" and return success
- remove the now-unneeded `ErrCommandExitedWithStatusOne` string constant

## Why
Recent SSH error wrapping includes connection details and can preserve upstream error text casing (`Process exited with status 1`).
The previous check used a case-sensitive string match on `"process exited with status 1"`, which can fail and incorrectly block host provisioning in `ensure-provisioned`.

## Notes
I checked the latest merged PR (`#1871`). It contains this fix idea in an early commit, but the final merged branch keeps the fragile string comparison, so this targeted fix is still needed on `v1.1.x`.

## Testing
- `go test ./pkg/services/baremetal/client/ssh -count=1`
- `go test ./pkg/services/baremetal/host -run TestDoesNotExist -count=1`
