### PR TITLE
:bug: requeue instead of silent return when rate-limited when 'HCloudMachine' already has 'Status.Ready=true'

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -116,8 +116,14 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
-		// If HCloudMachine is ready, stop reconciling.
-		return reconcile.Result{}, nil
+		// HCloudMachine is ready so we skip setting a misleading rate-limit condition.
+		// However, we still requeue so that any stale error conditions (e.g. ServerCreateSucceeded=False
+		// left over from a previous rate-limit storm) can be cleared once the rate limit lifts.
+		s.scope.Info("rate limit exceeded during findServer, requeueing to clear stale conditions",
+			"namespace", s.scope.HCloudMachine.Namespace,
+			"name", s.scope.HCloudMachine.Name,
+		)
+		return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
 	// if no server is found we have to create one.


### PR DESCRIPTION
**AI Disclaimer**
This PR was created by Claude Sonnet 4.6 through GitHub Copilot

**What this PR does / why we need it**:

When `findServer` returns a rate-limit error but the `HCloudMachine` already has `Status.Ready=true`, the previous code silently returned `reconcile.Result{}` with no `RequeueAfter`. This meant the reconciler never re-scheduled the machine after the rate limit lifted.

As a result, stale error conditions written during the rate-limit event (e.g. `ServerCreateSucceeded=False`, `HetznerAPIReachable=False`) persisted indefinitely on `status.conditions`. The parent `MachineDeployment` observed fewer `availableReplicas` than desired (with `maxUnavailable=0`) and stayed `Available=False` even though every underlying Hetzner server was healthy and its node was registered in Kubernetes.

The fix changes the silent return to `RequeueAfter: 5 * time.Minute`, so once the rate limit lifts the reconciler runs the happy path and clears any stale conditions automatically — no operator intervention required.

**Which issue(s) this PR fixes**:
Fixes #1966

**Special notes for your reviewer**:

The same bug exists on `v1.1.x` and has been ported there in a separate branch (`fix/rate-limit-silent-return-v1.1.x`). That branch also interacts with the upcoming v1beta2 `HCloudRateLimitExceeded` condition from PR #1935 — without this requeue, a stuck `HCloudRateLimitExceeded=True` condition on a ready machine would similarly never be cleared by `reconcileRateLimit`.

---
**TODOs**:

- [x] squash commits
- [x] include documentation
- [ ] add unit tests
