### PR TITLE
🌱 Split v1beta1 ServerAvailable into ServerProvisioned and ServerAvailable conditions for HCloudMachine

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -53,14 +53,18 @@ const (
 )
 
 const (
+	// ServerProvisionedCondition reports on whether the HCloud server has completed
+	// boot-time provisioning (rescue boot, image install, OS startup).
+	ServerProvisionedCondition clusterv1.ConditionType = "ServerProvisioned"
+	// ServerOffReason instance is off.
+	ServerOffReason = "ServerOff"
+)
+
+const (
 	// ServerAvailableCondition indicates the instance is in a Running state.
 	ServerAvailableCondition clusterv1.ConditionType = "ServerAvailable"
 	// ServerTerminatingReason instance is in a terminated state.
 	ServerTerminatingReason = "InstanceTerminated"
-	// ServerStartingReason instance is in a terminated state.
-	ServerStartingReason = "ServerStarting"
-	// ServerOffReason instance is off.
-	ServerOffReason = "ServerOff"
 )
 
 const (

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -445,6 +445,11 @@ var _ = Describe("HCloudMachineReconciler", func() {
 					return isPresentAndTrue(key, hcloudMachine, infrav1.ServerCreateSucceededCondition)
 				}, timeout, interval).Should(BeTrue())
 
+				By("checking if server provisioned condition is set")
+				Eventually(func() bool {
+					return isPresentAndTrue(key, hcloudMachine, infrav1.ServerProvisionedCondition)
+				}, timeout, interval).Should(BeTrue())
+
 				By("checking if server available condition is set")
 
 				Eventually(func() bool {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -197,7 +197,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			return reconcile.Result{}, err
 		}
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+		conditions.MarkFalse(hm, infrav1.ServerCreateSucceededCondition,
 			"HandleBootStateUnsetTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -216,9 +216,6 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		msg = fmt.Sprintf("Updating old resource (pre BootState) %s", hm.Status.BootState)
 
 		s.scope.Info(msg)
-		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"HandleBootStateUnset", clusterv1.ConditionSeverityInfo,
-			"%s", msg)
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
@@ -256,7 +253,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		if errors.Is(err, errServerCreateNotPossible) {
 			err = fmt.Errorf("createServerFromImageNameOrURL failed: %w", err)
 			s.scope.Error(err, "")
-			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			conditions.MarkFalse(hm, infrav1.ServerCreateSucceededCondition,
 				"ServerCreateNotPossible", clusterv1.ConditionSeverityWarning,
 				"%s", err.Error())
 			return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
@@ -749,9 +746,6 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 	case hcloud.ServerStatusRunning:
 		hm.SetBootState(infrav1.HCloudBootStateOperatingSystemRunning)
 		conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
-			"RealOSRunning", clusterv1.ConditionSeverityInfo,
-			"hcloud server status: %s", server.Status)
 		// Show changes in Status and go to next BootState.
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -197,7 +197,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			return reconcile.Result{}, err
 		}
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"HandleBootStateUnsetTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -216,7 +216,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		msg = fmt.Sprintf("Updating old resource (pre BootState) %s", hm.Status.BootState)
 
 		s.scope.Info(msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"HandleBootStateUnset", clusterv1.ConditionSeverityInfo,
 			"%s", msg)
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
@@ -256,7 +256,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		if errors.Is(err, errServerCreateNotPossible) {
 			err = fmt.Errorf("createServerFromImageNameOrURL failed: %w", err)
 			s.scope.Error(err, "")
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"ServerCreateNotPossible", clusterv1.ConditionSeverityWarning,
 				"%s", err.Error())
 			return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
@@ -284,7 +284,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 	if image.RapidDeploy {
 		requeueAfter = 10 * time.Second
 	}
-	conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+	conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"ProvisioningServer", clusterv1.ConditionSeverityInfo,
 		"Provisioning and rebooting server")
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
@@ -304,7 +304,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 			return reconcile.Result{}, err
 		}
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootStateInitializingTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -316,7 +316,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	if s.scope.ImageURLCommand == "" {
 		msg := "imageURL is set, but the caph command is missing the --hcloud-image-url-command"
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
 			"ImageURLSetButNoCommandProvided", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		// No need for Requeue, because adding the command line argument to the caph deployment,
@@ -331,7 +331,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	if err != nil {
 		err = fmt.Errorf("getSSHPrivateKey failed: %w", err)
 		s.scope.Error(err, "")
-		conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
 			"GetSSHPrivateKeyFailed", clusterv1.ConditionSeverityWarning,
 			"%s", err.Error())
 		return reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
@@ -342,7 +342,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	// analyze status of server
 	switch server.Status {
 	case hcloud.ServerStatusStarting, hcloud.ServerStatusInitializing:
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"ServerNotRunningYet", clusterv1.ConditionSeverityInfo,
 			"hcloud server is %q", server.Status)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -351,7 +351,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	default:
 		// some temporary status
 		s.scope.Info("Unknown hcloud server status", "status", server.Status)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"UnknownHCloudStatus", clusterv1.ConditionSeverityInfo, "hcloud server has unknown status: %q", server.Status)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -379,7 +379,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 
 	hm.SetBootState(infrav1.HCloudBootStateEnablingRescue)
 
-	conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+	conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"WaitForRescueSystem", clusterv1.ConditionSeverityInfo,
 		"waiting for rescue system to be enabled")
 	return reconcile.Result{RequeueAfter: 4 * time.Second}, nil
@@ -399,7 +399,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"EnablingRescueTimedOut", clusterv1.ConditionSeverityWarning, "%s", msg)
 		return reconcile.Result{}, nil
 	}
@@ -413,7 +413,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"ActionIDForEnablingRescueSystemNotSet", clusterv1.ConditionSeverityWarning, "%s", msg)
 		return reconcile.Result{}, nil
 	}
@@ -425,7 +425,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 			// machine will be created.
 			err = fmt.Errorf("GetAction failed: %w", err)
 			s.scope.Error(err, "")
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"EnablingRescueGetActionFailed", clusterv1.ConditionSeverityWarning,
 				"%s", err.Error())
 			return reconcile.Result{}, err
@@ -433,7 +433,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 
 		if action.Finished.IsZero() {
 			// not finished yet.
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"WaitingForEnablingRescueAction", clusterv1.ConditionSeverityInfo,
 				"Waiting until Action RescueEnabled is finished")
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -447,7 +447,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 			if err != nil {
 				return reconcile.Result{}, err
 			}
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"EnablingRescueActionFailed", clusterv1.ConditionSeverityWarning,
 				"%s", err.Error())
 			return reconcile.Result{}, nil
@@ -459,7 +459,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 			"actionStatus", action.Status)
 
 		hm.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"EnablingRescueActionDone", clusterv1.ConditionSeverityInfo,
 			"Action RescueEnabled is finished")
 		// When the reboot is triggered immediately after the action is finished,
@@ -470,7 +470,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 	if !server.RescueEnabled {
 		msg := "rescue system is not enabled yet? Requeue"
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"RescueNotEnabledYet", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -484,7 +484,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 	if err != nil {
 		err = fmt.Errorf("getSSHClient failed: %w", err)
 		s.scope.Error(err, "")
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"GetSSHClientFailed", clusterv1.ConditionSeverityWarning,
 			"%s", err.Error())
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -495,7 +495,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		if errors.Is(err, syscall.ECONNREFUSED) {
 			// ssh connection refused is common while the rescue system starts.
 			// Provide a nice message.
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"RetryingSSHConnection",
 				clusterv1.ConditionSeverityInfo, "Rebooting")
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -503,7 +503,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 
 		err = fmt.Errorf("reboot to rescue: reboot via ssh failed: %w", err)
 		s.scope.Error(err, "")
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"RebootViaSSHFailed",
 			clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -512,7 +512,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 	s.scope.Info("Reboot started (via ssh)")
 
 	hm.SetBootState(infrav1.HCloudBootStateBootingToRescue)
-	conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+	conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"BootingToRescue", clusterv1.ConditionSeverityInfo,
 		"reboot to rescue started")
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -533,7 +533,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 			return reconcile.Result{}, err
 		}
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootingToRescueTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -542,7 +542,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 	if server.RescueEnabled {
 		msg := "Waiting until RescueEnabled is false"
 		s.scope.Info(msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"WaitForRescueEnabledToBeFalse", clusterv1.ConditionSeverityInfo,
 			"%s", msg)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -560,14 +560,14 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		if errors.Is(err, syscall.ECONNREFUSED) {
 			// This is common. Provide a nice message.
 			msg = "getHostName: ssh not reachable yet. Retrying"
-			conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+			conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"RetryingSSHConnection", clusterv1.ConditionSeverityInfo,
 				"%s", msg)
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		err = fmt.Errorf("get hostname failed: %w", err)
 		s.scope.Error(err, "")
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"GetHostnameFailed", clusterv1.ConditionSeverityWarning,
 			"%s", err.Error())
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
@@ -584,7 +584,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"UnexpectedHostname", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -605,7 +605,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 			"ImageURLCommand", s.scope.ImageURLCommand,
 			"exitStatus", exitStatus,
 			"stdoutStderr", stdoutStderr)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"StartImageURLCommandFailed", clusterv1.ConditionSeverityWarning,
 			"%s", err.Error())
 		return reconcile.Result{}, err
@@ -621,13 +621,13 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"StartImageURLCommandNoZeroExitCode", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
 	}
 
-	conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+	conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"HCloudImageURLCommandRunning", clusterv1.ConditionSeverityInfo,
 		"hcloud-image-url-command running")
 	hm.SetBootState(infrav1.HCloudBootStateRunningImageCommand)
@@ -662,7 +662,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			return reconcile.Result{}, err
 		}
 		record.Warn(hm, "ImageURLCommandFailed", logFile)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"RunningImageCommandTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -670,7 +670,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 
 	switch state {
 	case sshclient.ImageURLCommandStateRunning:
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"HCloudImageURLCommandRunning", clusterv1.ConditionSeverityInfo,
 			"hcloud-image-url-command running")
 		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
@@ -686,7 +686,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 
 		hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)
 
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootingToRealOS", clusterv1.ConditionSeverityInfo,
 			"Operating system of node is booting")
 
@@ -700,7 +700,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"ImageCommandFailed", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -729,7 +729,7 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 			return reconcile.Result{}, err
 		}
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootingToRealOSTimedOut", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{}, nil
@@ -741,13 +741,14 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 		return s.handleServerStatusOff(ctx, server)
 
 	case hcloud.ServerStatusStarting, hcloud.ServerStatusInitializing:
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootingToRealOS", clusterv1.ConditionSeverityInfo,
 			"Operating system of node is booting")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 
 	case hcloud.ServerStatusRunning:
 		hm.SetBootState(infrav1.HCloudBootStateOperatingSystemRunning)
+		conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
 			"RealOSRunning", clusterv1.ConditionSeverityInfo,
 			"hcloud server status: %s", server.Status)
@@ -757,7 +758,7 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 	default:
 		msg := fmt.Sprintf("hcloud server status unknown: %s", server.Status)
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"UnknownServerStatus", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -771,6 +772,8 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 
 	// Clean up old Status fields
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = 0
+
+	conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 
 	// check whether server is attached to the network
 	if err := s.reconcileNetworkAttachment(ctx, server); err != nil {
@@ -1015,7 +1018,7 @@ func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server,
 		msg := err.Error()
 		record.Warn(hm, "FailedGetServerImage", msg)
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"GetServerImageFailed", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return nil, nil, err
@@ -1038,7 +1041,7 @@ func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server
 		msg := err.Error()
 		record.Warn(hm, "FailedGetBootstrapData", msg)
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"GetRawBootstrapDataFailed", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return nil, nil, err
@@ -1050,7 +1053,7 @@ func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server
 		msg := err.Error()
 		record.Warn(hm, "FailedGetServerImage", msg)
 		s.scope.Error(nil, msg)
-		conditions.MarkFalse(hm, infrav1.ServerAvailableCondition,
+		conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"GetServerImageFailed", clusterv1.ConditionSeverityWarning,
 			"%s", msg)
 		return nil, nil, err
@@ -1321,17 +1324,17 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 	// Check if server is in ServerStatusOff and turn it on. This is to avoid a bug of Hetzner where
 	// sometimes machines are created and not turned on
 
-	serverAvailableCondition := conditions.Get(s.scope.HCloudMachine, infrav1.ServerAvailableCondition)
-	if serverAvailableCondition != nil &&
-		serverAvailableCondition.Status == corev1.ConditionFalse &&
-		serverAvailableCondition.Reason == infrav1.ServerOffReason {
+	serverProvisionedCondition := conditions.Get(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition)
+	if serverProvisionedCondition != nil &&
+		serverProvisionedCondition.Status == corev1.ConditionFalse &&
+		serverProvisionedCondition.Reason == infrav1.ServerOffReason {
 		s.scope.Info("Trigger power on again")
-		if time.Now().Before(serverAvailableCondition.LastTransitionTime.Add(serverOffTimeout)) {
+		if time.Now().Before(serverProvisionedCondition.LastTransitionTime.Add(serverOffTimeout)) {
 			// Not yet timed out, try again to power on
 			if err := s.scope.HCloudClient.PowerOnServer(ctx, server); err != nil {
 				if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 					// if server is locked, we just retry again
-					conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+					conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
 						"PowerOnServerFailed", clusterv1.ConditionSeverityInfo,
 						"handleServerStatusOff: server locked. Will retry")
 					return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
@@ -1344,6 +1347,9 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 			if err != nil {
 				return reconcile.Result{}, err
 			}
+			conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
+				"ServerOffTimeout", clusterv1.ConditionSeverityWarning,
+				"reached timeout waiting for server that is switched off")
 			return res, nil
 		}
 	} else {
@@ -1351,7 +1357,7 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 		if err := s.scope.HCloudClient.PowerOnServer(ctx, server); err != nil {
 			if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 				// if server is locked, we just retry again
-				conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+				conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
 					"PowerOnServerFailed", clusterv1.ConditionSeverityInfo, "handleServerStatusOff: server locked. Will retry")
 				return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 			}
@@ -1359,7 +1365,7 @@ func (s *Service) handleServerStatusOff(ctx context.Context, server *hcloud.Serv
 		}
 		conditions.MarkFalse(
 			s.scope.HCloudMachine,
-			infrav1.ServerAvailableCondition,
+			infrav1.ServerProvisionedCondition,
 			infrav1.ServerOffReason,
 			clusterv1.ConditionSeverityInfo,
 			"server is switched off",

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -160,13 +160,13 @@ var _ = Describe("handleServerStatusOff", func() {
 
 		Expect(res).Should(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
 
-		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerProvisionedCondition)).To(Equal(infrav1.ServerOffReason))
 
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
 	})
 
 	It("tries to power on server again if it is not timed out", func() {
-		conditions.MarkFalse(hcloudMachine, infrav1.ServerAvailableCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
+		conditions.MarkFalse(hcloudMachine, infrav1.ServerProvisionedCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
 
 		service := newTestService(hcloudMachine, client)
 
@@ -177,16 +177,16 @@ var _ = Describe("handleServerStatusOff", func() {
 
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
 
-		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerProvisionedCondition)).To(Equal(infrav1.ServerOffReason))
 	})
 
 	It("sets a failure message if it timed out", func() {
-		conditions.MarkFalse(hcloudMachine, infrav1.ServerAvailableCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
+		conditions.MarkFalse(hcloudMachine, infrav1.ServerProvisionedCondition, infrav1.ServerOffReason, clusterv1.ConditionSeverityInfo, "")
 
 		// manipulate lastTransitionTime
 		conditionsList := hcloudMachine.GetConditions()
 		for i, c := range conditionsList {
-			if c.Type == infrav1.ServerAvailableCondition {
+			if c.Type == infrav1.ServerProvisionedCondition {
 				conditionsList[i].LastTransitionTime = metav1.NewTime(time.Now().Add(-time.Hour))
 			}
 		}
@@ -206,7 +206,7 @@ var _ = Describe("handleServerStatusOff", func() {
 	})
 
 	It("tries to power on server and sets new condition if different one is set", func() {
-		conditions.MarkTrue(hcloudMachine, infrav1.ServerAvailableCondition)
+		conditions.MarkTrue(hcloudMachine, infrav1.ServerProvisionedCondition)
 
 		service := newTestService(hcloudMachine, client)
 
@@ -215,7 +215,7 @@ var _ = Describe("handleServerStatusOff", func() {
 
 		Expect(res).Should(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
 
-		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerAvailableCondition)).To(Equal(infrav1.ServerOffReason))
+		Expect(conditions.GetReason(hcloudMachine, infrav1.ServerProvisionedCondition)).To(Equal(infrav1.ServerOffReason))
 
 		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
 	})


### PR DESCRIPTION

**What this PR does / why we need it**:
Splits the overloaded v1beta1 `ServerAvailableCondition` into two distinct conditions:
- `ServerProvisionedCondition`: tracks boot time provisioning progress (rescue boot, image install, OS startup)
- `ServerAvailableCondition`: indicates the server is running and ready (network attached, LB attached)
This ensures provisioning status is tracked separately from post provisioning availability, and that post provisioning operations never mutate the provisioned condition.

**Which issue(s) this PR fixes:**
Fixes #1947

**Special notes for your reviewer**:
- `ServerProvisionedCondition` is only set to `False` during provisioning and `True` once the OS is running
- Post provisioning code (`handleOperatingSystemRunning`, delete path) only touches `ServerAvailableCondition`

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests