### PR TITLE
:seedling: Integrate ccm-hetzner 2.0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ ifeq ($(BUILD_IN_CONTAINER),true)
 else
 	helm repo add syself https://charts.syself.com
 	helm repo update syself
-	KUBECONFIG=$(WORKER_CLUSTER_KUBECONFIG) helm upgrade --install ccm syself/ccm-hetzner --version 2.0.1 \
+	KUBECONFIG=$(WORKER_CLUSTER_KUBECONFIG) helm upgrade --install ccm syself/ccm-hetzner --version 2.0.6 \
 	--namespace kube-system \
 	--set privateNetwork.enabled=$(PRIVATE_NETWORK)
 	@echo

--- a/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md
+++ b/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md
@@ -78,7 +78,7 @@ Let's deploy the hetzner CCM helm chart.
 helm repo add syself https://charts.syself.com
 helm repo update syself
 
-$ helm upgrade --install ccm syself/ccm-hetzner --version 2.0.1 \
+$ helm upgrade --install ccm syself/ccm-hetzner --version 2.0.6 \
               --namespace kube-system \
               --kubeconfig workload-kubeconfig
 Release "ccm" does not exist. Installing it now.

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -84,7 +84,7 @@ e2e-ccm-templates:
 	--set networking.network.valueFrom.secretKeyRef.name=hetzner \
 	--set networking.network.valueFrom.secretKeyRef.key=network > $(REPO_ROOT)/test/e2e/data/ccm/hcloud-ccm-network.yaml
 
-	helm template ccm syself/ccm-hetzner --version 2.0.1 \
+	helm template ccm syself/ccm-hetzner --version 2.0.6 \
 	--namespace kube-system \
 	--set pdb.enabled=false \
 	--set privateNetwork.enabled=false > $(REPO_ROOT)/test/e2e/data/ccm/hcloud-ccm-hetzner.yaml

--- a/test/e2e/data/ccm/hcloud-ccm-hetzner.yaml
+++ b/test/e2e/data/ccm/hcloud-ccm-hetzner.yaml
@@ -6,11 +6,11 @@ metadata:
   name: ccm-ccm-hetzner
   namespace: kube-system
   labels:
-    helm.sh/chart: ccm-hetzner-2.0.1
+    helm.sh/chart: ccm-hetzner-2.0.6
     app: ccm
     app.kubernetes.io/name: ccm-hetzner
     app.kubernetes.io/instance: ccm
-    app.kubernetes.io/version: "v2.0.1"
+    app.kubernetes.io/version: "v2.0.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: ccm-hetzner/templates/serviceaccount.yaml
@@ -20,11 +20,11 @@ metadata:
   name: ccm-ccm-hetzner
   namespace: kube-system
   labels:
-    helm.sh/chart: ccm-hetzner-2.0.1
+    helm.sh/chart: ccm-hetzner-2.0.6
     app: ccm
     app.kubernetes.io/name: ccm-hetzner
     app.kubernetes.io/instance: ccm
-    app.kubernetes.io/version: "v2.0.1"
+    app.kubernetes.io/version: "v2.0.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -42,11 +42,11 @@ metadata:
   name: ccm-ccm-hetzner
   namespace: kube-system
   labels:
-    helm.sh/chart: ccm-hetzner-2.0.1
+    helm.sh/chart: ccm-hetzner-2.0.6
     app: ccm
     app.kubernetes.io/name: ccm-hetzner
     app.kubernetes.io/instance: ccm
-    app.kubernetes.io/version: "v2.0.1"
+    app.kubernetes.io/version: "v2.0.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -92,7 +92,7 @@ spec:
         - name: ccm-hetzner
           securityContext:
             {}
-          image: "ghcr.io/syself/hetzner-cloud-controller-manager:v2.0.1"
+          image: "ghcr.io/syself/hetzner-cloud-controller-manager:v2.0.6"
           imagePullPolicy: Always
           command:
             - "/bin/hetzner-cloud-controller-manager"


### PR DESCRIPTION
## What changed
- bump the `syself/ccm-hetzner` chart version from `2.0.1` to `2.0.6` in the workload-cluster install target
- bump the same version in the baremetal workload-cluster docs example
- update the e2e fixture generator and the checked-in rendered `hcloud-ccm-hetzner.yaml` fixture to match the `ccm-hetzner-2.0.6` release


This integrates the newly published `ccm-hetzner-2.0.6` chart release into CAPH's install flow, docs, and test fixtures.
