### PR TITLE
fix: nil pointer panic in createOptsFromSpec when ControlPlaneEndpoint is unset

### DIFF
--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -323,7 +323,12 @@ func createOptsFromSpec(hc *infrav1.HetznerCluster) hcloud.LoadBalancerCreateOpt
 		network = &hcloud.Network{ID: hc.Status.Network.ID}
 	}
 
-	listenPort := int(hc.Spec.ControlPlaneEndpoint.Port)
+	// ControlPlaneEndpoint is set by CAPH after LB creation, so it may be nil on
+	// the first reconciliation. Fall back to ControlPlaneLoadBalancer.Port in that case.
+	listenPort := int(hc.Spec.ControlPlaneLoadBalancer.Port)
+	if hc.Spec.ControlPlaneEndpoint != nil && hc.Spec.ControlPlaneEndpoint.Port != 0 {
+		listenPort = int(hc.Spec.ControlPlaneEndpoint.Port)
+	}
 	publicInterface := true
 	return hcloud.LoadBalancerCreateOpts{
 		LoadBalancerType: &hcloud.LoadBalancerType{Name: hc.Spec.ControlPlaneLoadBalancer.Type},


### PR DESCRIPTION
## Summary

- `createOptsFromSpec` dereferences `hc.Spec.ControlPlaneEndpoint.Port` unconditionally, but `ControlPlaneEndpoint` is a pointer (`*clusterv1.APIEndpoint`) that is `nil` during the first reconciliation — before CAPH has created the LB and populated the field.
- This causes a controller crash loop (`nil pointer dereference` at `loadbalancer.go:326`) on every fresh `HetznerCluster` with `controlPlaneLoadBalancer.enabled: true`.
- The official cluster template uses `controlPlaneEndpoint: {host: "", port: 443}` as a workaround, but Kubernetes strips the field due to `omitempty` serialization on the pointer type, so the nil dereference is unavoidable following the documented bootstrap flow.

## Fix

Fall back to `ControlPlaneLoadBalancer.Port` when `ControlPlaneEndpoint` is nil or has no port set. This is the correct value anyway since the LB listen port is configured via `controlPlaneLoadBalancer.port`.

## How to reproduce

1. Apply a `HetznerCluster` with `controlPlaneLoadBalancer.enabled: true` and no `controlPlaneEndpoint` (or `host: ""` which gets stripped by Kubernetes).
2. CAPH controller enters crash loop immediately on first reconciliation.

## Test plan

- [ ] Fresh `HetznerCluster` with LB enabled and no `controlPlaneEndpoint` — controller no longer crashes
- [ ] `controlPlaneEndpoint.port` is respected when explicitly set (non-nil, non-zero)
- [ ] `controlPlaneLoadBalancer.port` is used as fallback when endpoint is nil