### PR TITLE
:seedling: When image-url-command is missing, don't create server.

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -63,6 +63,8 @@ var hcloudImageURLCommandDir = "/shared"
 
 var errServerCreateNotPossible = errors.New("server create not possible - need action")
 
+var errServerCreateStopReconcile = errors.New("stopped Reconciling")
+
 // Service defines struct with machine scope to reconcile HCloudMachines.
 type Service struct {
 	scope *scope.MachineScope
@@ -258,6 +260,13 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			s.scope.Error(err, "")
 			return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
+
+		if errors.Is(err, errServerCreateStopReconcile) {
+			err = fmt.Errorf("createServerFromImageNameOrURL failed: %w", err)
+			s.scope.Error(err, "")
+			return reconcile.Result{}, nil
+		}
+
 		return reconcile.Result{}, fmt.Errorf("failed to create server: %w", err)
 	}
 
@@ -308,30 +317,6 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	}
 
 	updateHCloudMachineStatusFromServer(hm, server)
-
-	// This is a new machine with imageURL. Do some pre-flight checks.
-	imageURLCommandName := hm.Spec.ImageURLCommand
-	if imageURLCommandName == "" {
-		msg := "imageURL is set, but spec.imageURLCommand is empty"
-		s.scope.Error(nil, msg)
-		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
-			"ImageURLSetButNoCommandProvided", clusterv1beta1.ConditionSeverityWarning,
-			"%s", msg)
-		return reconcile.Result{}, nil
-	}
-
-	// The webhook already validates this, but we check again before any file access because we
-	// never want a HCloudMachine to make CAPH copy arbitrary controller files into the rescue
-	// system, for example service-account tokens. The webhook could also have been disabled
-	// temporarily, so this runtime check is still meaningful.
-	if _, err := utils.ResolveImageURLCommandPath(hcloudImageURLCommandDir, imageURLCommandName); err != nil {
-		err = fmt.Errorf("imageURLCommand %q is invalid or not accessible by the controller pod: %w", imageURLCommandName, err)
-		s.scope.Error(err, "")
-		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
-			"ImageURLCommandNotAccessible", clusterv1beta1.ConditionSeverityWarning,
-			"%s", err.Error())
-		return reconcile.Result{}, nil
-	}
 
 	// Fetch the SSH private key from the secret referenced in HetznerCluster.Spec.SSHKeys.RobotRescueSecretRef.
 	// Check that we have valid SSH private key in the secret. A failure could also mean there is a
@@ -1039,8 +1024,31 @@ func (s *Service) createServerFromImageNameOrURL(ctx context.Context) (*hcloud.S
 }
 
 func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server, *hcloud.Image, error) {
-	// Validate that ImageURLCommand is given
 	hm := s.scope.HCloudMachine
+
+	// This is a new machine with imageURL. Do some pre-flight checks.
+	imageURLCommandName := hm.Spec.ImageURLCommand
+	if imageURLCommandName == "" {
+		msg := "imageURL is set, but spec.imageURLCommand is empty"
+		s.scope.Error(nil, msg)
+		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
+			"ImageURLSetButNoCommandProvided", clusterv1beta1.ConditionSeverityWarning,
+			"%s", msg)
+		return nil, nil, errServerCreateStopReconcile
+	}
+
+	// The webhook already validates this, but we check again before any file access because we
+	// never want a HCloudMachine to make CAPH copy arbitrary controller files into the rescue
+	// system, for example service-account tokens. The webhook could also have been disabled
+	// temporarily, so this runtime check is still meaningful.
+	if _, err := utils.ResolveImageURLCommandPath(hcloudImageURLCommandDir, imageURLCommandName); err != nil {
+		err = fmt.Errorf("imageURLCommand %q is invalid or not accessible by the controller pod: %w", imageURLCommandName, err)
+		s.scope.Error(err, "")
+		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+			"ImageURLCommandNotAccessible", clusterv1beta1.ConditionSeverityWarning,
+			"%s", err.Error())
+		return nil, nil, errServerCreateStopReconcile
+	}
 
 	image, err := s.getServerImage(ctx, preRescueOSImage)
 	if err != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1044,7 +1044,7 @@ func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server,
 	if _, err := utils.ResolveImageURLCommandPath(hcloudImageURLCommandDir, imageURLCommandName); err != nil {
 		err = fmt.Errorf("imageURLCommand %q is invalid or not accessible by the controller pod: %w", imageURLCommandName, err)
 		s.scope.Error(err, "")
-		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
 			"ImageURLCommandNotAccessible", clusterv1beta1.ConditionSeverityWarning,
 			"%s", err.Error())
 		return nil, nil, errServerCreateStopReconcile

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1308,6 +1308,38 @@ var _ = Describe("Reconcile", func() {
 		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason)).To(BeTrue())
 		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.HetznerAPIReachableCondition, infrav1.RateLimitExceededReason)).To(BeTrue())
 	})
+
+	It("does not create a server when the image-url-command is not available on disk", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		By("setting imageURL and a command that does not exist in the command directory")
+		service.scope.HCloudMachine.Spec.ImageName = ""
+		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
+		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-nonexistent.sh"
+
+		By("calling reconcile — CreateServer must not be called")
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		By("ensuring the ImageURLCommandNotAccessible condition is set")
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerAvailableCondition, "ImageURLCommandNotAccessible")).To(BeTrue())
+
+		By("ensuring no hcloud API calls were made to create a server")
+		hcloudClient.AssertNotCalled(GinkgoT(), "CreateServer", mock.Anything, mock.Anything)
+	})
 })
 
 var _ = Describe("handleOperatingSystemRunning", func() {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1335,7 +1335,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 
 		By("ensuring the ImageURLCommandNotAccessible condition is set")
-		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerAvailableCondition, "ImageURLCommandNotAccessible")).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "ImageURLCommandNotAccessible")).To(BeTrue())
 
 		By("ensuring no hcloud API calls were made to create a server")
 		hcloudClient.AssertNotCalled(GinkgoT(), "CreateServer", mock.Anything, mock.Anything)


### PR DESCRIPTION
When image-url-command is missing, don't create server.

Otherwise:

> InfrastructureReady: failed to create HCloud server foo in LOCATION (type TYPE): server name is already used (uniqueness_error, ...)

