### PR TITLE
:seedling: Serialize baremetal e2e globally

### DIFF
--- a/.github/workflows/e2e-basic-baremetal.yaml
+++ b/.github/workflows/e2e-basic-baremetal.yaml
@@ -30,7 +30,7 @@ jobs:
 
   e2e-hetzner-basic:
     name: Test Hetzner Basic
-    concurrency: ci-${{ github.ref }}-e2e-baremetal-hetzner
+    concurrency: ci-e2e-baremetal-global
     runs-on: ubuntu-latest
     permissions:
       # Required for hcloud TPS

--- a/.github/workflows/e2e-feature-baremetal.yaml
+++ b/.github/workflows/e2e-feature-baremetal.yaml
@@ -30,7 +30,7 @@ jobs:
 
   e2e-hetzner-baremetal-feature:
     name: Test Hetzner Baremetal Features
-    concurrency: ci-${{ github.ref }}-e2e-baremetal-hetzner
+    concurrency: ci-e2e-baremetal-global
     runs-on: ubuntu-latest
     permissions:
       # Required for hcloud TPS

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -69,7 +69,7 @@ jobs:
   e2e-hetzner-basic:
     name: Test Hetzner Baremetal Basic
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    concurrency: ci-${{ github.ref }}-e2e-basic-hetzner
+    concurrency: ci-e2e-baremetal-global
     runs-on: ubuntu-latest
     permissions:
       # Required for hcloud TPS


### PR DESCRIPTION
## What changed
This changes the bare-metal GitHub Actions concurrency groups to a fixed global key: `ci-e2e-baremetal-global`.

## Why
The previous concurrency keys were based on `${{ github.ref }}`, which serialized runs only per PR ref. That still allowed bare-metal e2e jobs from different PRs to run at the same time against the shared `ci-pool`.

That overlap can cause host reuse and cross-run interference. In the March 26, 2026 failure on PR #1850, one bare-metal run observed a hostname from another workflow run, which is consistent with concurrent use of the same bare-metal pool.

## Scope
This only changes bare-metal workflows:
- `E2E PR Blocking` bare-metal job
- `E2E Basic Baremetal`
- `E2E Baremetal Feature`

Hcloud-only jobs keep their existing per-ref concurrency.

Matching `v1.1.x` PR: #1908
