### PR TITLE
:seedling: Backport Robot rescue flag handling to v1.1.x

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -234,22 +234,6 @@ func (s *Service) actionPreparing(ctx context.Context) actionResult {
 		s.scope.HetznerBareMetalHost.Spec.Status.RebootTypes = rebootTypes
 	}
 
-	// if there is no rescue system, we cannot provision the server
-	if !server.Rescue {
-		errMsg := fmt.Sprintf("bm server %v has no rescue system", server.ServerNumber)
-		conditions.MarkFalse(
-			s.scope.HetznerBareMetalHost,
-			infrav1.ProvisionSucceededCondition,
-			infrav1.RescueSystemUnavailableReason,
-			clusterv1.ConditionSeverityError,
-			"%s",
-			errMsg,
-		)
-		record.Warnf(s.scope.HetznerBareMetalHost, "NoRescueSystemAvailable", errMsg)
-		s.scope.HetznerBareMetalHost.SetError(infrav1.PermanentError, errMsg)
-		return actionStop{}
-	}
-
 	if err := s.enforceRescueMode(); err != nil {
 		return actionError{err: fmt.Errorf("failed to enforce rescue mode: %w", err)}
 	}

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -870,6 +870,53 @@ var _ = Describe("ensureSSHKey", func() {
 	)
 })
 
+var _ = Describe("actionPreparing", func() {
+	It("continues when Robot omits rescue availability from the server response", func() {
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithSSHSpecInclPorts(22, 22),
+		)
+
+		robotMock := robotmock.Client{}
+		robotMock.On("GetBMServer", mock.Anything).Return(&models.Server{
+			ServerNumber:  1,
+			ServerIP:      "1.2.3.4",
+			ServerIPv6Net: "2a01:4f9:3051:12ce::",
+			Rescue:        false,
+		}, nil)
+		robotMock.On("ListSSHKeys").Return([]models.Key{}, nil)
+		robotMock.On("SetSSHKey", mock.Anything, mock.Anything).Return(
+			&models.Key{Name: rescueSSHKeyName, Fingerprint: sshFingerprint},
+			nil,
+		)
+		robotMock.On("GetReboot", mock.Anything).Return(&models.Reset{Type: []string{"sw", "hw"}}, nil)
+		robotMock.On("DeleteBootRescue", mock.Anything).Return(&models.Rescue{Active: false}, nil)
+		robotMock.On("SetBootRescue", mock.Anything, sshFingerprint).Return(&models.Rescue{Active: true}, nil)
+		robotMock.On("RebootBMServer", mock.Anything, infrav1.RebootTypeSoftware).Return(&models.ResetPost{}, nil)
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName").Return(sshclient.Output{})
+
+		service := newTestService(
+			host,
+			&robotMock,
+			bmmock.NewSSHFactory(sshMock, sshMock, sshMock),
+			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+			helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"),
+		)
+
+		actResult := service.actionPreparing(context.Background())
+
+		Expect(actResult).To(BeAssignableToTypeOf(actionComplete{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.ErrorTypeSoftwareRebootTriggered))
+		Expect(host.Spec.Status.IPv4).To(Equal("1.2.3.4"))
+		Expect(host.Spec.Status.IPv6).To(Equal("2a01:4f9:3051:12ce::1"))
+		Expect(robotMock.AssertCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
+		Expect(robotMock.AssertCalled(GinkgoT(), "SetBootRescue", mock.Anything, sshFingerprint)).To(BeTrue())
+	})
+})
+
 var _ = Describe("analyzeSSHOutputInstallImage", func() {
 	type testCaseAnalyzeSSHOutputInstallImageOutErr struct {
 		err                         error

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -875,7 +875,7 @@ var _ = Describe("actionPreparing", func() {
 		host := helpers.BareMetalHost(
 			"test-host",
 			"default",
-			helpers.WithSSHSpecInclPorts(22, 22),
+			helpers.WithSSHSpecInclPorts(22),
 		)
 
 		robotMock := robotmock.Client{}


### PR DESCRIPTION
## What changed
- remove the bare-metal preflight check that stops when Robot reports `server.Rescue == false`
- add a regression test for Robot responses that omit rescue availability even though rescue activation still works

## Why
`main` fixed this in #1926. `v1.1.x` still trusts the `server.Rescue` flag from `GetBMServer()`, but Robot can omit that flag for servers where rescue mode can still be activated. That turns an API inconsistency into a permanent provisioning failure.


## Overview

#1781 