### PR TITLE
:seedling: Use IgnoreNotFound when fetching related objects in controllers

### DIFF
--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -95,7 +95,7 @@ func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.R
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r, hcloudMachine.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get owner machine: %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	if machine == nil {
 		log.Info("Machine Controller has not yet set OwnerRef")

--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -102,7 +102,7 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 	if cluster == nil {
 		log.Info(fmt.Sprintf("%s is missing ownerRef to cluster %s/%s",
 			machineTemplate.Kind, machineTemplate.Namespace, machineTemplate.Name))
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	}
 	machineTemplate.Status.OwnerType = cluster.Kind
 

--- a/controllers/hcloudmachinetemplate_controller.go
+++ b/controllers/hcloudmachinetemplate_controller.go
@@ -96,8 +96,11 @@ func (r *HCloudMachineTemplateReconciler) Reconcile(ctx context.Context, req rec
 
 	var cluster *clusterv1.Cluster
 	cluster, err = util.GetOwnerCluster(ctx, r, machineTemplate.ObjectMeta)
-	if err != nil || cluster == nil {
-		log.Info(fmt.Sprintf("%s is missing ownerRef to cluster or cluster does not exist %s/%s",
+	if err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	if cluster == nil {
+		log.Info(fmt.Sprintf("%s is missing ownerRef to cluster %s/%s",
 			machineTemplate.Kind, machineTemplate.Namespace, machineTemplate.Name))
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -82,7 +82,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r, hcloudRemediation.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	if machine == nil {
 		log.Info("Machine Controller has not yet set OwnerRef")

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -215,10 +215,7 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 		return reconcile.Result{Requeue: true}, nil
 	}
 	if err := r.Get(ctx, hetznerClusterName, hetznerCluster); err != nil {
-		if apierrors.IsNotFound(err) {
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-		return reconcile.Result{}, fmt.Errorf("failed to get HetznerCluster: %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log = log.WithValues("HetznerCluster", klog.KObj(hetznerCluster))
@@ -226,7 +223,7 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 	// Fetch the Cluster.
 	cluster, err := util.GetClusterFromMetadata(ctx, r, hetznerCluster.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get Cluster: %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log = log.WithValues("Cluster", klog.KObj(cluster))
@@ -240,7 +237,7 @@ func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 
 		if err := r.Get(ctx, name, hetznerBareMetalMachine); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to get HetznerBareMetalMachine: %w", err)
+			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}
 

--- a/controllers/hetznerbaremetalmachine_controller.go
+++ b/controllers/hetznerbaremetalmachine_controller.go
@@ -83,8 +83,7 @@ func (r *HetznerBareMetalMachineReconciler) Reconcile(ctx context.Context, req r
 	// Fetch the Machine.
 	capiMachine, err := util.GetOwnerMachine(ctx, r, hbmMachine.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get owner machine. BareMetalMachine.ObjectMeta.OwnerReferences %v: %w",
-			hbmMachine.OwnerReferences, err)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	if capiMachine == nil {
 		log.Info("Machine Controller has not yet set OwnerRef")

--- a/controllers/hetznerbaremetalremediation_controller.go
+++ b/controllers/hetznerbaremetalremediation_controller.go
@@ -75,7 +75,7 @@ func (r *HetznerBareMetalRemediationReconciler) Reconcile(ctx context.Context, r
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r, bareMetalRemediation.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 	if machine == nil {
 		log.Info("Machine Controller has not yet set OwnerRef")

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -113,7 +113,7 @@ func (r *HetznerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Fetch the Cluster.
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, hetznerCluster.ObjectMeta)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get owner cluster: %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
 	log = log.WithValues("Cluster", klog.KObj(cluster))

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -121,9 +121,7 @@ func (r *HetznerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	if cluster == nil {
 		log.Info("Cluster Controller has not yet set OwnerRef")
-		return reconcile.Result{
-			RequeueAfter: 2 * time.Second,
-		}, nil
+		return reconcile.Result{}, nil
 	}
 
 	if annotations.IsPaused(cluster, hetznerCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses `client.IgnoreNotFound` when fetching related objects (Machine, Cluster, HetznerCluster, HetznerBareMetalMachine) across all controllers. This prevents repeated reconciliation loops when related objects are missing due to dangling references (the controller cannot fix these inconsistencies, so it should stop reconciling instead of retrying indefinitely).

**Which issue(s) this PR fixes:**
Fixes #1894

**Special notes for your reviewer**:
Base branch is `v1.1.x`.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests