### PR TITLE
:seedling: Stop reconciling if associated host is not found for hbmm

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -102,9 +102,13 @@ const (
 
 const (
 	// HostReadyCondition reports on whether the HetznerBareMetalHost is ready or not. The hbmm
-	// reconciler reads the clusterv1.ReadyCondition condition from the host, and mirrors the Reason
-	// and Message on the HostReadyCondition of the hbmm.
+	// reconciler reads the clusterv1.ReadyCondition condition from the host (if the host exists),
+	// and mirrors the Reason and Message on the HostReadyCondition of the hbmm.
 	HostReadyCondition clusterv1.ConditionType = "HostReady"
+
+	// HostNotFoundReason indicates that the HetznerBaremetalHost associated with the HetznerBaremetalMachine
+	// was not found.
+	HostNotFoundReason = "HostNotFound"
 )
 
 const (

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -763,7 +763,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 		})
 	})
 
-	Context("Tests with hosts that got deleted later", func() {
+	Context("Tests with hosts which get deleted later", func() {
 		var (
 			host        *infrav1.HetznerBareMetalHost
 			hostKey     client.ObjectKey

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -763,6 +763,106 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 		})
 	})
 
+	Context("Tests with hosts that got deleted later", func() {
+		var (
+			host        *infrav1.HetznerBareMetalHost
+			hostKey     client.ObjectKey
+			capiMachine *clusterv1.Machine
+			bmmKey      client.ObjectKey
+		)
+
+		BeforeEach(func() {
+			host = helpers.BareMetalHost(
+				hostName,
+				testNs.Name,
+				helpers.WithRootDeviceHintWWN(),
+				helpers.WithHetznerClusterRef(hetznerClusterName),
+			)
+			Expect(testEnv.Create(ctx, host)).To(Succeed())
+
+			hostKey = client.ObjectKeyFromObject(host)
+
+			capiMachine = &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       machineName,
+					Namespace:  testNs.Name,
+					Finalizers: []string{clusterv1.MachineFinalizer},
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: capiCluster.Name,
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: capiCluster.Name,
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "HetznerBareMetalMachine",
+						Name:       machineName,
+					},
+					FailureDomain: &defaultFailureDomain,
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To("bootstrap-secret"),
+					},
+				},
+			}
+			Expect(testEnv.Create(ctx, capiMachine)).To(Succeed())
+
+			bmMachine = &infrav1.HetznerBareMetalMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      machineName,
+					Namespace: testNs.Name,
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: capiCluster.Name,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cluster.x-k8s.io/v1beta1",
+							Kind:       "Machine",
+							Name:       capiMachine.Name,
+							UID:        capiMachine.UID,
+						},
+					},
+				},
+				Spec: getDefaultHetznerBareMetalMachineSpec(),
+			}
+			Expect(testEnv.Create(ctx, bmMachine)).To(Succeed())
+
+			bmmKey = client.ObjectKeyFromObject(bmMachine)
+
+			osSSHSecret := helpers.GetDefaultSSHSecret("os-ssh-secret", testNs.Name)
+			Expect(testEnv.Create(ctx, osSSHSecret)).To(Succeed())
+		})
+
+		It("First associate a host with baremetal machine and later delete the host", func() {
+			By("Waiting until host is provisioned")
+
+			Eventually(func() bool {
+				return isPresentAndTrue(bmmKey, bmMachine, infrav1.HostReadyCondition)
+			}, timeout).Should(BeTrue())
+
+			err := testEnv.Get(ctx, hostKey, host)
+			Expect(err).To(BeNil())
+
+			Expect(host.Spec.Status.ProvisioningState).To(Equal(infrav1.StateProvisioned))
+
+			By("Deleting the host, expect HostReady condition is set to false")
+			Expect(testEnv.Delete(ctx, host)).To(Succeed())
+
+			Eventually(func() bool {
+				return isPresentAndFalseWithReason(bmmKey, bmMachine, infrav1.HostReadyCondition, infrav1.HostNotFoundReason)
+			}, timeout).Should(BeTrue())
+
+			By("ensuring remediate machine annotation is set on CAPI machine")
+			Expect(testEnv.Get(ctx, client.ObjectKeyFromObject(capiMachine), capiMachine)).To(Succeed())
+
+			_, found := capiMachine.Annotations[clusterv1.RemediateMachineAnnotation]
+			Expect(found).To(BeTrue())
+		})
+
+		AfterEach(func() {
+			Expect(testEnv.Cleanup(ctx, host)).To(Succeed())
+		})
+	})
+
 	Context("hetznerBareMetalMachine validation", func() {
 		var capiMachine *clusterv1.Machine
 

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -114,6 +114,19 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	// update the machine
 	host, err := s.update(ctx)
+	if apierrors.IsNotFound(err) {
+		// if host doesn't exist, set HostNotFound condition on HetznerBaremetalMachine
+		// and mark the machine object for remediation and stop reconciling.
+		conditions.MarkFalse(
+			s.scope.BareMetalMachine,
+			infrav1.HostReadyCondition,
+			infrav1.HostNotFoundReason,
+			clusterv1.ConditionSeverityError,
+			"associated host not found",
+		)
+
+		return reconcile.Result{}, s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found")
+	}
 	if err != nil {
 		return checkForRequeueError(err, "failed to update machine")
 	}
@@ -126,7 +139,21 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	}
 
 	// set providerID if necessary
-	if err := s.setProviderID(ctx); err != nil {
+	err = s.setProviderID(ctx)
+	if apierrors.IsNotFound(err) {
+		// if host doesn't exist, set HostNotFound condition on HetznerBaremetalMachine
+		// and mark the machine object for remediation and stop reconciling.
+		conditions.MarkFalse(
+			s.scope.BareMetalMachine,
+			infrav1.HostReadyCondition,
+			infrav1.HostNotFoundReason,
+			clusterv1.ConditionSeverityError,
+			"associated host not found",
+		)
+
+		return reconcile.Result{}, s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found")
+	}
+	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to set providerID: %w", err)
 	}
 
@@ -140,10 +167,9 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 func (s *Service) Delete(ctx context.Context) (reconcile.Result, error) {
 	// get host - ignore if not found
 	host, helper, err := s.getAssociatedHostAndPatchHelper(ctx)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, fmt.Errorf("failed to get associated host: %w", err)
 	}
-
 	if host != nil && host.Spec.ConsumerRef != nil {
 		s.scope.BareMetalMachine.Status.Phase = clusterv1.MachinePhaseDeleting
 
@@ -215,13 +241,9 @@ func (s *Service) Delete(ctx context.Context) (reconcile.Result, error) {
 func (s *Service) update(ctx context.Context) (*infrav1.HetznerBareMetalHost, error) {
 	host, helper, err := s.getAssociatedHostAndPatchHelper(ctx)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			msg := fmt.Sprintf("host not found for machine %q. Setting error and deleting machine", s.scope.Machine.Name)
-			err = s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, msg)
-			return nil, err
-		}
 		return nil, fmt.Errorf("failed to get host: %w", err)
 	}
+
 	if host == nil {
 		err = errors.Join(s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found"))
 		return nil, fmt.Errorf("host not found for machine %s: %w", s.scope.Machine.Name, err)
@@ -362,7 +384,7 @@ func (s *Service) associate(ctx context.Context) error {
 }
 
 // getAssociatedHostAndPatchHelper gets the associated host by looking for an annotation on the
-// machine that contains a reference to the host. Returns nil if not found. Assumes the host is in
+// machine that contains a reference to the host. Assumes the host is in
 // the same namespace as the machine. Additionally, a PatchHelper gets returned.
 func (s *Service) getAssociatedHostAndPatchHelper(ctx context.Context) (*infrav1.HetznerBareMetalHost, *patch.Helper, error) {
 	host, err := host.GetAssociatedHost(ctx, s.scope.Client, s.scope.BareMetalMachine)

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -114,20 +114,21 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	// update the machine
 	host, err := s.update(ctx)
-	if apierrors.IsNotFound(err) {
-		// if host doesn't exist, set HostNotFound condition on HetznerBaremetalMachine
-		// and mark the machine object for remediation and stop reconciling.
-		conditions.MarkFalse(
-			s.scope.BareMetalMachine,
-			infrav1.HostReadyCondition,
-			infrav1.HostNotFoundReason,
-			clusterv1.ConditionSeverityError,
-			"associated host not found",
-		)
-
-		return reconcile.Result{}, s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found")
-	}
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// if host doesn't exist, set HostNotFound condition on HetznerBaremetalMachine
+			// and mark the machine object for remediation and stop reconciling.
+			conditions.MarkFalse(
+				s.scope.BareMetalMachine,
+				infrav1.HostReadyCondition,
+				infrav1.HostNotFoundReason,
+				clusterv1.ConditionSeverityError,
+				"associated host not found",
+			)
+
+			return reconcile.Result{}, s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found")
+		}
+
 		return checkForRequeueError(err, "failed to update machine")
 	}
 
@@ -139,21 +140,7 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	}
 
 	// set providerID if necessary
-	err = s.setProviderID(ctx)
-	if apierrors.IsNotFound(err) {
-		// if host doesn't exist, set HostNotFound condition on HetznerBaremetalMachine
-		// and mark the machine object for remediation and stop reconciling.
-		conditions.MarkFalse(
-			s.scope.BareMetalMachine,
-			infrav1.HostReadyCondition,
-			infrav1.HostNotFoundReason,
-			clusterv1.ConditionSeverityError,
-			"associated host not found",
-		)
-
-		return reconcile.Result{}, s.scope.SetRemediateMachineAnnotationToDeleteMachine(ctx, "Reconcile of hbmm: host not found")
-	}
-	if err != nil {
+	if err := s.setProviderID(ctx); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to set providerID: %w", err)
 	}
 

--- a/pkg/services/baremetal/host/utils.go
+++ b/pkg/services/baremetal/host/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -134,9 +133,6 @@ func GetAssociatedHost(ctx context.Context, crClient client.Client, hbmm *infrav
 	}
 
 	err := crClient.Get(ctx, key, host)
-	if apierrors.IsNotFound(err) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host object: %w", err)
 	}

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -52,11 +52,12 @@ func NewService(scope *scope.BareMetalRemediationScope) *Service {
 // Reconcile implements reconcilement of HetznerBareMetalRemediations.
 func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	host, err := host.GetAssociatedHost(ctx, s.scope.Client, s.scope.BareMetalMachine)
-	if apierrors.IsNotFound(err) {
-		return reconcile.Result{}, s.setOwnerRemediatedConditionToFailed(ctx,
-			"exit remediation because host associated with hbmm no longer exists")
-	}
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, s.setOwnerRemediatedConditionToFailed(ctx,
+				"exit remediation because host associated with hbmm no longer exists")
+		}
+
 		// retry
 		err := fmt.Errorf("failed to find the unhealthy host (will retry): %w", err)
 		record.Warn(s.scope.BareMetalRemediation, "FailedToFindHost", err.Error())

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -52,6 +52,10 @@ func NewService(scope *scope.BareMetalRemediationScope) *Service {
 // Reconcile implements reconcilement of HetznerBareMetalRemediations.
 func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 	host, err := host.GetAssociatedHost(ctx, s.scope.Client, s.scope.BareMetalMachine)
+	if apierrors.IsNotFound(err) {
+		return reconcile.Result{}, s.setOwnerRemediatedConditionToFailed(ctx,
+			"exit remediation because host associated with hbmm no longer exists")
+	}
 	if err != nil {
 		// retry
 		err := fmt.Errorf("failed to find the unhealthy host (will retry): %w", err)


### PR DESCRIPTION

<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If associated `HetznerBaremetalHost` object no longer exists for a `HetznerBaremetalMachine`, hbmm controller does the following:
- Set condition `HostReady` to true with reason `HostNotFound`.
- Set annotation `cluster.x-k8s.io/remediate-machine` on the CAPI machine to mark it for remediation.
- Do not reque or return an error to avoid further reconciliation.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1897

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
