### PR TITLE
:seedling: Stop reconciling on irrecoverable and unauthorized errors

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -48,6 +48,8 @@ const (
 	ServerTypeNotFoundReason = "ServerTypeNotFound"
 	// ServerCreateFailedReason indicates that server could not get created.
 	ServerCreateFailedReason = "ServerCreateFailedReason"
+	// ServerCreateFailedIrrecoverableErrorReason indicates that server creation failed with an irrecoverable error.
+	ServerCreateFailedIrrecoverableErrorReason = "ServerCreateFailedIrrecoverableError"
 )
 
 const (

--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -92,15 +92,6 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 
 	log = log.WithValues("HCloudMachine", klog.KObj(hcloudMachine))
 
-	// If the HCloudMachine has an unauthorized / HCloudCredentialsInvalid error, stop reconciling.
-	// There is no point in retrying API calls with an invalid token.
-	// The MachineHealthCheck will eventually remediate the machine by deleting and recreating it.
-	if conditions.IsFalse(hcloudMachine, infrav1.HCloudTokenAvailableCondition) &&
-		conditions.GetReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition) == infrav1.HCloudCredentialsInvalidReason {
-		log.Info("HCloudMachine has HCloudCredentialsInvalid, stopping reconciliation")
-		return reconcile.Result{}, nil
-	}
-
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r, hcloudMachine.ObjectMeta)
 	if err != nil {
@@ -175,6 +166,9 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 	defer func() {
 		if reterr != nil && errors.Is(reterr, hcloudclient.ErrUnauthorized) {
 			conditions.MarkFalse(hcloudMachine, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason, clusterv1.ConditionSeverityError, "wrong hcloud token")
+			// Don't return an error, no point retrying with invalid credentials.
+			reterr = nil
+			res = reconcile.Result{}
 		} else {
 			conditions.MarkTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)
 		}

--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -92,6 +92,15 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 
 	log = log.WithValues("HCloudMachine", klog.KObj(hcloudMachine))
 
+	// If the HCloudMachine has an unauthorized / HCloudCredentialsInvalid error, stop reconciling.
+	// There is no point in retrying API calls with an invalid token.
+	// The MachineHealthCheck will eventually remediate the machine by deleting and recreating it.
+	if conditions.IsFalse(hcloudMachine, infrav1.HCloudTokenAvailableCondition) &&
+		conditions.GetReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition) == infrav1.HCloudCredentialsInvalidReason {
+		log.Info("HCloudMachine has HCloudCredentialsInvalid, stopping reconciliation")
+		return reconcile.Result{}, nil
+	}
+
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r, hcloudMachine.ObjectMeta)
 	if err != nil {

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -108,6 +108,19 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 
 	log = log.WithValues("HCloudMachine", klog.KObj(hcloudMachine))
 
+	// Skip remediation for machines that failed to create with irrecoverable errors (e.g. invalid_input, resource_unavailable).
+	// These errors cannot be fixed by rebooting or replacing the machine.
+	// We return without error so the MHC does not keep retrying remediation.
+	if conditions.IsFalse(hcloudMachine, infrav1.ServerCreateSucceededCondition) &&
+		conditions.GetReason(hcloudMachine, infrav1.ServerCreateSucceededCondition) == infrav1.ServerCreateFailedIrrecoverableErrorReason {
+		log.Info("Skipping remediation for machine with irrecoverable creation failure",
+			"reason", conditions.GetMessage(hcloudMachine, infrav1.ServerCreateSucceededCondition),
+		)
+
+		// signal remediation done.
+		return reconcile.Result{}, nil
+	}
+
 	// Fetch the Cluster.
 	cluster, err := util.GetClusterFromMetadata(ctx, r, machine.ObjectMeta)
 	if err != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -199,6 +199,21 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 
 	server, image, err := s.createServerFromImageNameOrURL(ctx)
 	if err != nil {
+		// Terminal errors like invalid_input (e.g. unsupported location for server type)
+		// or resource_unavailable (e.g. server location disabled) will never succeed on retry.
+		// Mark the machine as irrecoverably failed and stop reconciling.
+		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable) {
+			conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.ServerCreateSucceededCondition,
+				infrav1.ServerCreateFailedIrrecoverableErrorReason,
+				clusterv1.ConditionSeverityError,
+				"%s",
+				err.Error(),
+			)
+			return reconcile.Result{}, nil
+		}
+
 		if errors.Is(err, errServerCreateNotPossible) {
 			err = fmt.Errorf("createServerFromImageNameOrURL failed: %w", err)
 			s.scope.Error(err, "")


### PR DESCRIPTION


<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
HCloudMachine should not be reconciled further if it encounters an irrecoverable error such as `invalid_input`, `resource_unavailable` OR
`unauthorized` error which occurs when a wrong HCloudToken is used to call the Hetzner API.

Additionally, the remediation should be skipped as well for irrecoverable errors.

This is inline with the changes made to the main branch via #1887 and #1888

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
