### PR TITLE
:seedling: Stop reconciling HBMH on `unauthorized` error

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -154,8 +154,6 @@ const (
 const (
 	// CredentialsAvailableCondition reports on whether the Hetzner cluster is in ready state.
 	CredentialsAvailableCondition clusterv1.ConditionType = "CredentialsAvailable"
-	// RobotCredentialsInvalidReason indicates that credentials for Robot are invalid.
-	RobotCredentialsInvalidReason = "RobotCredentialsInvalid" // #nosec
 	// SSHCredentialsInSecretInvalidReason indicates that ssh credentials are invalid.
 	SSHCredentialsInSecretInvalidReason = "SSHCredentialsInSecretInvalid" // #nosec
 	// SSHKeyAlreadyExistsReason indicates that the ssh key which is specified in the host spec exists already under a different name in Hetzner robot.
@@ -164,6 +162,13 @@ const (
 	OSSSHSecretMissingReason = "OSSSHSecretMissing"
 	// RescueSSHSecretMissingReason indicates that secret with the rescue ssh key is missing.
 	RescueSSHSecretMissingReason = "RescueSSHSecretMissing"
+)
+
+const (
+	// RobotCredentialsAvailableCondition indicates that the robot credentials are available and valid.
+	RobotCredentialsAvailableCondition clusterv1.ConditionType = "RobotCredentialsAvailable"
+	// RobotCredentialsInvalidReason indicates that credentials for Robot are invalid.
+	RobotCredentialsInvalidReason = "RobotCredentialsInvalid" // #nosec
 )
 
 const (

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -475,12 +475,12 @@ func hetznerSecretErrorResult(
 	if errors.As(err, &credValidationErr) {
 		conditions.MarkFalse(
 			bmHost,
-			infrav1.CredentialsAvailableCondition,
+			infrav1.RobotCredentialsAvailableCondition,
 			infrav1.RobotCredentialsInvalidReason,
 			clusterv1.ConditionSeverityError,
 			infrav1.ErrorMessageMissingOrInvalidSecretData,
 		)
-		record.Warnf(bmHost, infrav1.SSHCredentialsInSecretInvalidReason, err.Error())
+		record.Warnf(bmHost, infrav1.RobotCredentialsInvalidReason, err.Error())
 		return res, nil
 	}
 	return reconcile.Result{}, fmt.Errorf("hetznerSecretErrorResult: an unhandled failure occurred: %T %w", err, err)

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -835,6 +835,95 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 			}, timeout).Should(BeTrue())
 		})
 	})
+
+	Context("Wrong Robot Credentials - unauthorized", func() {
+		BeforeEach(func() {
+			host = helpers.BareMetalHost(
+				hostName,
+				testNs.Name,
+				helpers.WithHetznerClusterRef(hetznerClusterName),
+				helpers.WithRootDeviceHintWWN(),
+			)
+			Expect(testEnv.Create(ctx, host)).To(Succeed())
+
+			key = client.ObjectKey{Namespace: testNs.Name, Name: host.Name}
+
+			hetznerSecret = getDefaultHetznerSecret(testNs.Name)
+			Expect(testEnv.Create(ctx, hetznerSecret)).To(Succeed())
+
+			rescueSSHSecret = helpers.GetDefaultSSHSecret("rescue-ssh-secret", testNs.Name)
+			Expect(testEnv.Create(ctx, rescueSSHSecret)).To(Succeed())
+
+			osSSHSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "os-ssh-secret",
+					Namespace: testNs.Name,
+				},
+				Data: map[string][]byte{
+					"private-key": []byte("os-ssh-secret-private-key"),
+					"sshkey-name": []byte("ssh-key-name"),
+					"public-key":  []byte("my-public-key"),
+				},
+			}
+			Expect(testEnv.Create(ctx, osSSHSecret)).To(Succeed())
+
+			robotClient.ExpectedCalls = nil
+			robotClient.On("GetBMServer", mock.Anything).Return(nil, models.Error{
+				Code:    models.ErrorCodeUnauthorized,
+				Message: "You are not authorized - wrong RobotCredentials",
+			}).Once()
+		})
+
+		It("should set CredentialsAvailable condition to false if Robot API returned unauthorized", func() {
+			By("making the Robot client return an unauthorized error")
+			Eventually(func() bool {
+				return isPresentAndFalseWithReason(key, host, infrav1.RobotCredentialsAvailableCondition, infrav1.RobotCredentialsInvalidReason)
+			}, timeout).Should(BeTrue())
+
+			Expect(robotClient.AssertExpectations(GinkgoT())).To(BeTrue())
+		})
+
+		AfterEach(func() {
+			Expect(testEnv.Cleanup(ctx, host, hetznerSecret, rescueSSHSecret)).To(Succeed())
+		})
+	})
+
+	Context("Wrong Robot Credentials - missing username in secret", func() {
+		BeforeEach(func() {
+			host = helpers.BareMetalHost(
+				hostName,
+				testNs.Name,
+				helpers.WithHetznerClusterRef(hetznerClusterName),
+				helpers.WithRootDeviceHintWWN(),
+			)
+			Expect(testEnv.Create(ctx, host)).To(Succeed())
+
+			hetznerSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hetzner-secret",
+					Namespace: testNs.Name,
+				},
+				Data: map[string][]byte{
+					"hcloud":         []byte("my-token"),
+					"robot-user":     []byte(""),
+					"robot-password": []byte("my-password"),
+				},
+			}
+			Expect(testEnv.Create(ctx, hetznerSecret)).To(Succeed())
+
+			key = client.ObjectKey{Namespace: testNs.Name, Name: host.Name}
+		})
+
+		AfterEach(func() {
+			Expect(testEnv.Cleanup(ctx, host, hetznerSecret)).To(Succeed())
+		})
+
+		It("sets RobotCredentialsAvailable to false if robot-user is empty", func() {
+			Eventually(func() bool {
+				return isPresentAndFalseWithReason(key, host, infrav1.RobotCredentialsAvailableCondition, infrav1.RobotCredentialsInvalidReason)
+			}, timeout).Should(BeTrue())
+		})
+	})
 })
 
 func configureRescueSSHClient(sshClient *sshmock.Client) {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -137,6 +137,23 @@ func (s *Service) actionPreparing(ctx context.Context) actionResult {
 
 	server, err := s.scope.RobotClient.GetBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID)
 	if err != nil {
+		// If Robot API returned "unauthorized" error - mark condition RobotCredentialsAvailable as false
+		// with reason RobotCredentialsInvalid and stop reconciling.
+		if models.IsError(err, models.ErrorCodeUnauthorized) {
+			msg := "Robot API returned unauthorized; verify the credentials in the referenced secret are correct"
+			conditions.MarkFalse(
+				s.scope.HetznerBareMetalHost,
+				infrav1.RobotCredentialsAvailableCondition,
+				infrav1.RobotCredentialsInvalidReason,
+				clusterv1.ConditionSeverityError,
+				"%s",
+				msg,
+			)
+			record.Warnf(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsInvalidReason, msg)
+
+			return actionStop{}
+		}
+
 		s.handleRobotRateLimitExceeded(err, "GetBMServer")
 		if models.IsError(err, models.ErrorCodeServerNotFound) {
 			msg := "GetBMServer (Robot API) replied: ServerNotFound"
@@ -162,6 +179,8 @@ func (s *Service) actionPreparing(ctx context.Context) actionResult {
 		}
 		return actionError{err: fmt.Errorf("failed to get bare metal server: %w", err)}
 	}
+
+	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsAvailableCondition)
 
 	s.scope.HetznerBareMetalHost.Spec.Status.IPv4 = server.ServerIP
 	s.scope.HetznerBareMetalHost.Spec.Status.IPv6 = server.ServerIPv6Net + "1"
@@ -2034,6 +2053,23 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 		} else {
 			rebootType := infrav1.RebootTypeHardware
 			if _, err := s.scope.RobotClient.RebootBMServer(host.Spec.ServerID, rebootType); err != nil {
+				// If Robot API returned "unauthorized" error - mark condition RobotCredentialsAvailable as false
+				// with reason RobotCredentialsInvalidReason and stop reconciling.
+				if models.IsError(err, models.ErrorCodeUnauthorized) {
+					msg := "Robot API returned unauthorized; verify the credentials in the referenced secret are correct"
+					conditions.MarkFalse(
+						s.scope.HetznerBareMetalHost,
+						infrav1.RobotCredentialsAvailableCondition,
+						infrav1.RobotCredentialsInvalidReason,
+						clusterv1.ConditionSeverityError,
+						"%s",
+						msg,
+					)
+					record.Warnf(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsInvalidReason, msg)
+
+					return actionStop{}
+				}
+
 				s.handleRobotRateLimitExceeded(err, rebootServerStr)
 
 				err = fmt.Errorf("actionProvisioned (Reboot via Annotation), reboot (%s) failed: %w", rebootType, err)
@@ -2044,6 +2080,8 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 					err.Error())
 				return actionError{err: err}
 			}
+
+			conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsAvailableCondition)
 		}
 
 		msg := fmt.Sprintf("Rebooting because annotation was set. Old BootID: %s", currentBootID)
@@ -2162,6 +2200,24 @@ func (s *Service) actionDeprovisioning(_ context.Context) actionResult {
 		s.scope.HetznerBareMetalHost.Spec.ServerID,
 		s.scope.HetznerBareMetalHost.Spec.ConsumerRef.Name,
 	); err != nil {
+		if models.IsError(err, models.ErrorCodeUnauthorized) {
+			// If Robot API returned "unauthorized" error while trying to set baremetal server name, then
+			// mark condition RobotCredentialsAvailable as false with reason RobotCredentialsInvalid
+			// and stop reconciling.
+			msg := "Robot API returned unauthorized; verify the credentials in the referenced secret are correct"
+			conditions.MarkFalse(
+				s.scope.HetznerBareMetalHost,
+				infrav1.RobotCredentialsAvailableCondition,
+				infrav1.RobotCredentialsInvalidReason,
+				clusterv1.ConditionSeverityError,
+				"%s",
+				msg,
+			)
+			record.Warnf(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsInvalidReason, msg)
+
+			return actionStop{}
+		}
+
 		s.handleRobotRateLimitExceeded(err, "SetBMServerName")
 		if models.IsError(err, models.ErrorCodeServerNotFound) {
 			msg := "server not found in Robot API during deprovisioning, assuming already removed"
@@ -2173,6 +2229,8 @@ func (s *Service) actionDeprovisioning(_ context.Context) actionResult {
 		}
 		return actionError{err: fmt.Errorf("failed to update name of host in robot API: %w", err)}
 	}
+
+	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsAvailableCondition)
 
 	if s.scope.SSHAfterInstallImage {
 		// If has been provisioned completely, stop all running pods


### PR DESCRIPTION


<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If we recieve the error `unauthorized` on making the first call to Robot API in an HBMH's phase then we should mark condition `CredentialsAvailable` to false with reason `RobotCredentialsInvalid` and stop reconciling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1895

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
