### PR TITLE
Remove reconcile-time ServerCreateSucceededCondition update

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -240,10 +240,6 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 
 	updateHCloudMachineStatusFromServer(hm, server)
 
-	// If server creation was successful, but reconciliation failed afterward, its
-	// condition might not be true yet.
-	conditions.MarkTrue(hm, infrav1.ServerCreateSucceededCondition)
-
 	s.scope.SetProviderID(server.ID)
 
 	// Provisioning from a hcloud image like ubuntu-YY.MM takes roughly 11 seconds.


### PR DESCRIPTION
Removes the reconcile-time `ServerCreateSucceededCondition` mark added in #1781.

Local validation is blocked because envtest binaries are missing (`/usr/local/kubebuilder/bin/etcd`).