### PR TITLE
🌱 Add CAPI version verification and align e2e config

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Verify Shellcheck
         run: make verify-shellcheck
 
+      - name: Verify CAPI Version
+        run: make verify-capi-version
+
       - name: Verify Starlark
         run: make verify-starlark
 

--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,10 @@ verify-starlark: ## Verify Starlark Code
 verify-manifests:
 	./hack/verify-manifests.sh
 
+.PHONY: verify-capi-version
+verify-capi-version: ## Verify Cluster API versions stay aligned with go.mod
+	./hack/check-capi-version.sh
+
 .PHONY: verify-container-images
 verify-container-images: ## Verify container images
 	trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL $(IMAGE_PREFIX)/$(INFRA_SHORT):latest
@@ -753,7 +757,7 @@ endif
 .PHONY: generate
 generate: generate-manifests generate-go-deepcopy generate-boilerplate generate-modules generate-mocks ## Generate Files
 
-ALL_VERIFY_CHECKS = boilerplate shellcheck starlark manifests
+ALL_VERIFY_CHECKS = boilerplate shellcheck starlark manifests capi-version
 .PHONY: verify
 verify: generate lint $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Verify all
 

--- a/hack/check-capi-version.sh
+++ b/hack/check-capi-version.sh
@@ -67,9 +67,14 @@ if ! awk \
     -v desired_major="${DESIRED_MAJOR}" \
     -v desired_minor="${DESIRED_MINOR}" \
     '
-        match($0, /major:[[:space:]]*([0-9]+)/, captures) { major = captures[1] }
-        match($0, /minor:[[:space:]]*([0-9]+)/, captures) {
-            minor = captures[1]
+        /^[[:space:]]*-[[:space:]]*major:[[:space:]]*/ {
+            major = $0
+            sub(/.*major:[[:space:]]*/, "", major)
+            next
+        }
+        /^[[:space:]]*minor:[[:space:]]*/ {
+            minor = $0
+            sub(/.*minor:[[:space:]]*/, "", minor)
             if (major == desired_major && minor == desired_minor) {
                 found = 1
             }

--- a/hack/check-capi-version.sh
+++ b/hack/check-capi-version.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/check-capi-version.sh
+++ b/hack/check-capi-version.sh
@@ -57,4 +57,28 @@ if git ls-files | grep -v vendor | grep -v '\.md$' | xargs grep -nH -E '(cluster
     exit 1
 fi
 
+DESIRED_SERIES="${DESIRED_VERSION#v}"
+DESIRED_SERIES="${DESIRED_SERIES%.*}"
+DESIRED_MAJOR="${DESIRED_SERIES%%.*}"
+DESIRED_MINOR="${DESIRED_SERIES##*.}"
+METADATA_FILE="test/e2e/data/shared/v1beta1/metadata.yaml"
+
+if ! awk \
+    -v desired_major="${DESIRED_MAJOR}" \
+    -v desired_minor="${DESIRED_MINOR}" \
+    '
+        match($0, /major:[[:space:]]*([0-9]+)/, captures) { major = captures[1] }
+        match($0, /minor:[[:space:]]*([0-9]+)/, captures) {
+            minor = captures[1]
+            if (major == desired_major && minor == desired_minor) {
+                found = 1
+            }
+        }
+        END { exit(found ? 0 : 1) }
+    ' "${METADATA_FILE}"; then
+    echo "❌ Missing releaseSeries entry for CAPI ${DESIRED_MAJOR}.${DESIRED_MINOR} in ${METADATA_FILE}"
+    echo "Please update the shared e2e metadata to include the major/minor series from go.mod"
+    exit 1
+fi
+
 echo "✅ All CAPI versions are in sync with go.mod (${DESIRED_VERSION})"

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -48,7 +48,7 @@ verify() {
   # Run boilerplate check
   if [[ ${#files_need_boilerplate[@]} -gt 0 ]]; then
     for file in "${files_need_boilerplate[@]}"; do
-      echo "Boilerplate header is wrong for: ${file}" >&2
+      echo "Boilerplate header is wrong for (use ./hack/ensure-boilerplate.sh): ${file}" >&2
     done
 
     return 1

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -14,8 +14,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.8.10
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/core-components.yaml"
+      - name: v1.10.9
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -31,8 +31,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.8.10
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/bootstrap-components.yaml"
+      - name: v1.10.9
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -48,8 +48,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.8.10
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/control-plane-components.yaml"
+      - name: v1.10.9
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -7,6 +7,12 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 10
+    contract: v1beta1
+  - major: 1
+    minor: 9
+    contract: v1beta1
+  - major: 1
     minor: 8
     contract: v1beta1
   - major: 1


### PR DESCRIPTION
## What changed
- add `make verify-capi-version` backed by `hack/check-capi-version.sh`
- include the new target in `make verify`
- run the CAPI version check in `pr-verify`
- align the stale Cluster API provider URLs in `test/e2e/config/hetzner.yaml` with the version from `go.mod`

## Why
The repo already had a script to detect Cluster API version drift, but it was not enforced in CI. That allowed the e2e config to keep referencing `v1.8.10` while `go.mod` had already moved to `v1.10.9`.

## Impact
Pull requests now fail when CAPI-related versions drift from `go.mod`, and the current e2e config is back in sync.

## Validation
- `make verify-capi-version`
- `make lint-yaml-ci`
- `git diff --check`
