### PR TITLE
:seedling: Return early from handleOperatingSystemRunning on non-zero reconcile.Result

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -822,11 +822,12 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 		return res, reterr
 	}
 
+	s.scope.SetReady(true)
+
 	if res != (reconcile.Result{}) {
 		return res, nil
 	}
 
-	s.scope.SetReady(true)
 	conditions.MarkTrue(hm, infrav1.ServerAvailableCondition)
 	return reconcile.Result{}, nil
 }

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -823,9 +823,14 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 	}
 
 	// Order matters:
-	// 1. SetReady(true) first so CAPI propagates ProviderID to the Machine.
-	// 2. Return early if reconcileLoadBalancerAttachment requested a requeue,
-	//    so the False reason it set on ServerAvailable is not overwritten.
+	// 1. SetReady(true) first. This is what makes the Machine become ready and
+	//    lets the Node get linked to it. Otherwise we deadlock:
+	//    reconcileLoadBalancerAttachment only adds this control plane to the
+	//    load balancer once its apiserver pod is marked healthy, and that can
+	//    only happen after the Node is linked to the Machine, which in turn
+	//    requires this call to SetReady.
+	// 2. Return early on a non-zero res so the False reason set on
+	//    ServerAvailable inside reconcileLoadBalancerAttachment is not overwritten.
 	// 3. Mark ServerAvailable=True only on the happy path.
 	s.scope.SetReady(true)
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -822,6 +822,10 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 		return res, reterr
 	}
 
+	if res != (reconcile.Result{}) {
+		return res, nil
+	}
+
 	s.scope.SetReady(true)
 	conditions.MarkTrue(hm, infrav1.ServerAvailableCondition)
 	return reconcile.Result{}, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -822,6 +822,11 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 		return res, reterr
 	}
 
+	// Order matters:
+	// 1. SetReady(true) first so CAPI propagates ProviderID to the Machine.
+	// 2. Return early if reconcileLoadBalancerAttachment requested a requeue,
+	//    so the False reason it set on ServerAvailable is not overwritten.
+	// 3. Mark ServerAvailable=True only on the happy path.
 	s.scope.SetReady(true)
 
 	if res != (reconcile.Result{}) {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1302,6 +1302,79 @@ var _ = Describe("Reconcile", func() {
 	})
 })
 
+var _ = Describe("handleOperatingSystemRunning", func() {
+	var (
+		hcloudMachine *infrav1.HCloudMachine
+		server        *hcloud.Server
+		service       *Service
+	)
+
+	BeforeEach(func() {
+		client := fakehcloudclient.NewHCloudClientFactory().NewClient("")
+		server = newTestServer()
+
+		hcloudMachine = &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.HCloudMachineSpec{
+				ImageName: "ubuntu-24.04",
+				Type:      "cpx22",
+			},
+		}
+
+		service = newTestService(hcloudMachine, client)
+
+		// Mark capi Machine as control plane so the load balancer branch runs.
+		service.scope.Machine.Labels = map[string]string{
+			clusterv1.MachineControlPlaneLabel: "",
+		}
+
+		service.scope.Cluster = &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneRef: &corev1.ObjectReference{
+					Kind: "KubeadmControlPlane",
+				},
+			},
+		}
+		service.scope.HetznerCluster = &infrav1.HetznerCluster{}
+	})
+
+	It("returns early without setting Ready when reconcileLoadBalancerAttachment requeues", func() {
+		// Existing LB target plus an unhealthy kube-apiserver pod makes
+		// reconcileLoadBalancerAttachment return RequeueAfter 30s and mark
+		// ServerAvailableCondition=False. Without the early return in
+		// handleOperatingSystemRunning, that condition would be overwritten to True.
+		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
+			ID: 1,
+			Target: []infrav1.LoadBalancerTarget{
+				{
+					Type:     infrav1.LoadBalancerTargetTypeServer,
+					ServerID: server.ID + 1,
+				},
+			},
+		}
+
+		res, err := service.handleOperatingSystemRunning(context.Background(), server)
+		Expect(err).To(Succeed())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
+
+		Expect(hcloudMachine.Status.Ready).To(BeFalse())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerAvailableCondition, "WaitingForAPIServer")).To(BeTrue())
+	})
+
+	It("sets Ready and ServerAvailableCondition when reconcileLoadBalancerAttachment returns an empty Result", func() {
+		// No load balancer → reconcileLoadBalancerAttachment returns an empty Result.
+		res, err := service.handleOperatingSystemRunning(context.Background(), server)
+		Expect(err).To(Succeed())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(hcloudMachine.Status.Ready).To(BeTrue())
+		Expect(conditions.IsTrue(hcloudMachine, infrav1.ServerAvailableCondition)).To(BeTrue())
+	})
+})
+
 func isPresentAndFalseWithReason(getter conditions.Getter, condition clusterv1.ConditionType, reason string) bool {
 	if !conditions.Has(getter, condition) {
 		return false

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1341,11 +1341,13 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 		service.scope.HetznerCluster = &infrav1.HetznerCluster{}
 	})
 
-	It("returns early without setting Ready when reconcileLoadBalancerAttachment requeues", func() {
+	It("propagates the requeue and preserves ServerAvailableCondition=False when reconcileLoadBalancerAttachment requeues", func() {
 		// Existing LB target plus an unhealthy kube-apiserver pod makes
 		// reconcileLoadBalancerAttachment return RequeueAfter 30s and mark
 		// ServerAvailableCondition=False. Without the early return in
 		// handleOperatingSystemRunning, that condition would be overwritten to True.
+		// Ready must still flip to true so CAPI can propagate ProviderID and
+		// downstream controllers can observe the apiserver pod health.
 		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
 			ID: 1,
 			Target: []infrav1.LoadBalancerTarget{
@@ -1360,7 +1362,7 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 		Expect(err).To(Succeed())
 		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
 
-		Expect(hcloudMachine.Status.Ready).To(BeFalse())
+		Expect(hcloudMachine.Status.Ready).To(BeTrue())
 		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerAvailableCondition, "WaitingForAPIServer")).To(BeTrue())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`handleOperatingSystemRunning` calls `reconcileLoadBalancerAttachment` but then ignores its returned `reconcile.Result`. When that result carries a `RequeueAfter` (e.g. the kube-apiserver pod is not yet healthy and the server should not be attached to the load balancer yet), `handleOperatingSystemRunning` would still fall through to:

~~~go
s.scope.SetReady(true)
conditions.MarkTrue(hm, infrav1.ServerAvailableCondition)
~~~

overwriting the `ServerAvailableCondition=False/WaitingForAPIServer` that `reconcileLoadBalancerAttachment` had just set, and marking the server Ready prematurely.

This PR adds the missing early return so the requeue propagates and the condition is preserved:

~~~go
if res != (reconcile.Result{}) {
    return res, nil
}
~~~

This fix was originally bundled in #1978; it is split out here so it can land on its own.

**Which issue(s) this PR fixes:**
None

**Special notes for your reviewer**:

none.



**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests