### PR TITLE
🌱 Backport console-language docs cleanup to v1.1.x

### DIFF
--- a/docs/caph/01-getting-started/03-preparation.md
+++ b/docs/caph/01-getting-started/03-preparation.md
@@ -85,7 +85,7 @@ export HCLOUD_WORKER_MACHINE_TYPE=cpx32
 
 For a list of all variables needed for generating a cluster manifest (from the cluster-template.yaml), use `clusterctl generate cluster --infrastructure hetzner:<caph-version> --list-variables hetzner-cluster`
 
-```shell
+```console
 $ clusterctl generate cluster --infrastructure hetzner:<caph-version> --list-variables hetzner-cluster
 Required Variables:
   - HCLOUD_CONTROL_PLANE_MACHINE_TYPE

--- a/docs/caph/02-topics/04-upgrading-caph.md
+++ b/docs/caph/02-topics/04-upgrading-caph.md
@@ -13,7 +13,7 @@ Connect `kubectl` to the management cluster.
 
 Check, that you are connected to the correct cluster:
 
-```shell
+```console
 ❯ k config current-context
 mgm-cluster-admin@mgm-cluster
 ```
@@ -24,7 +24,7 @@ OK, looks good.
 
 Is clusterctl still up to date?
 
-```shell
+```console
 $ clusterctl version -oyaml
 clusterctl:
   buildDate: "2024-04-09T17:23:12Z"
@@ -48,7 +48,7 @@ If your clusterctl is outdated, then upgrade it. See the above URL for details.
 
 Have a look at what could get upgraded:
 
-```shell
+```console
 $ clusterctl upgrade plan
 Checking cert-manager version...
 Cert-Manager is already up to date
@@ -83,7 +83,7 @@ You might be surprised that for `infrastructure-hetzner`, you see the "Already u
 We will upgrade cluster API core components to v1.8.4 version.
 Use the command, which you saw in the plan:
 
-```shell
+```console
 $ clusterctl upgrade apply --contract v1beta1
 Checking cert-manager version...
 Cert-manager is already up to date
@@ -113,7 +113,7 @@ You can find the latest version of CAPH here:
 
 <https://github.com/syself/cluster-api-provider-hetzner/tags>
 
-```shell
+```console
 $ clusterctl upgrade apply --infrastructure=hetzner:v1.0.7
 Checking cert-manager version...
 Cert-manager is already up to date
@@ -125,7 +125,7 @@ Installing Provider="infrastructure-hetzner" Version="v1.0.7" TargetNamespace="c
 
 After the upgrade, you'll notice the new pod spinning up the `caph-system` namespace.
 
-```shell
+```console
 $ kubectl get pods -n caph-system
 NAME                                       READY   STATUS    RESTARTS   AGE
 caph-controller-manager-85fcb6ffcb-4sj6d   1/1     Running   0          79s

--- a/docs/caph/02-topics/05-baremetal/02-management-cluster.md
+++ b/docs/caph/02-topics/05-baremetal/02-management-cluster.md
@@ -33,7 +33,7 @@ Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/
 
 After creating the bootstrap cluster, it is also required to have some variables exported and the name of the variables that needs to be exported can be known by running the following command:
 
-```shell
+```console
 $ clusterctl generate cluster my-cluster --list-variables --flavor hetzner-hcloud-control-planes
 Required Variables:
   - HCLOUD_CONTROL_PLANE_MACHINE_TYPE
@@ -207,7 +207,7 @@ In the above server, we have not specified the WWN of the server and we have app
 
 After a while, you will see that there is an error in provisioning of `HetznerBareMetalHost` object that you just applied above. The error will look the following:
 
-```shell
+```console
 $ kubectl get hetznerbaremetalhost -A
 default     my-cluster-md-1-tgvl5   my-cluster   default/test-bm-gpu    my-cluster-md-1-t9znj-694hs   Provisioning   23m   ValidationFailed   no root device hints specified
 ```

--- a/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md
+++ b/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md
@@ -25,7 +25,7 @@ And apply it:
 kubectl apply -f my-cluster.yaml
 ```
 
-```shell
+```console
 $ kubectl apply -f my-cluster.yaml
 kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/my-cluster-md-0 created
 kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/my-cluster-md-1 created
@@ -94,7 +94,7 @@ TEST SUITE: None
 
 For CNI, let's deploy cilium in the workload cluster that will facilitate the networking in the cluster.
 
-```shell
+```console
 $ helm install cilium cilium/cilium --kubeconfig workload-kubeconfig
 NAME: cilium
 LAST DEPLOYED: Thu Apr  4 21:11:13 2024
@@ -112,7 +112,7 @@ For any further help, visit https://docs.cilium.io/en/v1.15/gettinghelp
 
 Now, the cluster should be up and you can verify it by running the following commands:
 
-```shell
+```console
 $ kubectl get clusters -A
 NAMESPACE   NAME         CLUSTERCLASS   PHASE         AGE   VERSION
 default     my-cluster                  Provisioned   10h


### PR DESCRIPTION
## Summary
- switch the affected docs examples from `shell` to `console`
- preserve the current `v1.1.x` example content while aligning the markdown fence type

## Main PRs
- Backport of #1739

## Why
`main` already includes the docs rendering fix from #1739, but the affected `v1.1.x` pages still use the older fence type.

## Testing
- not run locally
