### PR TITLE
:seedling: Update CAPI to v1.10.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(CTLPTL):
 CLUSTERCTL := $(abspath $(TOOLS_BIN_DIR)/clusterctl)
 clusterctl: $(CLUSTERCTL) ## Build a local copy of clusterctl
 $(CLUSTERCTL):
-	go install sigs.k8s.io/cluster-api/cmd/clusterctl@v1.10.9
+	go install sigs.k8s.io/cluster-api/cmd/clusterctl@v1.10.10
 
 HCLOUD := $(abspath $(TOOLS_BIN_DIR)/hcloud)
 hcloud: $(HCLOUD) ## Build a local copy of hcloud

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_observability": False,
     "preload_images_for_kind": True,
     "kind_cluster_name": "caph",
-    "capi_version": "v1.10.9",
+    "capi_version": "v1.10.10",
     "cabpt_version": "v0.5.6",
     "cacppt_version": "v0.4.11",
     "cert_manager_version": "v1.11.0",

--- a/docs/caph/02-topics/05-baremetal/02-management-cluster.md
+++ b/docs/caph/02-topics/05-baremetal/02-management-cluster.md
@@ -74,9 +74,9 @@ clusterctl init --infrastructure hetzner
 Fetching providers
 Installing cert-manager Version="v1.14.2"
 Waiting for cert-manager to be available...
-Installing Provider="cluster-api" Version="v1.10.9" TargetNamespace="capi-system"
-Installing Provider="bootstrap-kubeadm" Version="v1.10.9" TargetNamespace="capi-kubeadm-bootstrap-system"
-Installing Provider="control-plane-kubeadm" Version="v1.10.9" TargetNamespace="capi-kubeadm-control-plane-system"
+Installing Provider="cluster-api" Version="v1.10.10" TargetNamespace="capi-system"
+Installing Provider="bootstrap-kubeadm" Version="v1.10.10" TargetNamespace="capi-kubeadm-bootstrap-system"
+Installing Provider="control-plane-kubeadm" Version="v1.10.10" TargetNamespace="capi-kubeadm-control-plane-system"
 Installing Provider="infrastructure-hetzner" Version="v1.0.7" TargetNamespace="caph-system"
 
 Your management cluster has been initialized successfully!

--- a/docs/caph/04-developers/02-tilt.md
+++ b/docs/caph/04-developers/02-tilt.md
@@ -17,7 +17,7 @@ solution.
 "deploy_observability": False,
 "preload_images_for_kind": True,
 "kind_cluster_name": "caph",
-"capi_version": "v1.10.9",
+"capi_version": "v1.10.10",
 "cabpt_version": "v0.5.5",
 "cacppt_version": "v0.4.10",
 "cert_manager_version": "v1.11.0",
@@ -43,5 +43,5 @@ solution.
 | `deploy_observability`    | `bool`     | `false`         | no       | If true, installs grafana, loki and promtail in the dev cluster. Grafana UI will be accessible via a link in the tilt console. Important! This feature requires the `helm` command to be available in the user's path |
 | `preload_images_for_kind` | `bool`     | `true`          | no       | If set to true, uses `kind load docker-image` to preload images into a kind cluster                                                                                                                                   |
 | `kind_cluster_name`       | `[]object` | `"caph"`        | no       | The name of the kind cluster to use when preloading images                                                                                                                                                            |
-| `capi_version`            | `string`   | `"v1.10.9"`      | no       | Version of CAPI                                                                                                                                                                                                       |
+| `capi_version`            | `string`   | `"v1.10.10"`     | no       | Version of CAPI                                                                                                                                                                                                       |
 | `cert_manager_version`    | `string`   | `"v1.11.0"`     | no       | Version of cert manager                                                                                                                                                                                               |

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.32.7
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
-	sigs.k8s.io/cluster-api v1.10.9
-	sigs.k8s.io/cluster-api/test v1.10.9
+	sigs.k8s.io/cluster-api v1.10.10
+	sigs.k8s.io/cluster-api/test v1.10.10
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/kind v0.29.0
 )

--- a/go.sum
+++ b/go.sum
@@ -406,10 +406,10 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.10.9 h1:6vjjs4a8kF5oP+t6JqHGDIjyP36ZLgqAU+8EVGjmPyE=
-sigs.k8s.io/cluster-api v1.10.9/go.mod h1:IHnO3HR8ta0yK1S2SyI2qKpcrZNsyOdArwRjUfnJwnc=
-sigs.k8s.io/cluster-api/test v1.10.9 h1:bf5X9VKwTdOqrZIuKnEOABVcbAXlEZbWec+rBS+mkWo=
-sigs.k8s.io/cluster-api/test v1.10.9/go.mod h1:ehnxLYJn73nn/0NM0x6dJgdYa04ZWwqn7T5xcvwRwYg=
+sigs.k8s.io/cluster-api v1.10.10 h1:GF9B04puY1IrK9l8nc7xZaDITvKEkPtFAzccfgN4Gp0=
+sigs.k8s.io/cluster-api v1.10.10/go.mod h1:IHnO3HR8ta0yK1S2SyI2qKpcrZNsyOdArwRjUfnJwnc=
+sigs.k8s.io/cluster-api/test v1.10.10 h1:himbsoB2Yu1bY7il/qSwXzAVN2zWHGef+nxJw4eqqQI=
+sigs.k8s.io/cluster-api/test v1.10.10/go.mod h1:ehnxLYJn73nn/0NM0x6dJgdYa04ZWwqn7T5xcvwRwYg=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/test/e2e/config/hetzner.yaml
+++ b/test/e2e/config/hetzner.yaml
@@ -14,8 +14,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.10.9
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/core-components.yaml"
+      - name: v1.10.10
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.10/core-components.yaml"
         type: "url"
         contract: v1beta1
         files:
@@ -31,8 +31,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.10.9
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/bootstrap-components.yaml"
+      - name: v1.10.10
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.10/bootstrap-components.yaml"
         type: "url"
         contract: "v1beta1"
         files:
@@ -48,8 +48,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.10.9
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/control-plane-components.yaml"
+      - name: v1.10.10
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.10/control-plane-components.yaml"
         type: "url"
         files:
           - sourcePath: "../data/shared/v1beta1/metadata.yaml"
@@ -149,7 +149,7 @@ variables:
 
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.9/clusterctl-linux-amd64"
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.10/clusterctl-linux-amd64"
   INIT_WITH_PROVIDERS_CONTRACT: "v1beta1"
   INIT_WITH_KUBERNETES_VERSION: "v1.33.6"
   INIT_WITH_INFRASTRUCTURE_PROVIDER_VERSION: ${CAPH_LATEST_VERSION}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,8 +27,6 @@ github.com/Masterminds/sprig/v3
 ## explicit; go 1.12
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
-# github.com/NYTimes/gziphandler v1.1.1
-## explicit; go 1.11
 # github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 ## explicit; go 1.13
 github.com/ProtonMail/go-crypto/bitcurves
@@ -277,8 +275,6 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/kylelemons/godebug v1.1.0
-## explicit; go 1.11
 # github.com/mailru/easyjson v0.7.7
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,6 +27,8 @@ github.com/Masterminds/sprig/v3
 ## explicit; go 1.12
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
+# github.com/NYTimes/gziphandler v1.1.1
+## explicit; go 1.11
 # github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 ## explicit; go 1.13
 github.com/ProtonMail/go-crypto/bitcurves
@@ -275,6 +277,8 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
+# github.com/kylelemons/godebug v1.1.0
+## explicit; go 1.11
 # github.com/mailru/easyjson v0.7.7
 ## explicit; go 1.12
 github.com/mailru/easyjson/buffer
@@ -1267,7 +1271,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/cluster-api v1.10.9
+# sigs.k8s.io/cluster-api v1.10.10
 ## explicit; go 1.23.0
 sigs.k8s.io/cluster-api/api/addons/v1beta1
 sigs.k8s.io/cluster-api/api/v1beta1
@@ -1353,7 +1357,7 @@ sigs.k8s.io/cluster-api/util/topology
 sigs.k8s.io/cluster-api/util/version
 sigs.k8s.io/cluster-api/util/yaml
 sigs.k8s.io/cluster-api/version
-# sigs.k8s.io/cluster-api/test v1.10.9
+# sigs.k8s.io/cluster-api/test v1.10.10
 ## explicit; go 1.23.0
 sigs.k8s.io/cluster-api/test/e2e
 sigs.k8s.io/cluster-api/test/e2e/internal/log

--- a/vendor/sigs.k8s.io/cluster-api/internal/runtime/client/client.go
+++ b/vendor/sigs.k8s.io/cluster-api/internal/runtime/client/client.go
@@ -20,6 +20,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,6 +44,7 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
@@ -69,15 +71,28 @@ type Options struct {
 }
 
 // New returns a new Client.
-func New(options Options) runtimeclient.Client {
+func New(options Options) (runtimeclient.Client, *certwatcher.CertWatcher, error) {
+	httpClientCache := cache.New[httpClientEntry](24 * time.Hour)
+
+	var certWatcher *certwatcher.CertWatcher
+	if options.CertFile != "" && options.KeyFile != "" {
+		var err error
+		certWatcher, err = certwatcher.New(options.CertFile, options.KeyFile)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to create RuntimeSDK client: failed to create cert-watcher")
+		}
+		certWatcher.RegisterCallback(func(_ tls.Certificate) {
+			httpClientCache.DeleteAll()
+		})
+	}
 	return &client{
 		certFile:         options.CertFile,
 		keyFile:          options.KeyFile,
 		catalog:          options.Catalog,
 		registry:         options.Registry,
 		client:           options.Client,
-		httpClientsCache: cache.New[httpClientEntry](24 * time.Hour),
-	}
+		httpClientsCache: httpClientCache,
+	}, certWatcher, nil
 }
 
 var _ runtimeclient.Client = &client{}

--- a/vendor/sigs.k8s.io/cluster-api/util/cache/cache.go
+++ b/vendor/sigs.k8s.io/cluster-api/util/cache/cache.go
@@ -52,6 +52,9 @@ type Cache[E Entry] interface {
 
 	// Len returns the number of entries in the cache.
 	Len() int
+
+	// DeleteAll deletes all entries from the cache.
+	DeleteAll()
 }
 
 // New creates a new cache.
@@ -101,6 +104,11 @@ func (r *cache[E]) Has(key string) (E, bool) {
 
 func (r *cache[E]) Len() int {
 	return len(r.ListKeys())
+}
+
+func (r *cache[E]) DeleteAll() {
+	// Note: We are intentionally using Replace instead of List + Delete because the latter would be racy.
+	_ = r.Store.Replace(nil, "")
 }
 
 // ReconcileEntry is an Entry for the Cache that stores the


### PR DESCRIPTION

- bump Cluster API and Cluster API test dependencies from `v1.10.9` to `v1.10.10`
- sync the matching `clusterctl`, Tilt, and e2e config version pins to `v1.10.10`
- refresh vendored Cluster API code and module metadata for the patch release
- update docs that showed the old CAPI version
