### PR TITLE
[codex] Backport #1752 to v1.1.x

### DIFF
--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -65,6 +65,8 @@ const (
 
 	// FailureMessageMaintenanceMode indicates that host is in maintenance mode.
 	FailureMessageMaintenanceMode = "host machine in maintenance mode"
+
+	defaultSSHPort = 22
 )
 
 // Service defines struct with machine scope to reconcile HetznerBareMetalMachines.
@@ -711,7 +713,16 @@ func (s *Service) setHostSpec(host *infrav1.HetznerBareMetalHost) {
 	if host.Spec.Status.InstallImage == nil && s.scope.Machine.Spec.Bootstrap.DataSecretName != nil {
 		host.Spec.Status.InstallImage = &s.scope.BareMetalMachine.Spec.InstallImage
 		host.Spec.Status.UserData = &corev1.SecretReference{Namespace: s.scope.Namespace(), Name: *s.scope.Machine.Spec.Bootstrap.DataSecretName}
-		host.Spec.Status.SSHSpec = &s.scope.BareMetalMachine.Spec.SSHSpec
+
+		sshSpec := s.scope.BareMetalMachine.Spec.SSHSpec
+		if sshSpec.PortAfterInstallImage == 0 {
+			sshSpec.PortAfterInstallImage = defaultSSHPort
+		}
+		if sshSpec.PortAfterCloudInit == 0 {
+			sshSpec.PortAfterCloudInit = sshSpec.PortAfterInstallImage
+		}
+		host.Spec.Status.SSHSpec = &sshSpec
+
 		host.Spec.Status.HetznerClusterRef = s.scope.HetznerCluster.Name
 	}
 }

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1776,15 +1776,6 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 				infrav1.StateEnsureProvisioned, err.Error())
 			return actionError{err: fmt.Errorf("failed to handle incomplete boot - actionEnsureProvisioned: %w", err)}
 		}
-		// A connection refused error could mean that cloud-init is still running on the old port.
-		if isSSHConnectionRefusedError {
-			if actionRes := s.handleConnectionRefused(ctx); actionRes != nil {
-				s.scope.Logger.Info("ensureProvisioned: ConnectionRefused",
-					"ssh-port-after-cloud-init", s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterCloudInit,
-					"actionResult", actionRes)
-				return actionRes
-			}
-		}
 
 		failed, err := s.handleIncompleteBoot(ctx, false, isTimeout, isSSHConnectionRefusedError)
 		if failed {
@@ -1871,37 +1862,6 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.ProvisionSucceededCondition)
 	s.scope.HetznerBareMetalHost.ClearError()
 	return createEventWithCloudInitOutput(actionComplete{})
-}
-
-// handleConnectionRefused checks cloud-init status via ssh to the old ssh port if the new ssh port
-// gave a connection refused error.
-func (s *Service) handleConnectionRefused(ctx context.Context) actionResult {
-	// Nothing to do if ports didn't change.
-	if s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage == s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterCloudInit {
-		return nil
-	}
-
-	oldSSHClient := s.scope.SSHClientFactory.NewClient(sshclient.Input{
-		PrivateKey: sshclient.CredentialsFromSecret(s.scope.OSSSHSecret, s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.SecretRef).PrivateKey,
-		Port:       s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage,
-		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
-	})
-
-	actResult, _ := s.checkCloudInitStatus(ctx, oldSSHClient)
-
-	// If cloud-init completed successfully on the old port, wait for the reboot and port switch.
-	if _, complete := actResult.(actionComplete); complete {
-		actResult = s.handleCloudInitNotStarted(ctx)
-		if _, complete := actResult.(actionComplete); complete {
-			return actionContinue{delay: 10 * time.Second}
-		}
-	}
-
-	if _, actionErr := actResult.(actionError); !actionErr {
-		return actResult
-	}
-
-	return nil
 }
 
 func (s *Service) checkCloudInitStatus(ctx context.Context, sshClient sshclient.Client) (actionResult, string) {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1776,6 +1776,15 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 				infrav1.StateEnsureProvisioned, err.Error())
 			return actionError{err: fmt.Errorf("failed to handle incomplete boot - actionEnsureProvisioned: %w", err)}
 		}
+		// A connection refused error could mean that cloud-init is still running on the old port.
+		if isSSHConnectionRefusedError {
+			if actionRes := s.handleConnectionRefused(ctx); actionRes != nil {
+				s.scope.Logger.Info("ensureProvisioned: ConnectionRefused",
+					"ssh-port-after-cloud-init", s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterCloudInit,
+					"actionResult", actionRes)
+				return actionRes
+			}
+		}
 
 		failed, err := s.handleIncompleteBoot(ctx, false, isTimeout, isSSHConnectionRefusedError)
 		if failed {
@@ -1862,6 +1871,37 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.ProvisionSucceededCondition)
 	s.scope.HetznerBareMetalHost.ClearError()
 	return createEventWithCloudInitOutput(actionComplete{})
+}
+
+// handleConnectionRefused checks cloud-init status via ssh to the old ssh port if the new ssh port
+// gave a connection refused error.
+func (s *Service) handleConnectionRefused(ctx context.Context) actionResult {
+	// Nothing to do if ports didn't change.
+	if s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage == s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterCloudInit {
+		return nil
+	}
+
+	oldSSHClient := s.scope.SSHClientFactory.NewClient(sshclient.Input{
+		PrivateKey: sshclient.CredentialsFromSecret(s.scope.OSSSHSecret, s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.SecretRef).PrivateKey,
+		Port:       s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage,
+		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
+	})
+
+	actResult, _ := s.checkCloudInitStatus(ctx, oldSSHClient)
+
+	// If cloud-init completed successfully on the old port, wait for the reboot and port switch.
+	if _, complete := actResult.(actionComplete); complete {
+		actResult = s.handleCloudInitNotStarted(ctx)
+		if _, complete := actResult.(actionComplete); complete {
+			return actionContinue{delay: 10 * time.Second}
+		}
+	}
+
+	if _, actionErr := actResult.(actionError); !actionErr {
+		return actResult
+	}
+
+	return nil
 }
 
 func (s *Service) checkCloudInitStatus(ctx context.Context, sshClient sshclient.Client) (actionResult, string) {


### PR DESCRIPTION
## What changed
Backports the fix from #1752 to `v1.1.x` by defaulting SSH ports when copying the machine `SSHSpec` into the baremetal host status.

The effective change on `v1.1.x` is limited to `pkg/services/baremetal/baremetal/baremetal.go`.

## Why it changed
If the SSH port is not specified, `PortAfterInstallImage` can remain `0`. On `v1.1.x`, `ensure-provisioned` then tries to use that zero port and provisioning never finishes.

## Impact
When the SSH port is omitted:
- `PortAfterInstallImage` now falls back to `22`
- `PortAfterCloudInit` now falls back to `PortAfterInstallImage`

This keeps the host status usable for the provisioning flow on `v1.1.x`.

## Validation
- `go test ./pkg/services/baremetal/baremetal ./pkg/services/baremetal/host`
