### PR TITLE
:sparkles: Backport namespace skip annotation to v1.1.x

### DIFF
--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -34,6 +34,8 @@ const (
 	// AllowEmptyControlPlaneAddressAnnotation allows HetznerCluster Webhook
 	// to skip some validation steps for externally managed control planes.
 	AllowEmptyControlPlaneAddressAnnotation = "capi.syself.com/allow-empty-control-plane-address"
+	// SkipNamespaceAnnotation marks a namespace so CAPH controllers skip reconciliation.
+	SkipNamespaceAnnotation = "capi.syself.com/skip-namespace"
 	// ConstantBareMetalHostnameAnnotation makes hostnames of bare metal servers constant.
 	ConstantBareMetalHostnameAnnotation = "capi.syself.com/constant-bare-metal-hostname"
 )

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -82,10 +82,18 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	// Fetch the HCloudMachine instance.
 	hcloudMachine := &infrav1.HCloudMachine{}
-	err := r.Get(ctx, req.NamespacedName, hcloudMachine)
+	err = r.Get(ctx, req.NamespacedName, hcloudMachine)
 	if err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -65,6 +65,14 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	machineTemplate := &infrav1.HCloudMachineTemplate{}
 	if err := r.Get(ctx, req.NamespacedName, machineTemplate); err != nil {

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -67,9 +67,17 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	hcloudRemediation := &infrav1.HCloudRemediation{}
-	err := r.Get(ctx, req.NamespacedName, hcloudRemediation)
+	err = r.Get(ctx, req.NamespacedName, hcloudRemediation)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -80,6 +80,14 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	start := time.Now()
 	defer func() {
@@ -92,7 +100,7 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Fetch the Hetzner bare metal host instance.
 	bmHost := &infrav1.HetznerBareMetalHost{}
-	err := r.Get(ctx, req.NamespacedName, bmHost)
+	err = r.Get(ctx, req.NamespacedName, bmHost)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -70,10 +70,18 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	// Fetch the Hetzner bare metal instance.
 	hbmMachine := &infrav1.HetznerBareMetalMachine{}
-	err := r.Get(ctx, req.NamespacedName, hbmMachine)
+	err = r.Get(ctx, req.NamespacedName, hbmMachine)
 	if err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/controllers/hetznerbaremetalremediation_controller.go
+++ b/controllers/hetznerbaremetalremediation_controller.go
@@ -59,10 +59,18 @@ func (r *HetznerBareMetalRemediationReconciler) Reconcile(ctx context.Context, r
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	// Fetch the Hetzner bare metal host instance.
 	bareMetalRemediation := &infrav1.HetznerBareMetalRemediation{}
-	err := r.Get(ctx, req.NamespacedName, bareMetalRemediation)
+	err = r.Get(ctx, req.NamespacedName, bareMetalRemediation)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -97,10 +97,18 @@ func (r *HetznerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		// Just for testing, skip reconciling objects from finished tests.
 		return ctrl.Result{}, nil
 	}
+	skipReconciliation, err := shouldSkipReconciliationForNamespace(ctx, r.Client, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if skipReconciliation {
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		return ctrl.Result{}, nil
+	}
 
 	// Fetch the HetznerCluster instance
 	hetznerCluster := &infrav1.HetznerCluster{}
-	err := r.Get(ctx, req.NamespacedName, hetznerCluster)
+	err = r.Get(ctx, req.NamespacedName, hetznerCluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil

--- a/controllers/namespace_skip.go
+++ b/controllers/namespace_skip.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+)
+
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+func shouldSkipReconciliationForNamespace(ctx context.Context, c client.Reader, namespace string) (bool, error) {
+	if namespace == "" {
+		return false, nil
+	}
+
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to fetch namespace %q: %w", namespace, err)
+	}
+
+	return ns.GetAnnotations()[infrav1.SkipNamespaceAnnotation] == "true", nil
+}

--- a/controllers/namespace_skip_test.go
+++ b/controllers/namespace_skip_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+)
+
+func Test_shouldSkipReconciliationForNamespace(t *testing.T) {
+	testCases := []struct {
+		name          string
+		namespace     string
+		nsAnnotations map[string]string
+		createNS      bool
+		wantSkip      bool
+	}{
+		{
+			name:      "request has no namespace",
+			namespace: "",
+			wantSkip:  false,
+		},
+		{
+			name:      "namespace does not exist",
+			namespace: "missing",
+			wantSkip:  false,
+		},
+		{
+			name:      "namespace exists without annotation",
+			namespace: "default",
+			createNS:  true,
+			wantSkip:  false,
+		},
+		{
+			name:      "namespace exists with skip annotation set to true",
+			namespace: "default",
+			createNS:  true,
+			nsAnnotations: map[string]string{
+				infrav1.SkipNamespaceAnnotation: "true",
+			},
+			wantSkip: true,
+		},
+		{
+			name:      "namespace exists with skip annotation set to false",
+			namespace: "default",
+			createNS:  true,
+			nsAnnotations: map[string]string{
+				infrav1.SkipNamespaceAnnotation: "false",
+			},
+			wantSkip: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add corev1 scheme: %v", err)
+			}
+
+			builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+			if tc.createNS {
+				builder = builder.WithObjects(&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        tc.namespace,
+						Annotations: tc.nsAnnotations,
+					},
+				})
+			}
+
+			c := builder.Build()
+
+			gotSkip, err := shouldSkipReconciliationForNamespace(context.Background(), c, tc.namespace)
+			if err != nil {
+				t.Fatalf("shouldSkipReconciliationForNamespace returned error: %v", err)
+			}
+			if gotSkip != tc.wantSkip {
+				t.Fatalf("shouldSkipReconciliationForNamespace(%q) = %v, want %v", tc.namespace, gotSkip, tc.wantSkip)
+			}
+		})
+	}
+}

--- a/docs/caph/03-reference/08-annotations.md
+++ b/docs/caph/03-reference/08-annotations.md
@@ -33,6 +33,14 @@ You can set [Kubernetes Annotations](https://kubernetes.io/docs/concepts/overvie
 | **Value**       | `"true"` enables this feature. All other strings are considered `"false"`.                                                                                                                                                                                           |
 | **Auto-Remove** | Disabled: The annotation remains on the resource.                                                                                                                                                                                                                    |
 
+### capi.syself.com/skip-namespace
+
+| **Resource**    | [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Description** | This annotation makes CAPH skip reconciliation for namespaced CAPH resources in the annotated namespace. This is useful while debugging or during namespace-level maintenance.                                       |
+| **Value**       | `"true"` enables this feature. All other strings are considered `"false"`.                                                                                                                                            |
+| **Auto-Remove** | Disabled: The annotation remains on the resource.                                                                                                                                                                     |
+
 ### capi.syself.com/constant-bare-metal-hostname
 
 | **Resource**    | Cluster (CRD of Cluster-API), HetznerBareMetalMachine                                                        |


### PR DESCRIPTION
## Summary
- add the `capi.syself.com/skip-namespace` annotation constant and helper
- make CAPH reconcilers exit early for annotated namespaces
- add the namespace RBAC needed by the cache-backed client
- document the annotation and add a focused unit test

## Main PRs
- Backport of #1865
- Backport of #1867

## Why
`main` has the namespace-level skip mechanism from #1865 and the namespace RBAC dependency from #1867, while `v1.1.x` had neither.

## Testing
- `go test ./controllers -run ^'^Test_shouldSkipReconciliationForNamespace$' -count=1`
