### PR TITLE
:seedling: fix LastUpdated field description

### DIFF
--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -310,7 +310,7 @@ type ControllerGeneratedStatus struct {
 	// +optional
 	ErrorMessage string `json:"errorMessage"`
 
-	// the last error message reported by the provisioning subsystem.
+	// LastUpdated indicates when the provisioning subsystem last updated the host state.
 	// +optional
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -504,8 +504,8 @@ spec:
                     description: IPv6 address of server.
                     type: string
                   lastUpdated:
-                    description: the last error message reported by the provisioning
-                      subsystem.
+                    description: LastUpdated indicates when the provisioning subsystem
+                      last updated the host state.
                     format: date-time
                     type: string
                   provisioningState:


### PR DESCRIPTION
## What changed

This fixes the `LastUpdated` field description on `HetznerBareMetalHost` and regenerates the CRD so the published schema matches the Go type comment.

## Why

The `LastUpdated` field had a copied description from `ErrorMessage`, so the generated CRD documented `lastUpdated` as an error message instead of a timestamp.
