### PR TITLE
:seedling: Enable PR lint on v1.1.x pushes

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -6,6 +6,19 @@ on: # yamllint disable-line rule:truthy
       - v1.1.x
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+    paths:
+      - "**.go"
+      - "**go.mod"
+      - "**go.sum"
+      - "<templates|test>/**/*.<yml|yaml>"
+      - ".github/actions/**/*"
+      - ".github/workflows/e2e-*"
+      - ".github/workflows/pr-*"
+      - ".golangci.yaml"
+      - "images/caph/**"
+      - "!**/vendor/**"
+      - "test/e2e/**"
+      - "docs/**"
 # yamllint disable rule:line-length
 jobs:
   pr-lint:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,21 +1,11 @@
 name: "Lint Pull Request"
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
+  push:
+    branches:
+      - v1.1.x
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
-    paths:
-      - "**.go"
-      - "**go.mod"
-      - "**go.sum"
-      - "<templates|test>/**/*.<yml|yaml>"
-      - ".github/actions/**/*"
-      - ".github/workflows/e2e-*"
-      - ".github/workflows/pr-*"
-      - ".golangci.yaml"
-      - "images/caph/**"
-      - "!**/vendor/**"
-      - "test/e2e/**"
-      - "docs/**"
 # yamllint disable rule:line-length
 jobs:
   pr-lint:


### PR DESCRIPTION
run `pr-lint` on pushes to `v1.1.x`

This lets the base branch populate the Lychee cache so newly created pull requests targeting `v1.1.x` can restore it.

Up to now Lychee often fails when we create a new PR. After this PR is merged, new PRs get the cache from the base-branch. 