### PR TITLE
:seedling: Set permanent error when bare metal server has no IPv4

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -194,6 +194,8 @@ const (
 	CloudInitNotInstalledReason = "CloudInitNotInstalled"
 	// ServerNotFoundReason indicates that a bare metal server could not be found.
 	ServerNotFoundReason = "ServerNotFound"
+	// ServerHasNoIPv4Reason indicates that a bare metal server has no IPv4 address assigned.
+	ServerHasNoIPv4Reason = "ServerHasNoIPv4"
 	// LinuxOnOtherDiskFoundReason indicates that the server can't be provisioned on the given WWN, since the reboot would fail.
 	LinuxOnOtherDiskFoundReason = "LinuxOnOtherDiskFound"
 	// WipeDiskFailedReason indicates that erasing the disks before provisioning failed.

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -182,6 +182,21 @@ func (s *Service) actionPreparing(ctx context.Context) actionResult {
 
 	conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.RobotCredentialsAvailableCondition)
 
+	if server.ServerIP == "" {
+		msg := fmt.Sprintf("bare metal server %d has no IPv4 address assigned", s.scope.HetznerBareMetalHost.Spec.ServerID)
+		conditions.MarkFalse(
+			s.scope.HetznerBareMetalHost,
+			infrav1.ProvisionSucceededCondition,
+			infrav1.ServerHasNoIPv4Reason,
+			clusterv1.ConditionSeverityError,
+			"%s",
+			msg,
+		)
+		record.Warnf(s.scope.HetznerBareMetalHost, infrav1.ServerHasNoIPv4Reason, msg)
+		s.scope.HetznerBareMetalHost.SetError(infrav1.PermanentError, msg)
+		return actionStop{}
+	}
+
 	s.scope.HetznerBareMetalHost.Spec.Status.IPv4 = server.ServerIP
 	s.scope.HetznerBareMetalHost.Spec.Status.IPv6 = server.ServerIPv6Net + "1"
 

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -915,6 +915,37 @@ var _ = Describe("actionPreparing", func() {
 		Expect(robotMock.AssertCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
 		Expect(robotMock.AssertCalled(GinkgoT(), "SetBootRescue", mock.Anything, sshFingerprint)).To(BeTrue())
 	})
+
+	It("sets a permanent error when the server has no IPv4", func() {
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithSSHSpecInclPorts(22),
+		)
+
+		robotMock := robotmock.Client{}
+		robotMock.On("GetBMServer", mock.Anything).Return(&models.Server{
+			ServerNumber:  1,
+			ServerIP:      "",
+			ServerIPv6Net: "2a01:4f9:3051:12ce::",
+		}, nil)
+
+		service := newTestService(
+			host,
+			&robotMock,
+			nil,
+			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+			helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"),
+		)
+
+		actResult := service.actionPreparing(context.Background())
+
+		Expect(actResult).To(BeAssignableToTypeOf(actionStop{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.PermanentError))
+		Expect(host.Spec.Status.ErrorMessage).To(ContainSubstring("no IPv4"))
+		Expect(host.Spec.Status.IPv4).To(BeEmpty())
+		Expect(host.Annotations).To(HaveKey(infrav1.PermanentErrorAnnotation))
+	})
 })
 
 var _ = Describe("analyzeSSHOutputInstallImage", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a bare metal server has no IPv4 address assigned in Robot, CAPH previously stored the empty string as `Status.IPv4` and continued the provisioning flow. SSH attempts and reboots later failed in ways that were not transparent to the operator.

This PR adds an early check in `actionPreparing`, right after `GetBMServer` succeeds and credentials are confirmed. If `server.ServerIP` is empty:

- `ProvisionSucceeded` is marked `False` with the new reason `ServerHasNoIPv4`
- a warning event is recorded
- `SetError(PermanentError, ...)` is called, which adds `PermanentErrorAnnotation`: the operator must remove it to retry
- reconciliation stops (`actionStop{}`)

This mirrors the existing `ServerNotFound` handler at the same call site.

**Which issue(s) this PR fixes:**
Fixes #1973

**Special notes for your reviewer**:
None.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests