### PR TITLE
:seedling: Mark condition RemediationSkipped on HCloudRemediation

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -255,3 +255,12 @@ const (
 	// RebootSucceededCondition indicates that the machine got rebooted successfully.
 	RebootSucceededCondition clusterv1.ConditionType = "RebootSucceeded"
 )
+
+const (
+	// RemediationSkippedCondition reports that remediation was skipped because
+	// the HCloudMachine has a state that makes remediation unnecessary or impossible.
+	RemediationSkippedCondition clusterv1.ConditionType = "RemediationSkipped"
+	// IrrecoverableServerCreateFailureReason indicates remediation was skipped because
+	// the HCloudMachine failed to create with an irrecoverable error (e.g. invalid_input, resource_unavailable).
+	IrrecoverableServerCreateFailureReason = "IrrecoverableServerCreateFailure"
+)

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -121,11 +121,27 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 	// We return without error so the MHC does not keep retrying remediation.
 	if conditions.IsFalse(hcloudMachine, infrav1.ServerCreateSucceededCondition) &&
 		conditions.GetReason(hcloudMachine, infrav1.ServerCreateSucceededCondition) == infrav1.ServerCreateFailedIrrecoverableErrorReason {
+		irrecoverableMsg := conditions.GetMessage(hcloudMachine, infrav1.ServerCreateSucceededCondition)
 		log.Info("Skipping remediation for machine with irrecoverable creation failure",
-			"reason", conditions.GetMessage(hcloudMachine, infrav1.ServerCreateSucceededCondition),
+			"reason", irrecoverableMsg,
 		)
 
-		// signal remediation done.
+		patchHelper, err := patch.NewHelper(hcloudRemediation, r.Client)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to create patch helper for HCloudRemediation: %w", err)
+		}
+		conditions.MarkFalse(
+			hcloudRemediation,
+			infrav1.RemediationSkippedCondition,
+			infrav1.IrrecoverableServerCreateFailureReason,
+			clusterv1.ConditionSeverityWarning,
+			"Remediation skipped: HCloudMachine has an irrecoverable server creation error. Delete the Machine to trigger a new creation attempt. Error: %s",
+			irrecoverableMsg,
+		)
+		if err := patchHelper.Patch(ctx, hcloudRemediation); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to patch HCloudRemediation status: %w", err)
+		}
+
 		return reconcile.Result{}, nil
 	}
 

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -330,6 +330,45 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					isPresentAndFalseWithReason(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason)
 			}, timeout).Should(BeTrue())
 		})
+		It("should set RemediationSkippedCondition when HCloudMachine has irrecoverable server creation failure", func() {
+			By("waiting for HCloudMachine to be fully provisioned")
+			Eventually(func() error {
+				if err := testEnv.Get(ctx, hcloudMachineKey, hcloudMachine); err != nil {
+					return err
+				}
+				if hcloudMachine.Status.BootState != infrav1.HCloudBootStateOperatingSystemRunning {
+					return fmt.Errorf("expected BootState %q, got %q",
+						infrav1.HCloudBootStateOperatingSystemRunning, hcloudMachine.Status.BootState)
+				}
+				return nil
+			}, timeout).Should(Succeed())
+
+			By("marking HCloudMachine with irrecoverable server creation failure condition")
+			patchHelper, err := patch.NewHelper(hcloudMachine, testEnv.GetClient())
+			Expect(err).NotTo(HaveOccurred())
+			conditions.MarkFalse(
+				hcloudMachine,
+				infrav1.ServerCreateSucceededCondition,
+				infrav1.ServerCreateFailedIrrecoverableErrorReason,
+				clusterv1.ConditionSeverityError,
+				"server type cax31 not available in location fsn1: resource_unavailable",
+			)
+			Expect(patchHelper.Patch(ctx, hcloudMachine)).To(Succeed())
+
+			By("creating the HCloudRemediation")
+			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
+
+			By("checking that RemediationSkippedCondition is set with IrrecoverableServerCreateFailureReason")
+			Eventually(func() bool {
+				return isPresentAndFalseWithReason(
+					hcloudRemediationkey,
+					hcloudRemediation,
+					infrav1.RemediationSkippedCondition,
+					infrav1.IrrecoverableServerCreateFailureReason,
+				)
+			}, timeout).Should(BeTrue())
+		})
+
 		It("should delete machine if SetErrorAndRemediate() was called", func() {
 			By("Creating Server")
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -246,7 +246,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 				infrav1.ServerCreateSucceededCondition,
 				infrav1.ServerCreateFailedIrrecoverableErrorReason,
 				clusterv1.ConditionSeverityError,
-				"%s",
+				"Server creation failed with an irrecoverable error: %s. If the requested resources (server type or location) become available again, delete the Machine to trigger a new creation attempt.",
 				err.Error(),
 			)
 			return reconcile.Result{}, nil


### PR DESCRIPTION


<!--

    PLEASE BASE YOUR PULL REQUESTS ON THE v1.1.x BRANCH IF YOU ADD A NEW FEATURE.

    The main branch reflects v1.0.x. Use the main branch if you create a bug or security fix.

 -->

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Mark condition `RemediationSkipped` to false with reason `IrrecoverableServerCreateFailure` on HCloudRemediation object if the HCloudMachine has an irrecoverable failure during server creation.

- Also add a more verbose message to the condition `ServerCreateFailedIrrecoverableError` on HCloudMachine indicating that manual intervention is required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1969

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
