### PR TITLE
:seedling: Fix flaky Remediation test.

### DIFF
--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -389,6 +389,20 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				return testEnv.Update(ctx, hcloudMachine)
 			}, timeout).Should(Succeed())
 
+			By("Wait until HCloudMachine has reached a stable boot state")
+			Eventually(func() error {
+				err := testEnv.Get(ctx, client.ObjectKeyFromObject(hcloudMachine), hcloudMachine)
+				if err != nil {
+					return err
+				}
+				if hcloudMachine.Status.BootState != infrav1.HCloudBootStateBootingToRealOS &&
+					hcloudMachine.Status.BootState != infrav1.HCloudBootStateOperatingSystemRunning {
+					return fmt.Errorf("expected stable boot state before remediation, got %q",
+						hcloudMachine.Status.BootState)
+				}
+				return nil
+			}, timeout).Should(Succeed())
+
 			By("Call SetRemediateMachineAnnotationToDeleteMachine")
 			Eventually(func() error {
 				err = testEnv.Get(ctx, client.ObjectKeyFromObject(hcloudMachine), hcloudMachine)
@@ -404,7 +418,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					return err
 				}
 				return nil
-			}).Should(Succeed())
+			}, timeout).Should(Succeed())
 
 			By("Wait until HCloudBootStateProvisioningFailed is set.")
 			Eventually(func() error {
@@ -417,7 +431,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 						hcloudMachine.Status.BootState)
 				}
 				return nil
-			}).Should(Succeed())
+			}, timeout).Should(Succeed())
 
 			By("Do the job of CAPI: Create a HCloudRemediation")
 			rem := &infrav1.HCloudRemediation{
@@ -472,7 +486,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					return fmt.Errorf("Message is not as expected: %q", c.Message)
 				}
 				return nil
-			}).Should(Succeed())
+			}, timeout).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Fix flaky Remediation test.

[:seedling: Move SSHAfterInstallImage from cli argument to HetznerBaremetalMachine · syself/cluster-api-provider-hetzner@a1148ef](https://github.com/syself/cluster-api-provider-hetzner/actions/runs/24565971710/job/71826134814?pr=1965#step:8:1485)


----

```log 
• [FAILED] [1.066 seconds]
HCloudRemediationReconciler Basic hcloudremediation test [It] should delete machine if SetErrorAndRemediate() was called
/home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hcloudremediation_controller_test.go:372

  Timeline >>
  STEP: Creating Server @ 04/17/26 12:54:38.974
  STEP: Call SetRemediateMachineAnnotationToDeleteMachine @ 04/17/26 12:54:38.977
  STEP: Wait until HCloudBootStateProvisioningFailed is set. @ 04/17/26 12:54:38.999
  [FAILED] in [It] - /home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hcloudremediation_controller_test.go:420 @ 04/17/26 12:54:40
  << Timeline

  [FAILED] Timed out after 1.001s.
  Expected success, but got an error:
      <*errors.errorString | 0xc0012374e0>: 
      BootState is not HCloudBootStateProvisioningFailed, but "BootingToRealOS"
      {
          s: "BootState is not HCloudBootStateProvisioningFailed, but \"BootingToRealOS\"",
      }
  In [It] at: /home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hcloudremediation_controller_test.go:420 @ 04/17/26 12:54:40
------------------------------

Summarizing 1 Failure:
  [FAIL] HCloudRemediationReconciler Basic hcloudremediation test [It] should delete machine if SetErrorAndRemediate() was called
  /home/runner/work/cluster-api-provider-hetzner/cluster-api-provider-hetzner/controllers/hcloudremediation_controller_test.go:420
```