### PR TITLE
:bug: Backport nil ProviderID delete guard to v1.1.x

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -803,6 +803,11 @@ func handleRateLimit(hm *infrav1.HCloudMachine, err error, functionName string, 
 
 // Delete implements delete method of server.
 func (s *Service) Delete(ctx context.Context) (reconcile.Result, error) {
+	// Nothing to do if ProviderID was never set.
+	if s.scope.HCloudMachine.Spec.ProviderID == nil {
+		return reconcile.Result{}, nil
+	}
+
 	server, err := s.findServer(ctx)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to find server: %w", err)

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -221,6 +221,26 @@ var _ = Describe("handleServerStatusOff", func() {
 	})
 })
 
+var _ = Describe("Delete", func() {
+	It("returns without querying hcloud when ProviderID is nil", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+		}
+		hcloudClient := &mocks.Client{}
+		service := newTestService(hcloudMachine, hcloudClient)
+
+		res, err := service.Delete(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)).To(BeTrue())
+		Expect(hcloudClient.AssertNotCalled(GinkgoT(), "ListServers", mock.Anything, mock.Anything)).To(BeTrue())
+	})
+})
+
 var _ = Describe("Test handleRateLimit", func() {
 	type testCaseHandleRateLimit struct {
 		hm              *infrav1.HCloudMachine


### PR DESCRIPTION
## What changed
- return early from HCloud server deletion when `spec.providerID` was never set
- add a regression test that confirms `Delete()` does not query HCloud in that case


## Note

This part of the PR to main was never part of v1.1.x. So  this removal in #1930 does not show up in this PR:

```go 
// If the HCloudMachine has an unauthorized / HCloudCredentialsInvalid error, stop reconciling.
	// There is no point in retrying API calls with an invalid token.
	// The MachineHealthCheck will eventually remediate the machine by deleting and recreating it.
	if conditions.IsFalse(hcloudMachine, infrav1.HCloudTokenAvailableCondition) &&
		conditions.GetReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition) == infrav1.HCloudCredentialsInvalidReason {
		log.Info("HCloudMachine has HCloudCredentialsInvalid, stopping reconciliation")
		return reconcile.Result{}, nil
	}
```

## Why

`main` fixed this as part of #1930. The main-branch reconcile short-circuit removal from that PR is not needed on `v1.1.x`, because this branch does not have that early `HCloudCredentialsInvalid` gate. The delete-path nil-`ProviderID` guard is still relevant on `v1.1.x`: without it, deletion falls through to HCloud lookups even when no server ID exists yet.


## Overview 

#1781 