### PR TITLE
:seedling: Set HCloudCredentialsInvalid condition in main reconcile path

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -109,8 +109,17 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 			// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
 			// As there is no point retrying with invalid credentials.
 			if errors.Is(err, hcloudclient.ErrUnauthorized) {
+				conditions.MarkFalse(
+					s.scope.HCloudMachine,
+					infrav1.HCloudTokenAvailableCondition,
+					infrav1.HCloudCredentialsInvalidReason,
+					clusterv1.ConditionSeverityError,
+					"wrong hcloud token",
+				)
+
 				return reconcile.Result{}, nil
 			}
+
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 				if !s.scope.HCloudMachine.Status.Ready {
 					hcloudutil.HandleRateLimitExceeded(s.scope.HCloudMachine, err, "findServer")
@@ -121,6 +130,8 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 			return reconcile.Result{}, fmt.Errorf("findServer: %w", err)
 		}
+
+		conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 		// findServer will return both server and error as nil, if the server was not found.
 		if server == nil {
@@ -216,6 +227,14 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
 		// As there is no point retrying with invalid credentials.
 		if errors.Is(err, hcloudclient.ErrUnauthorized) {
+			conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.HCloudTokenAvailableCondition,
+				infrav1.HCloudCredentialsInvalidReason,
+				clusterv1.ConditionSeverityError,
+				"wrong hcloud token",
+			)
+
 			return reconcile.Result{}, nil
 		}
 
@@ -244,6 +263,8 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		}
 		return reconcile.Result{}, fmt.Errorf("failed to create server: %w", err)
 	}
+
+	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 	updateHCloudMachineStatusFromServer(hm, server)
 
@@ -1208,22 +1229,8 @@ func (s *Service) getServerImage(ctx context.Context, imageName string) (*hcloud
 	// Get server type so we can filter for images with correct architecture
 	serverType, err := s.scope.HCloudClient.GetServerType(ctx, string(s.scope.HCloudMachine.Spec.Type))
 	if err != nil {
-		// If it is an unauthorized error i.e. wrong HCloudToken, set HCloudCredentialsInvalid condition.
-		if errors.Is(err, hcloudclient.ErrUnauthorized) {
-			conditions.MarkFalse(
-				s.scope.HCloudMachine,
-				infrav1.HCloudTokenAvailableCondition,
-				infrav1.HCloudCredentialsInvalidReason,
-				clusterv1.ConditionSeverityError,
-				"wrong hcloud token",
-			)
-			return nil, err
-		}
-
 		return nil, handleRateLimit(s.scope.HCloudMachine, err, "GetServerType", "failed to get server type in HCloud")
 	}
-
-	conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 	if serverType == nil {
 		msg := fmt.Sprintf("failed to get server type %q", string(s.scope.HCloudMachine.Spec.Type))
@@ -1418,22 +1425,8 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	if err == nil {
 		server, err = s.scope.HCloudClient.GetServer(ctx, serverID)
 		if err != nil {
-			// If it is an unauthorized error i.e. wrong HCloudToken, set HCloudCredentialsInvalid condition.
-			if errors.Is(err, hcloudclient.ErrUnauthorized) {
-				conditions.MarkFalse(
-					s.scope.HCloudMachine,
-					infrav1.HCloudTokenAvailableCondition,
-					infrav1.HCloudCredentialsInvalidReason,
-					clusterv1.ConditionSeverityError,
-					"wrong hcloud token",
-				)
-				return nil, err
-			}
-
 			return nil, fmt.Errorf("failed to get server %d: %w", serverID, err)
 		}
-
-		conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
 
 		// if server has been found, return it
 		if server != nil {


### PR DESCRIPTION


<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Previously we set HCloudCredentialsInvalid condition inside utitlity functions, this makes these paths bit less visible. Moving this up in the main reconcile path ensure better visibility for easier maintenance.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
