### PR TITLE
:seedling: Use Context in ssh client

### DIFF
--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -165,27 +165,27 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 
 		configureRescueSSHClient(rescueSSHClient)
 
-		osSSHClientAfterInstallImage.On("Reboot").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("CloudInitStatus").Return(sshclient.Output{StdOut: "status: done"})
-		osSSHClientAfterInstallImage.On("CheckCloudInitLogsForSigTerm").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("ResetKubeadm").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("GetHostName").Return(sshclient.Output{
+		osSSHClientAfterInstallImage.On("Reboot", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("CloudInitStatus", mock.Anything).Return(sshclient.Output{StdOut: "status: done"})
+		osSSHClientAfterInstallImage.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("ResetKubeadm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: infrav1.BareMetalHostNamePrefix + machineName,
 			StdErr: "",
 			Err:    nil,
 		})
-		osSSHClientAfterInstallImage.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+		osSSHClientAfterInstallImage.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 
-		osSSHClientAfterCloudInit.On("Reboot").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("GetHostName").Return(sshclient.Output{
+		osSSHClientAfterCloudInit.On("Reboot", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: infrav1.BareMetalHostNamePrefix + machineName,
 			StdErr: "",
 			Err:    nil,
 		})
-		osSSHClientAfterCloudInit.On("CloudInitStatus").Return(sshclient.Output{StdOut: "status: done"})
-		osSSHClientAfterCloudInit.On("CheckCloudInitLogsForSigTerm").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("ResetKubeadm").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+		osSSHClientAfterCloudInit.On("CloudInitStatus", mock.Anything).Return(sshclient.Output{StdOut: "status: done"})
+		osSSHClientAfterCloudInit.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("ResetKubeadm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 	})
 
 	AfterEach(func() {
@@ -925,75 +925,75 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 })
 
 func configureRescueSSHClient(sshClient *sshmock.Client) {
-	sshClient.On("GetHostName").Return(sshclient.Output{
+	sshClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 		StdOut: "rescue",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsRAM").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsRAM", mock.Anything).Return(sshclient.Output{
 		StdOut: "100000",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsStorage").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{
 		StdOut: `NAME="loop0" LABEL="" FSTYPE="ext2" TYPE="loop" HCTL="" MODEL="" VENDOR="" SERIAL="" SIZE="3068773888" WWN="" ROTA="0"
 NAME="nvme2n1" LABEL="" FSTYPE="" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVL22T0HBLB-00B00" VENDOR="" SERIAL="S677NF0R402742" SIZE="2048408248320" WWN="eui.002538b411b2cee8" ROTA="0"
 NAME="nvme1n1" LABEL="" FSTYPE="" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`,
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsNics").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsNics", mock.Anything).Return(sshclient.Output{
 		StdOut: `name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)" mac="a8:a1:59:94:19:42" ip="23.88.6.239/26" speedMbps="1000"
 name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)" mac="a8:a1:59:94:19:42" ip="2a01:4f8:272:3e0f::2/64" speedMbps="1000"`,
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUArch").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUArch", mock.Anything).Return(sshclient.Output{
 		StdOut: "myarch",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUModel").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUModel", mock.Anything).Return(sshclient.Output{
 		StdOut: "mymodel",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUClockGigahertz").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUClockGigahertz", mock.Anything).Return(sshclient.Output{
 		StdOut: "42654",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUFlags").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUFlags", mock.Anything).Return(sshclient.Output{
 		StdOut: "flag1 flag2 flag3",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUThreads").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUThreads", mock.Anything).Return(sshclient.Output{
 		StdOut: "123",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsCPUCores").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsCPUCores", mock.Anything).Return(sshclient.Output{
 		StdOut: "12",
 		StdErr: "",
 		Err:    nil,
 	})
-	sshClient.On("GetHardwareDetailsDebug").Return(sshclient.Output{
+	sshClient.On("GetHardwareDetailsDebug", mock.Anything).Return(sshclient.Output{
 		StdOut: "Dummy output",
 		StdErr: "",
 		Err:    nil,
 	})
 	sshClient.On("DownloadImage", mock.Anything, mock.Anything).Return(sshclient.Output{})
 	sshClient.On("CreateAutoSetup", mock.Anything).Return(sshclient.Output{})
-	sshClient.On("UntarTGZ").Return(sshclient.Output{})
+	sshClient.On("UntarTGZ", mock.Anything).Return(sshclient.Output{})
 	sshClient.On("CreatePostInstallScript", mock.Anything).Return(sshclient.Output{})
 	sshClient.On("ExecuteInstallImage", mock.Anything).Return(sshclient.Output{StdOut: hostpkg.PostInstallScriptFinished})
-	sshClient.On("Reboot").Return(sshclient.Output{})
-	sshClient.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+	sshClient.On("Reboot", mock.Anything).Return(sshclient.Output{})
+	sshClient.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 	sshClient.On("DetectLinuxOnAnotherDisk", mock.Anything).Return(sshclient.Output{})
 	sshClient.On("ExecutePreProvisionCommand", mock.Anything, mock.Anything).Return(0, "", nil)
-	sshClient.On("GetInstallImageState").Return(sshclient.InstallImageStateFinished, nil)
-	sshClient.On("GetResultOfInstallImage").Return(hostpkg.PostInstallScriptFinished, nil)
+	sshClient.On("GetInstallImageState", mock.Anything).Return(sshclient.InstallImageStateFinished, nil)
+	sshClient.On("GetResultOfInstallImage", mock.Anything).Return(hostpkg.PostInstallScriptFinished, nil)
 }
 
 func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -169,16 +169,16 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 
 		configureRescueSSHClient(rescueSSHClient)
 
-		osSSHClient.On("Reboot").Return(sshclient.Output{})
-		osSSHClient.On("CloudInitStatus").Return(sshclient.Output{StdOut: "status: done"})
-		osSSHClient.On("CheckCloudInitLogsForSigTerm").Return(sshclient.Output{})
-		osSSHClient.On("ResetKubeadm").Return(sshclient.Output{})
-		osSSHClient.On("GetHostName").Return(sshclient.Output{
+		osSSHClient.On("Reboot", mock.Anything).Return(sshclient.Output{})
+		osSSHClient.On("CloudInitStatus", mock.Anything).Return(sshclient.Output{StdOut: "status: done"})
+		osSSHClient.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(sshclient.Output{})
+		osSSHClient.On("ResetKubeadm", mock.Anything).Return(sshclient.Output{})
+		osSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: infrav1.BareMetalHostNamePrefix + machineName,
 			StdErr: "",
 			Err:    nil,
 		})
-		osSSHClient.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+		osSSHClient.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 	})
 
 	AfterEach(func() {
@@ -452,9 +452,9 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 					return isPresentAndTrue(key, bmMachine, infrav1.HostReadyCondition)
 				}, timeout).Should(BeTrue())
 
-				osSSHClient.On("GetHostName").Unset()
+				osSSHClient.On("GetHostName", mock.Anything).Unset()
 
-				osSSHClient.On("GetHostName").Return(sshclient.Output{
+				osSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 					StdOut: "some-unexpected-hostname",
 					StdErr: "",
 					Err:    nil,
@@ -1259,7 +1259,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 
 			// The mock should wait until we know which machine is picked.
 			w := make(chan time.Time)
-			osSSHClient.On("GetHostName").WaitUntil(w)
+			osSSHClient.On("GetHostName", mock.Anything).WaitUntil(w)
 
 			Eventually(func() bool {
 				if err := testEnv.Get(ctx, client.ObjectKeyFromObject(host), host); err != nil {
@@ -1281,7 +1281,7 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 					// We need to change the mock on-the-fly. There are two
 					// machines, and we need to adapt the mock to the one that is
 					// picked.
-					osSSHClient.On("GetHostName").Return(sshclient.Output{
+					osSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 						StdOut: infrav1.BareMetalHostNamePrefix + pickedMachine.Name,
 						StdErr: "",
 						Err:    nil,

--- a/controllers/hetznerbaremetalremediation_controller_test.go
+++ b/controllers/hetznerbaremetalremediation_controller_test.go
@@ -205,26 +205,26 @@ var _ = Describe("HetznerBareMetalRemediationReconciler", func() {
 
 		configureRescueSSHClient(rescueSSHClient)
 
-		osSSHClientAfterInstallImage.On("Reboot").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("CloudInitStatus").Return(sshclient.Output{StdOut: "status: done"})
-		osSSHClientAfterInstallImage.On("CheckCloudInitLogsForSigTerm").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("ResetKubeadm").Return(sshclient.Output{})
-		osSSHClientAfterInstallImage.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
-		osSSHClientAfterInstallImage.On("GetHostName").Return(sshclient.Output{
+		osSSHClientAfterInstallImage.On("Reboot", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("CloudInitStatus", mock.Anything).Return(sshclient.Output{StdOut: "status: done"})
+		osSSHClientAfterInstallImage.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("ResetKubeadm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterInstallImage.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+		osSSHClientAfterInstallImage.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: infrav1.BareMetalHostNamePrefix + machineName,
 			StdErr: "",
 			Err:    nil,
 		})
-		osSSHClientAfterCloudInit.On("Reboot").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("GetHostName").Return(sshclient.Output{
+		osSSHClientAfterCloudInit.On("Reboot", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: infrav1.BareMetalHostNamePrefix + machineName,
 			StdErr: "",
 			Err:    nil,
 		})
-		osSSHClientAfterCloudInit.On("CloudInitStatus").Return(sshclient.Output{StdOut: "status: done"})
-		osSSHClientAfterCloudInit.On("CheckCloudInitLogsForSigTerm").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("ResetKubeadm").Return(sshclient.Output{})
-		osSSHClientAfterCloudInit.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+		osSSHClientAfterCloudInit.On("CloudInitStatus", mock.Anything).Return(sshclient.Output{StdOut: "status: done"})
+		osSSHClientAfterCloudInit.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("ResetKubeadm", mock.Anything).Return(sshclient.Output{})
+		osSSHClientAfterCloudInit.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 	})
 
 	AfterEach(func() {

--- a/pkg/services/baremetal/client/mocks/ssh/Client.go
+++ b/pkg/services/baremetal/client/mocks/ssh/Client.go
@@ -22,17 +22,17 @@ func (_m *Client) EXPECT() *Client_Expecter {
 	return &Client_Expecter{mock: &_m.Mock}
 }
 
-// CheckCloudInitLogsForSigTerm provides a mock function with no fields
-func (_m *Client) CheckCloudInitLogsForSigTerm() sshclient.Output {
-	ret := _m.Called()
+// CheckCloudInitLogsForSigTerm provides a mock function with given fields: ctx
+func (_m *Client) CheckCloudInitLogsForSigTerm(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckCloudInitLogsForSigTerm")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -46,13 +46,14 @@ type Client_CheckCloudInitLogsForSigTerm_Call struct {
 }
 
 // CheckCloudInitLogsForSigTerm is a helper method to define mock.On call
-func (_e *Client_Expecter) CheckCloudInitLogsForSigTerm() *Client_CheckCloudInitLogsForSigTerm_Call {
-	return &Client_CheckCloudInitLogsForSigTerm_Call{Call: _e.mock.On("CheckCloudInitLogsForSigTerm")}
+//   - ctx context.Context
+func (_e *Client_Expecter) CheckCloudInitLogsForSigTerm(ctx interface{}) *Client_CheckCloudInitLogsForSigTerm_Call {
+	return &Client_CheckCloudInitLogsForSigTerm_Call{Call: _e.mock.On("CheckCloudInitLogsForSigTerm", ctx)}
 }
 
-func (_c *Client_CheckCloudInitLogsForSigTerm_Call) Run(run func()) *Client_CheckCloudInitLogsForSigTerm_Call {
+func (_c *Client_CheckCloudInitLogsForSigTerm_Call) Run(run func(ctx context.Context)) *Client_CheckCloudInitLogsForSigTerm_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -62,7 +63,7 @@ func (_c *Client_CheckCloudInitLogsForSigTerm_Call) Return(_a0 sshclient.Output)
 	return _c
 }
 
-func (_c *Client_CheckCloudInitLogsForSigTerm_Call) RunAndReturn(run func() sshclient.Output) *Client_CheckCloudInitLogsForSigTerm_Call {
+func (_c *Client_CheckCloudInitLogsForSigTerm_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_CheckCloudInitLogsForSigTerm_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -124,17 +125,17 @@ func (_c *Client_CheckDisk_Call) RunAndReturn(run func(context.Context, []string
 	return _c
 }
 
-// CleanCloudInitInstances provides a mock function with no fields
-func (_m *Client) CleanCloudInitInstances() sshclient.Output {
-	ret := _m.Called()
+// CleanCloudInitInstances provides a mock function with given fields: ctx
+func (_m *Client) CleanCloudInitInstances(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CleanCloudInitInstances")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -148,13 +149,14 @@ type Client_CleanCloudInitInstances_Call struct {
 }
 
 // CleanCloudInitInstances is a helper method to define mock.On call
-func (_e *Client_Expecter) CleanCloudInitInstances() *Client_CleanCloudInitInstances_Call {
-	return &Client_CleanCloudInitInstances_Call{Call: _e.mock.On("CleanCloudInitInstances")}
+//   - ctx context.Context
+func (_e *Client_Expecter) CleanCloudInitInstances(ctx interface{}) *Client_CleanCloudInitInstances_Call {
+	return &Client_CleanCloudInitInstances_Call{Call: _e.mock.On("CleanCloudInitInstances", ctx)}
 }
 
-func (_c *Client_CleanCloudInitInstances_Call) Run(run func()) *Client_CleanCloudInitInstances_Call {
+func (_c *Client_CleanCloudInitInstances_Call) Run(run func(ctx context.Context)) *Client_CleanCloudInitInstances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -164,22 +166,22 @@ func (_c *Client_CleanCloudInitInstances_Call) Return(_a0 sshclient.Output) *Cli
 	return _c
 }
 
-func (_c *Client_CleanCloudInitInstances_Call) RunAndReturn(run func() sshclient.Output) *Client_CleanCloudInitInstances_Call {
+func (_c *Client_CleanCloudInitInstances_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_CleanCloudInitInstances_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CleanCloudInitLogs provides a mock function with no fields
-func (_m *Client) CleanCloudInitLogs() sshclient.Output {
-	ret := _m.Called()
+// CleanCloudInitLogs provides a mock function with given fields: ctx
+func (_m *Client) CleanCloudInitLogs(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CleanCloudInitLogs")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -193,13 +195,14 @@ type Client_CleanCloudInitLogs_Call struct {
 }
 
 // CleanCloudInitLogs is a helper method to define mock.On call
-func (_e *Client_Expecter) CleanCloudInitLogs() *Client_CleanCloudInitLogs_Call {
-	return &Client_CleanCloudInitLogs_Call{Call: _e.mock.On("CleanCloudInitLogs")}
+//   - ctx context.Context
+func (_e *Client_Expecter) CleanCloudInitLogs(ctx interface{}) *Client_CleanCloudInitLogs_Call {
+	return &Client_CleanCloudInitLogs_Call{Call: _e.mock.On("CleanCloudInitLogs", ctx)}
 }
 
-func (_c *Client_CleanCloudInitLogs_Call) Run(run func()) *Client_CleanCloudInitLogs_Call {
+func (_c *Client_CleanCloudInitLogs_Call) Run(run func(ctx context.Context)) *Client_CleanCloudInitLogs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -209,22 +212,22 @@ func (_c *Client_CleanCloudInitLogs_Call) Return(_a0 sshclient.Output) *Client_C
 	return _c
 }
 
-func (_c *Client_CleanCloudInitLogs_Call) RunAndReturn(run func() sshclient.Output) *Client_CleanCloudInitLogs_Call {
+func (_c *Client_CleanCloudInitLogs_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_CleanCloudInitLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CloudInitStatus provides a mock function with no fields
-func (_m *Client) CloudInitStatus() sshclient.Output {
-	ret := _m.Called()
+// CloudInitStatus provides a mock function with given fields: ctx
+func (_m *Client) CloudInitStatus(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CloudInitStatus")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -238,13 +241,14 @@ type Client_CloudInitStatus_Call struct {
 }
 
 // CloudInitStatus is a helper method to define mock.On call
-func (_e *Client_Expecter) CloudInitStatus() *Client_CloudInitStatus_Call {
-	return &Client_CloudInitStatus_Call{Call: _e.mock.On("CloudInitStatus")}
+//   - ctx context.Context
+func (_e *Client_Expecter) CloudInitStatus(ctx interface{}) *Client_CloudInitStatus_Call {
+	return &Client_CloudInitStatus_Call{Call: _e.mock.On("CloudInitStatus", ctx)}
 }
 
-func (_c *Client_CloudInitStatus_Call) Run(run func()) *Client_CloudInitStatus_Call {
+func (_c *Client_CloudInitStatus_Call) Run(run func(ctx context.Context)) *Client_CloudInitStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -254,22 +258,22 @@ func (_c *Client_CloudInitStatus_Call) Return(_a0 sshclient.Output) *Client_Clou
 	return _c
 }
 
-func (_c *Client_CloudInitStatus_Call) RunAndReturn(run func() sshclient.Output) *Client_CloudInitStatus_Call {
+func (_c *Client_CloudInitStatus_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_CloudInitStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreateAutoSetup provides a mock function with given fields: data
-func (_m *Client) CreateAutoSetup(data string) sshclient.Output {
-	ret := _m.Called(data)
+// CreateAutoSetup provides a mock function with given fields: ctx, data
+func (_m *Client) CreateAutoSetup(ctx context.Context, data string) sshclient.Output {
+	ret := _m.Called(ctx, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateAutoSetup")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func(string) sshclient.Output); ok {
-		r0 = rf(data)
+	if rf, ok := ret.Get(0).(func(context.Context, string) sshclient.Output); ok {
+		r0 = rf(ctx, data)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -283,14 +287,15 @@ type Client_CreateAutoSetup_Call struct {
 }
 
 // CreateAutoSetup is a helper method to define mock.On call
+//   - ctx context.Context
 //   - data string
-func (_e *Client_Expecter) CreateAutoSetup(data interface{}) *Client_CreateAutoSetup_Call {
-	return &Client_CreateAutoSetup_Call{Call: _e.mock.On("CreateAutoSetup", data)}
+func (_e *Client_Expecter) CreateAutoSetup(ctx interface{}, data interface{}) *Client_CreateAutoSetup_Call {
+	return &Client_CreateAutoSetup_Call{Call: _e.mock.On("CreateAutoSetup", ctx, data)}
 }
 
-func (_c *Client_CreateAutoSetup_Call) Run(run func(data string)) *Client_CreateAutoSetup_Call {
+func (_c *Client_CreateAutoSetup_Call) Run(run func(ctx context.Context, data string)) *Client_CreateAutoSetup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -300,22 +305,22 @@ func (_c *Client_CreateAutoSetup_Call) Return(_a0 sshclient.Output) *Client_Crea
 	return _c
 }
 
-func (_c *Client_CreateAutoSetup_Call) RunAndReturn(run func(string) sshclient.Output) *Client_CreateAutoSetup_Call {
+func (_c *Client_CreateAutoSetup_Call) RunAndReturn(run func(context.Context, string) sshclient.Output) *Client_CreateAutoSetup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreatePostInstallScript provides a mock function with given fields: data
-func (_m *Client) CreatePostInstallScript(data string) sshclient.Output {
-	ret := _m.Called(data)
+// CreatePostInstallScript provides a mock function with given fields: ctx, data
+func (_m *Client) CreatePostInstallScript(ctx context.Context, data string) sshclient.Output {
+	ret := _m.Called(ctx, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreatePostInstallScript")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func(string) sshclient.Output); ok {
-		r0 = rf(data)
+	if rf, ok := ret.Get(0).(func(context.Context, string) sshclient.Output); ok {
+		r0 = rf(ctx, data)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -329,14 +334,15 @@ type Client_CreatePostInstallScript_Call struct {
 }
 
 // CreatePostInstallScript is a helper method to define mock.On call
+//   - ctx context.Context
 //   - data string
-func (_e *Client_Expecter) CreatePostInstallScript(data interface{}) *Client_CreatePostInstallScript_Call {
-	return &Client_CreatePostInstallScript_Call{Call: _e.mock.On("CreatePostInstallScript", data)}
+func (_e *Client_Expecter) CreatePostInstallScript(ctx interface{}, data interface{}) *Client_CreatePostInstallScript_Call {
+	return &Client_CreatePostInstallScript_Call{Call: _e.mock.On("CreatePostInstallScript", ctx, data)}
 }
 
-func (_c *Client_CreatePostInstallScript_Call) Run(run func(data string)) *Client_CreatePostInstallScript_Call {
+func (_c *Client_CreatePostInstallScript_Call) Run(run func(ctx context.Context, data string)) *Client_CreatePostInstallScript_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -346,22 +352,22 @@ func (_c *Client_CreatePostInstallScript_Call) Return(_a0 sshclient.Output) *Cli
 	return _c
 }
 
-func (_c *Client_CreatePostInstallScript_Call) RunAndReturn(run func(string) sshclient.Output) *Client_CreatePostInstallScript_Call {
+func (_c *Client_CreatePostInstallScript_Call) RunAndReturn(run func(context.Context, string) sshclient.Output) *Client_CreatePostInstallScript_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DetectLinuxOnAnotherDisk provides a mock function with given fields: sliceOfWwns
-func (_m *Client) DetectLinuxOnAnotherDisk(sliceOfWwns []string) sshclient.Output {
-	ret := _m.Called(sliceOfWwns)
+// DetectLinuxOnAnotherDisk provides a mock function with given fields: ctx, sliceOfWwns
+func (_m *Client) DetectLinuxOnAnotherDisk(ctx context.Context, sliceOfWwns []string) sshclient.Output {
+	ret := _m.Called(ctx, sliceOfWwns)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DetectLinuxOnAnotherDisk")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func([]string) sshclient.Output); ok {
-		r0 = rf(sliceOfWwns)
+	if rf, ok := ret.Get(0).(func(context.Context, []string) sshclient.Output); ok {
+		r0 = rf(ctx, sliceOfWwns)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -375,14 +381,15 @@ type Client_DetectLinuxOnAnotherDisk_Call struct {
 }
 
 // DetectLinuxOnAnotherDisk is a helper method to define mock.On call
+//   - ctx context.Context
 //   - sliceOfWwns []string
-func (_e *Client_Expecter) DetectLinuxOnAnotherDisk(sliceOfWwns interface{}) *Client_DetectLinuxOnAnotherDisk_Call {
-	return &Client_DetectLinuxOnAnotherDisk_Call{Call: _e.mock.On("DetectLinuxOnAnotherDisk", sliceOfWwns)}
+func (_e *Client_Expecter) DetectLinuxOnAnotherDisk(ctx interface{}, sliceOfWwns interface{}) *Client_DetectLinuxOnAnotherDisk_Call {
+	return &Client_DetectLinuxOnAnotherDisk_Call{Call: _e.mock.On("DetectLinuxOnAnotherDisk", ctx, sliceOfWwns)}
 }
 
-func (_c *Client_DetectLinuxOnAnotherDisk_Call) Run(run func(sliceOfWwns []string)) *Client_DetectLinuxOnAnotherDisk_Call {
+func (_c *Client_DetectLinuxOnAnotherDisk_Call) Run(run func(ctx context.Context, sliceOfWwns []string)) *Client_DetectLinuxOnAnotherDisk_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]string))
+		run(args[0].(context.Context), args[1].([]string))
 	})
 	return _c
 }
@@ -392,22 +399,22 @@ func (_c *Client_DetectLinuxOnAnotherDisk_Call) Return(_a0 sshclient.Output) *Cl
 	return _c
 }
 
-func (_c *Client_DetectLinuxOnAnotherDisk_Call) RunAndReturn(run func([]string) sshclient.Output) *Client_DetectLinuxOnAnotherDisk_Call {
+func (_c *Client_DetectLinuxOnAnotherDisk_Call) RunAndReturn(run func(context.Context, []string) sshclient.Output) *Client_DetectLinuxOnAnotherDisk_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DownloadImage provides a mock function with given fields: path, url
-func (_m *Client) DownloadImage(path string, url string) sshclient.Output {
-	ret := _m.Called(path, url)
+// DownloadImage provides a mock function with given fields: ctx, path, url
+func (_m *Client) DownloadImage(ctx context.Context, path string, url string) sshclient.Output {
+	ret := _m.Called(ctx, path, url)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DownloadImage")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func(string, string) sshclient.Output); ok {
-		r0 = rf(path, url)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) sshclient.Output); ok {
+		r0 = rf(ctx, path, url)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -421,15 +428,16 @@ type Client_DownloadImage_Call struct {
 }
 
 // DownloadImage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - path string
 //   - url string
-func (_e *Client_Expecter) DownloadImage(path interface{}, url interface{}) *Client_DownloadImage_Call {
-	return &Client_DownloadImage_Call{Call: _e.mock.On("DownloadImage", path, url)}
+func (_e *Client_Expecter) DownloadImage(ctx interface{}, path interface{}, url interface{}) *Client_DownloadImage_Call {
+	return &Client_DownloadImage_Call{Call: _e.mock.On("DownloadImage", ctx, path, url)}
 }
 
-func (_c *Client_DownloadImage_Call) Run(run func(path string, url string)) *Client_DownloadImage_Call {
+func (_c *Client_DownloadImage_Call) Run(run func(ctx context.Context, path string, url string)) *Client_DownloadImage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -439,22 +447,22 @@ func (_c *Client_DownloadImage_Call) Return(_a0 sshclient.Output) *Client_Downlo
 	return _c
 }
 
-func (_c *Client_DownloadImage_Call) RunAndReturn(run func(string, string) sshclient.Output) *Client_DownloadImage_Call {
+func (_c *Client_DownloadImage_Call) RunAndReturn(run func(context.Context, string, string) sshclient.Output) *Client_DownloadImage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ExecuteInstallImage provides a mock function with given fields: hasPostInstallScript
-func (_m *Client) ExecuteInstallImage(hasPostInstallScript bool) sshclient.Output {
-	ret := _m.Called(hasPostInstallScript)
+// ExecuteInstallImage provides a mock function with given fields: ctx, hasPostInstallScript
+func (_m *Client) ExecuteInstallImage(ctx context.Context, hasPostInstallScript bool) sshclient.Output {
+	ret := _m.Called(ctx, hasPostInstallScript)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ExecuteInstallImage")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func(bool) sshclient.Output); ok {
-		r0 = rf(hasPostInstallScript)
+	if rf, ok := ret.Get(0).(func(context.Context, bool) sshclient.Output); ok {
+		r0 = rf(ctx, hasPostInstallScript)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -468,14 +476,15 @@ type Client_ExecuteInstallImage_Call struct {
 }
 
 // ExecuteInstallImage is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hasPostInstallScript bool
-func (_e *Client_Expecter) ExecuteInstallImage(hasPostInstallScript interface{}) *Client_ExecuteInstallImage_Call {
-	return &Client_ExecuteInstallImage_Call{Call: _e.mock.On("ExecuteInstallImage", hasPostInstallScript)}
+func (_e *Client_Expecter) ExecuteInstallImage(ctx interface{}, hasPostInstallScript interface{}) *Client_ExecuteInstallImage_Call {
+	return &Client_ExecuteInstallImage_Call{Call: _e.mock.On("ExecuteInstallImage", ctx, hasPostInstallScript)}
 }
 
-func (_c *Client_ExecuteInstallImage_Call) Run(run func(hasPostInstallScript bool)) *Client_ExecuteInstallImage_Call {
+func (_c *Client_ExecuteInstallImage_Call) Run(run func(ctx context.Context, hasPostInstallScript bool)) *Client_ExecuteInstallImage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(bool))
+		run(args[0].(context.Context), args[1].(bool))
 	})
 	return _c
 }
@@ -485,7 +494,7 @@ func (_c *Client_ExecuteInstallImage_Call) Return(_a0 sshclient.Output) *Client_
 	return _c
 }
 
-func (_c *Client_ExecuteInstallImage_Call) RunAndReturn(run func(bool) sshclient.Output) *Client_ExecuteInstallImage_Call {
+func (_c *Client_ExecuteInstallImage_Call) RunAndReturn(run func(context.Context, bool) sshclient.Output) *Client_ExecuteInstallImage_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -554,17 +563,17 @@ func (_c *Client_ExecutePreProvisionCommand_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// GetCloudInitOutput provides a mock function with no fields
-func (_m *Client) GetCloudInitOutput() sshclient.Output {
-	ret := _m.Called()
+// GetCloudInitOutput provides a mock function with given fields: ctx
+func (_m *Client) GetCloudInitOutput(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCloudInitOutput")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -578,13 +587,14 @@ type Client_GetCloudInitOutput_Call struct {
 }
 
 // GetCloudInitOutput is a helper method to define mock.On call
-func (_e *Client_Expecter) GetCloudInitOutput() *Client_GetCloudInitOutput_Call {
-	return &Client_GetCloudInitOutput_Call{Call: _e.mock.On("GetCloudInitOutput")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetCloudInitOutput(ctx interface{}) *Client_GetCloudInitOutput_Call {
+	return &Client_GetCloudInitOutput_Call{Call: _e.mock.On("GetCloudInitOutput", ctx)}
 }
 
-func (_c *Client_GetCloudInitOutput_Call) Run(run func()) *Client_GetCloudInitOutput_Call {
+func (_c *Client_GetCloudInitOutput_Call) Run(run func(ctx context.Context)) *Client_GetCloudInitOutput_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -594,22 +604,22 @@ func (_c *Client_GetCloudInitOutput_Call) Return(_a0 sshclient.Output) *Client_G
 	return _c
 }
 
-func (_c *Client_GetCloudInitOutput_Call) RunAndReturn(run func() sshclient.Output) *Client_GetCloudInitOutput_Call {
+func (_c *Client_GetCloudInitOutput_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetCloudInitOutput_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUArch provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUArch() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUArch provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUArch(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUArch")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -623,13 +633,14 @@ type Client_GetHardwareDetailsCPUArch_Call struct {
 }
 
 // GetHardwareDetailsCPUArch is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUArch() *Client_GetHardwareDetailsCPUArch_Call {
-	return &Client_GetHardwareDetailsCPUArch_Call{Call: _e.mock.On("GetHardwareDetailsCPUArch")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUArch(ctx interface{}) *Client_GetHardwareDetailsCPUArch_Call {
+	return &Client_GetHardwareDetailsCPUArch_Call{Call: _e.mock.On("GetHardwareDetailsCPUArch", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUArch_Call) Run(run func()) *Client_GetHardwareDetailsCPUArch_Call {
+func (_c *Client_GetHardwareDetailsCPUArch_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUArch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -639,22 +650,22 @@ func (_c *Client_GetHardwareDetailsCPUArch_Call) Return(_a0 sshclient.Output) *C
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUArch_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUArch_Call {
+func (_c *Client_GetHardwareDetailsCPUArch_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUArch_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUClockGigahertz provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUClockGigahertz() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUClockGigahertz provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUClockGigahertz(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUClockGigahertz")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -668,13 +679,14 @@ type Client_GetHardwareDetailsCPUClockGigahertz_Call struct {
 }
 
 // GetHardwareDetailsCPUClockGigahertz is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUClockGigahertz() *Client_GetHardwareDetailsCPUClockGigahertz_Call {
-	return &Client_GetHardwareDetailsCPUClockGigahertz_Call{Call: _e.mock.On("GetHardwareDetailsCPUClockGigahertz")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUClockGigahertz(ctx interface{}) *Client_GetHardwareDetailsCPUClockGigahertz_Call {
+	return &Client_GetHardwareDetailsCPUClockGigahertz_Call{Call: _e.mock.On("GetHardwareDetailsCPUClockGigahertz", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUClockGigahertz_Call) Run(run func()) *Client_GetHardwareDetailsCPUClockGigahertz_Call {
+func (_c *Client_GetHardwareDetailsCPUClockGigahertz_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUClockGigahertz_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -684,22 +696,22 @@ func (_c *Client_GetHardwareDetailsCPUClockGigahertz_Call) Return(_a0 sshclient.
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUClockGigahertz_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUClockGigahertz_Call {
+func (_c *Client_GetHardwareDetailsCPUClockGigahertz_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUClockGigahertz_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUCores provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUCores() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUCores provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUCores(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUCores")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -713,13 +725,14 @@ type Client_GetHardwareDetailsCPUCores_Call struct {
 }
 
 // GetHardwareDetailsCPUCores is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUCores() *Client_GetHardwareDetailsCPUCores_Call {
-	return &Client_GetHardwareDetailsCPUCores_Call{Call: _e.mock.On("GetHardwareDetailsCPUCores")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUCores(ctx interface{}) *Client_GetHardwareDetailsCPUCores_Call {
+	return &Client_GetHardwareDetailsCPUCores_Call{Call: _e.mock.On("GetHardwareDetailsCPUCores", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUCores_Call) Run(run func()) *Client_GetHardwareDetailsCPUCores_Call {
+func (_c *Client_GetHardwareDetailsCPUCores_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUCores_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -729,22 +742,22 @@ func (_c *Client_GetHardwareDetailsCPUCores_Call) Return(_a0 sshclient.Output) *
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUCores_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUCores_Call {
+func (_c *Client_GetHardwareDetailsCPUCores_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUCores_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUFlags provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUFlags() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUFlags provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUFlags(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUFlags")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -758,13 +771,14 @@ type Client_GetHardwareDetailsCPUFlags_Call struct {
 }
 
 // GetHardwareDetailsCPUFlags is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUFlags() *Client_GetHardwareDetailsCPUFlags_Call {
-	return &Client_GetHardwareDetailsCPUFlags_Call{Call: _e.mock.On("GetHardwareDetailsCPUFlags")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUFlags(ctx interface{}) *Client_GetHardwareDetailsCPUFlags_Call {
+	return &Client_GetHardwareDetailsCPUFlags_Call{Call: _e.mock.On("GetHardwareDetailsCPUFlags", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUFlags_Call) Run(run func()) *Client_GetHardwareDetailsCPUFlags_Call {
+func (_c *Client_GetHardwareDetailsCPUFlags_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUFlags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -774,22 +788,22 @@ func (_c *Client_GetHardwareDetailsCPUFlags_Call) Return(_a0 sshclient.Output) *
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUFlags_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUFlags_Call {
+func (_c *Client_GetHardwareDetailsCPUFlags_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUFlags_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUModel provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUModel() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUModel provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUModel(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUModel")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -803,13 +817,14 @@ type Client_GetHardwareDetailsCPUModel_Call struct {
 }
 
 // GetHardwareDetailsCPUModel is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUModel() *Client_GetHardwareDetailsCPUModel_Call {
-	return &Client_GetHardwareDetailsCPUModel_Call{Call: _e.mock.On("GetHardwareDetailsCPUModel")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUModel(ctx interface{}) *Client_GetHardwareDetailsCPUModel_Call {
+	return &Client_GetHardwareDetailsCPUModel_Call{Call: _e.mock.On("GetHardwareDetailsCPUModel", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUModel_Call) Run(run func()) *Client_GetHardwareDetailsCPUModel_Call {
+func (_c *Client_GetHardwareDetailsCPUModel_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUModel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -819,22 +834,22 @@ func (_c *Client_GetHardwareDetailsCPUModel_Call) Return(_a0 sshclient.Output) *
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUModel_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUModel_Call {
+func (_c *Client_GetHardwareDetailsCPUModel_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUModel_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsCPUThreads provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsCPUThreads() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsCPUThreads provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsCPUThreads(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsCPUThreads")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -848,13 +863,14 @@ type Client_GetHardwareDetailsCPUThreads_Call struct {
 }
 
 // GetHardwareDetailsCPUThreads is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsCPUThreads() *Client_GetHardwareDetailsCPUThreads_Call {
-	return &Client_GetHardwareDetailsCPUThreads_Call{Call: _e.mock.On("GetHardwareDetailsCPUThreads")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsCPUThreads(ctx interface{}) *Client_GetHardwareDetailsCPUThreads_Call {
+	return &Client_GetHardwareDetailsCPUThreads_Call{Call: _e.mock.On("GetHardwareDetailsCPUThreads", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsCPUThreads_Call) Run(run func()) *Client_GetHardwareDetailsCPUThreads_Call {
+func (_c *Client_GetHardwareDetailsCPUThreads_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsCPUThreads_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -864,22 +880,22 @@ func (_c *Client_GetHardwareDetailsCPUThreads_Call) Return(_a0 sshclient.Output)
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsCPUThreads_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsCPUThreads_Call {
+func (_c *Client_GetHardwareDetailsCPUThreads_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsCPUThreads_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsDebug provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsDebug() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsDebug provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsDebug(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsDebug")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -893,13 +909,14 @@ type Client_GetHardwareDetailsDebug_Call struct {
 }
 
 // GetHardwareDetailsDebug is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsDebug() *Client_GetHardwareDetailsDebug_Call {
-	return &Client_GetHardwareDetailsDebug_Call{Call: _e.mock.On("GetHardwareDetailsDebug")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsDebug(ctx interface{}) *Client_GetHardwareDetailsDebug_Call {
+	return &Client_GetHardwareDetailsDebug_Call{Call: _e.mock.On("GetHardwareDetailsDebug", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsDebug_Call) Run(run func()) *Client_GetHardwareDetailsDebug_Call {
+func (_c *Client_GetHardwareDetailsDebug_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsDebug_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -909,22 +926,22 @@ func (_c *Client_GetHardwareDetailsDebug_Call) Return(_a0 sshclient.Output) *Cli
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsDebug_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsDebug_Call {
+func (_c *Client_GetHardwareDetailsDebug_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsDebug_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsNics provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsNics() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsNics provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsNics(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsNics")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -938,13 +955,14 @@ type Client_GetHardwareDetailsNics_Call struct {
 }
 
 // GetHardwareDetailsNics is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsNics() *Client_GetHardwareDetailsNics_Call {
-	return &Client_GetHardwareDetailsNics_Call{Call: _e.mock.On("GetHardwareDetailsNics")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsNics(ctx interface{}) *Client_GetHardwareDetailsNics_Call {
+	return &Client_GetHardwareDetailsNics_Call{Call: _e.mock.On("GetHardwareDetailsNics", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsNics_Call) Run(run func()) *Client_GetHardwareDetailsNics_Call {
+func (_c *Client_GetHardwareDetailsNics_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsNics_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -954,22 +972,22 @@ func (_c *Client_GetHardwareDetailsNics_Call) Return(_a0 sshclient.Output) *Clie
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsNics_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsNics_Call {
+func (_c *Client_GetHardwareDetailsNics_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsNics_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsRAM provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsRAM() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsRAM provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsRAM(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsRAM")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -983,13 +1001,14 @@ type Client_GetHardwareDetailsRAM_Call struct {
 }
 
 // GetHardwareDetailsRAM is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsRAM() *Client_GetHardwareDetailsRAM_Call {
-	return &Client_GetHardwareDetailsRAM_Call{Call: _e.mock.On("GetHardwareDetailsRAM")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsRAM(ctx interface{}) *Client_GetHardwareDetailsRAM_Call {
+	return &Client_GetHardwareDetailsRAM_Call{Call: _e.mock.On("GetHardwareDetailsRAM", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsRAM_Call) Run(run func()) *Client_GetHardwareDetailsRAM_Call {
+func (_c *Client_GetHardwareDetailsRAM_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsRAM_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -999,22 +1018,22 @@ func (_c *Client_GetHardwareDetailsRAM_Call) Return(_a0 sshclient.Output) *Clien
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsRAM_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsRAM_Call {
+func (_c *Client_GetHardwareDetailsRAM_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsRAM_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHardwareDetailsStorage provides a mock function with no fields
-func (_m *Client) GetHardwareDetailsStorage() sshclient.Output {
-	ret := _m.Called()
+// GetHardwareDetailsStorage provides a mock function with given fields: ctx
+func (_m *Client) GetHardwareDetailsStorage(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHardwareDetailsStorage")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -1028,13 +1047,14 @@ type Client_GetHardwareDetailsStorage_Call struct {
 }
 
 // GetHardwareDetailsStorage is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHardwareDetailsStorage() *Client_GetHardwareDetailsStorage_Call {
-	return &Client_GetHardwareDetailsStorage_Call{Call: _e.mock.On("GetHardwareDetailsStorage")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHardwareDetailsStorage(ctx interface{}) *Client_GetHardwareDetailsStorage_Call {
+	return &Client_GetHardwareDetailsStorage_Call{Call: _e.mock.On("GetHardwareDetailsStorage", ctx)}
 }
 
-func (_c *Client_GetHardwareDetailsStorage_Call) Run(run func()) *Client_GetHardwareDetailsStorage_Call {
+func (_c *Client_GetHardwareDetailsStorage_Call) Run(run func(ctx context.Context)) *Client_GetHardwareDetailsStorage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1044,22 +1064,22 @@ func (_c *Client_GetHardwareDetailsStorage_Call) Return(_a0 sshclient.Output) *C
 	return _c
 }
 
-func (_c *Client_GetHardwareDetailsStorage_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHardwareDetailsStorage_Call {
+func (_c *Client_GetHardwareDetailsStorage_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHardwareDetailsStorage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetHostName provides a mock function with no fields
-func (_m *Client) GetHostName() sshclient.Output {
-	ret := _m.Called()
+// GetHostName provides a mock function with given fields: ctx
+func (_m *Client) GetHostName(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetHostName")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -1073,13 +1093,14 @@ type Client_GetHostName_Call struct {
 }
 
 // GetHostName is a helper method to define mock.On call
-func (_e *Client_Expecter) GetHostName() *Client_GetHostName_Call {
-	return &Client_GetHostName_Call{Call: _e.mock.On("GetHostName")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetHostName(ctx interface{}) *Client_GetHostName_Call {
+	return &Client_GetHostName_Call{Call: _e.mock.On("GetHostName", ctx)}
 }
 
-func (_c *Client_GetHostName_Call) Run(run func()) *Client_GetHostName_Call {
+func (_c *Client_GetHostName_Call) Run(run func(ctx context.Context)) *Client_GetHostName_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1089,14 +1110,14 @@ func (_c *Client_GetHostName_Call) Return(_a0 sshclient.Output) *Client_GetHostN
 	return _c
 }
 
-func (_c *Client_GetHostName_Call) RunAndReturn(run func() sshclient.Output) *Client_GetHostName_Call {
+func (_c *Client_GetHostName_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_GetHostName_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetInstallImageState provides a mock function with no fields
-func (_m *Client) GetInstallImageState() (sshclient.InstallImageState, error) {
-	ret := _m.Called()
+// GetInstallImageState provides a mock function with given fields: ctx
+func (_m *Client) GetInstallImageState(ctx context.Context) (sshclient.InstallImageState, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInstallImageState")
@@ -1104,17 +1125,17 @@ func (_m *Client) GetInstallImageState() (sshclient.InstallImageState, error) {
 
 	var r0 sshclient.InstallImageState
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (sshclient.InstallImageState, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (sshclient.InstallImageState, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() sshclient.InstallImageState); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.InstallImageState); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.InstallImageState)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1128,13 +1149,14 @@ type Client_GetInstallImageState_Call struct {
 }
 
 // GetInstallImageState is a helper method to define mock.On call
-func (_e *Client_Expecter) GetInstallImageState() *Client_GetInstallImageState_Call {
-	return &Client_GetInstallImageState_Call{Call: _e.mock.On("GetInstallImageState")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetInstallImageState(ctx interface{}) *Client_GetInstallImageState_Call {
+	return &Client_GetInstallImageState_Call{Call: _e.mock.On("GetInstallImageState", ctx)}
 }
 
-func (_c *Client_GetInstallImageState_Call) Run(run func()) *Client_GetInstallImageState_Call {
+func (_c *Client_GetInstallImageState_Call) Run(run func(ctx context.Context)) *Client_GetInstallImageState_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1144,14 +1166,14 @@ func (_c *Client_GetInstallImageState_Call) Return(_a0 sshclient.InstallImageSta
 	return _c
 }
 
-func (_c *Client_GetInstallImageState_Call) RunAndReturn(run func() (sshclient.InstallImageState, error)) *Client_GetInstallImageState_Call {
+func (_c *Client_GetInstallImageState_Call) RunAndReturn(run func(context.Context) (sshclient.InstallImageState, error)) *Client_GetInstallImageState_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetResultOfInstallImage provides a mock function with no fields
-func (_m *Client) GetResultOfInstallImage() (string, error) {
-	ret := _m.Called()
+// GetResultOfInstallImage provides a mock function with given fields: ctx
+func (_m *Client) GetResultOfInstallImage(ctx context.Context) (string, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetResultOfInstallImage")
@@ -1159,17 +1181,17 @@ func (_m *Client) GetResultOfInstallImage() (string, error) {
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1183,13 +1205,14 @@ type Client_GetResultOfInstallImage_Call struct {
 }
 
 // GetResultOfInstallImage is a helper method to define mock.On call
-func (_e *Client_Expecter) GetResultOfInstallImage() *Client_GetResultOfInstallImage_Call {
-	return &Client_GetResultOfInstallImage_Call{Call: _e.mock.On("GetResultOfInstallImage")}
+//   - ctx context.Context
+func (_e *Client_Expecter) GetResultOfInstallImage(ctx interface{}) *Client_GetResultOfInstallImage_Call {
+	return &Client_GetResultOfInstallImage_Call{Call: _e.mock.On("GetResultOfInstallImage", ctx)}
 }
 
-func (_c *Client_GetResultOfInstallImage_Call) Run(run func()) *Client_GetResultOfInstallImage_Call {
+func (_c *Client_GetResultOfInstallImage_Call) Run(run func(ctx context.Context)) *Client_GetResultOfInstallImage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1199,22 +1222,22 @@ func (_c *Client_GetResultOfInstallImage_Call) Return(_a0 string, _a1 error) *Cl
 	return _c
 }
 
-func (_c *Client_GetResultOfInstallImage_Call) RunAndReturn(run func() (string, error)) *Client_GetResultOfInstallImage_Call {
+func (_c *Client_GetResultOfInstallImage_Call) RunAndReturn(run func(context.Context) (string, error)) *Client_GetResultOfInstallImage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Reboot provides a mock function with no fields
-func (_m *Client) Reboot() sshclient.Output {
-	ret := _m.Called()
+// Reboot provides a mock function with given fields: ctx
+func (_m *Client) Reboot(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Reboot")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -1228,13 +1251,14 @@ type Client_Reboot_Call struct {
 }
 
 // Reboot is a helper method to define mock.On call
-func (_e *Client_Expecter) Reboot() *Client_Reboot_Call {
-	return &Client_Reboot_Call{Call: _e.mock.On("Reboot")}
+//   - ctx context.Context
+func (_e *Client_Expecter) Reboot(ctx interface{}) *Client_Reboot_Call {
+	return &Client_Reboot_Call{Call: _e.mock.On("Reboot", ctx)}
 }
 
-func (_c *Client_Reboot_Call) Run(run func()) *Client_Reboot_Call {
+func (_c *Client_Reboot_Call) Run(run func(ctx context.Context)) *Client_Reboot_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1244,22 +1268,22 @@ func (_c *Client_Reboot_Call) Return(_a0 sshclient.Output) *Client_Reboot_Call {
 	return _c
 }
 
-func (_c *Client_Reboot_Call) RunAndReturn(run func() sshclient.Output) *Client_Reboot_Call {
+func (_c *Client_Reboot_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_Reboot_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ResetKubeadm provides a mock function with no fields
-func (_m *Client) ResetKubeadm() sshclient.Output {
-	ret := _m.Called()
+// ResetKubeadm provides a mock function with given fields: ctx
+func (_m *Client) ResetKubeadm(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResetKubeadm")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -1273,13 +1297,14 @@ type Client_ResetKubeadm_Call struct {
 }
 
 // ResetKubeadm is a helper method to define mock.On call
-func (_e *Client_Expecter) ResetKubeadm() *Client_ResetKubeadm_Call {
-	return &Client_ResetKubeadm_Call{Call: _e.mock.On("ResetKubeadm")}
+//   - ctx context.Context
+func (_e *Client_Expecter) ResetKubeadm(ctx interface{}) *Client_ResetKubeadm_Call {
+	return &Client_ResetKubeadm_Call{Call: _e.mock.On("ResetKubeadm", ctx)}
 }
 
-func (_c *Client_ResetKubeadm_Call) Run(run func()) *Client_ResetKubeadm_Call {
+func (_c *Client_ResetKubeadm_Call) Run(run func(ctx context.Context)) *Client_ResetKubeadm_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1289,7 +1314,7 @@ func (_c *Client_ResetKubeadm_Call) Return(_a0 sshclient.Output) *Client_ResetKu
 	return _c
 }
 
-func (_c *Client_ResetKubeadm_Call) RunAndReturn(run func() sshclient.Output) *Client_ResetKubeadm_Call {
+func (_c *Client_ResetKubeadm_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_ResetKubeadm_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1362,9 +1387,9 @@ func (_c *Client_StartImageURLCommand_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-// StateOfImageURLCommand provides a mock function with no fields
-func (_m *Client) StateOfImageURLCommand() (sshclient.ImageURLCommandState, string, error) {
-	ret := _m.Called()
+// StateOfImageURLCommand provides a mock function with given fields: ctx
+func (_m *Client) StateOfImageURLCommand(ctx context.Context) (sshclient.ImageURLCommandState, string, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StateOfImageURLCommand")
@@ -1373,23 +1398,23 @@ func (_m *Client) StateOfImageURLCommand() (sshclient.ImageURLCommandState, stri
 	var r0 sshclient.ImageURLCommandState
 	var r1 string
 	var r2 error
-	if rf, ok := ret.Get(0).(func() (sshclient.ImageURLCommandState, string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (sshclient.ImageURLCommandState, string, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() sshclient.ImageURLCommandState); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.ImageURLCommandState); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.ImageURLCommandState)
 	}
 
-	if rf, ok := ret.Get(1).(func() string); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) string); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
 
-	if rf, ok := ret.Get(2).(func() error); ok {
-		r2 = rf()
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -1403,13 +1428,14 @@ type Client_StateOfImageURLCommand_Call struct {
 }
 
 // StateOfImageURLCommand is a helper method to define mock.On call
-func (_e *Client_Expecter) StateOfImageURLCommand() *Client_StateOfImageURLCommand_Call {
-	return &Client_StateOfImageURLCommand_Call{Call: _e.mock.On("StateOfImageURLCommand")}
+//   - ctx context.Context
+func (_e *Client_Expecter) StateOfImageURLCommand(ctx interface{}) *Client_StateOfImageURLCommand_Call {
+	return &Client_StateOfImageURLCommand_Call{Call: _e.mock.On("StateOfImageURLCommand", ctx)}
 }
 
-func (_c *Client_StateOfImageURLCommand_Call) Run(run func()) *Client_StateOfImageURLCommand_Call {
+func (_c *Client_StateOfImageURLCommand_Call) Run(run func(ctx context.Context)) *Client_StateOfImageURLCommand_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1419,22 +1445,22 @@ func (_c *Client_StateOfImageURLCommand_Call) Return(state sshclient.ImageURLCom
 	return _c
 }
 
-func (_c *Client_StateOfImageURLCommand_Call) RunAndReturn(run func() (sshclient.ImageURLCommandState, string, error)) *Client_StateOfImageURLCommand_Call {
+func (_c *Client_StateOfImageURLCommand_Call) RunAndReturn(run func(context.Context) (sshclient.ImageURLCommandState, string, error)) *Client_StateOfImageURLCommand_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// UntarTGZ provides a mock function with no fields
-func (_m *Client) UntarTGZ() sshclient.Output {
-	ret := _m.Called()
+// UntarTGZ provides a mock function with given fields: ctx
+func (_m *Client) UntarTGZ(ctx context.Context) sshclient.Output {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UntarTGZ")
 	}
 
 	var r0 sshclient.Output
-	if rf, ok := ret.Get(0).(func() sshclient.Output); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) sshclient.Output); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Get(0).(sshclient.Output)
 	}
@@ -1448,13 +1474,14 @@ type Client_UntarTGZ_Call struct {
 }
 
 // UntarTGZ is a helper method to define mock.On call
-func (_e *Client_Expecter) UntarTGZ() *Client_UntarTGZ_Call {
-	return &Client_UntarTGZ_Call{Call: _e.mock.On("UntarTGZ")}
+//   - ctx context.Context
+func (_e *Client_Expecter) UntarTGZ(ctx interface{}) *Client_UntarTGZ_Call {
+	return &Client_UntarTGZ_Call{Call: _e.mock.On("UntarTGZ", ctx)}
 }
 
-func (_c *Client_UntarTGZ_Call) Run(run func()) *Client_UntarTGZ_Call {
+func (_c *Client_UntarTGZ_Call) Run(run func(ctx context.Context)) *Client_UntarTGZ_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -1464,7 +1491,7 @@ func (_c *Client_UntarTGZ_Call) Return(_a0 sshclient.Output) *Client_UntarTGZ_Ca
 	return _c
 }
 
-func (_c *Client_UntarTGZ_Call) RunAndReturn(run func() sshclient.Output) *Client_UntarTGZ_Call {
+func (_c *Client_UntarTGZ_Call) RunAndReturn(run func(context.Context) sshclient.Output) *Client_UntarTGZ_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -25,16 +25,17 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	scp "github.com/bramvdbogaerde/go-scp"
-	"github.com/go-logr/logr"
 	"golang.org/x/crypto/ssh"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -157,32 +158,32 @@ func (o Output) ExitStatus() (int, error) {
 
 // Client is the interface defining all functions necessary to talk to a bare metal server via SSH.
 type Client interface {
-	GetHostName() Output
-	GetHardwareDetailsRAM() Output
-	GetHardwareDetailsNics() Output
-	GetHardwareDetailsStorage() Output
-	GetHardwareDetailsCPUArch() Output
-	GetHardwareDetailsCPUModel() Output
-	GetHardwareDetailsCPUClockGigahertz() Output
-	GetHardwareDetailsCPUFlags() Output
-	GetHardwareDetailsCPUThreads() Output
-	GetHardwareDetailsCPUCores() Output
-	GetHardwareDetailsDebug() Output
-	GetInstallImageState() (InstallImageState, error)
-	GetResultOfInstallImage() (string, error)
-	GetCloudInitOutput() Output
-	CreateAutoSetup(data string) Output
-	DownloadImage(path, url string) Output
-	CreatePostInstallScript(data string) Output
-	ExecuteInstallImage(hasPostInstallScript bool) Output
-	Reboot() Output
-	CloudInitStatus() Output
-	CheckCloudInitLogsForSigTerm() Output
-	CleanCloudInitLogs() Output
-	CleanCloudInitInstances() Output
-	ResetKubeadm() Output
-	UntarTGZ() Output
-	DetectLinuxOnAnotherDisk(sliceOfWwns []string) Output
+	GetHostName(ctx context.Context) Output
+	GetHardwareDetailsRAM(ctx context.Context) Output
+	GetHardwareDetailsNics(ctx context.Context) Output
+	GetHardwareDetailsStorage(ctx context.Context) Output
+	GetHardwareDetailsCPUArch(ctx context.Context) Output
+	GetHardwareDetailsCPUModel(ctx context.Context) Output
+	GetHardwareDetailsCPUClockGigahertz(ctx context.Context) Output
+	GetHardwareDetailsCPUFlags(ctx context.Context) Output
+	GetHardwareDetailsCPUThreads(ctx context.Context) Output
+	GetHardwareDetailsCPUCores(ctx context.Context) Output
+	GetHardwareDetailsDebug(ctx context.Context) Output
+	GetInstallImageState(ctx context.Context) (InstallImageState, error)
+	GetResultOfInstallImage(ctx context.Context) (string, error)
+	GetCloudInitOutput(ctx context.Context) Output
+	CreateAutoSetup(ctx context.Context, data string) Output
+	DownloadImage(ctx context.Context, path, url string) Output
+	CreatePostInstallScript(ctx context.Context, data string) Output
+	ExecuteInstallImage(ctx context.Context, hasPostInstallScript bool) Output
+	Reboot(ctx context.Context) Output
+	CloudInitStatus(ctx context.Context) Output
+	CheckCloudInitLogsForSigTerm(ctx context.Context) Output
+	CleanCloudInitLogs(ctx context.Context) Output
+	CleanCloudInitInstances(ctx context.Context) Output
+	ResetKubeadm(ctx context.Context) Output
+	UntarTGZ(ctx context.Context) Output
+	DetectLinuxOnAnotherDisk(ctx context.Context, sliceOfWwns []string) Output
 
 	// Erase filesystem, raid and partition-table signatures.
 	// String "all" will wipe all disks.
@@ -207,7 +208,7 @@ type Client interface {
 
 	// StateOfImageURLCommand returns the current states of the ImageURLCommand. States can
 	// be: NotStarted, Running, Failed, FinishedSuccesfully.
-	StateOfImageURLCommand() (state ImageURLCommandState, logFile string, err error)
+	StateOfImageURLCommand(ctx context.Context) (state ImageURLCommandState, logFile string, err error)
 }
 
 // Factory is the interface for creating new Client objects.
@@ -230,7 +231,6 @@ func (f *sshFactory) NewClient(in Input) Client {
 		privateSSHKey: in.PrivateKey,
 		ip:            in.IP,
 		port:          in.Port,
-		log:           ctrl.Log.WithName("ssh-client"),
 	}
 }
 
@@ -238,24 +238,23 @@ type sshClient struct {
 	ip            string
 	privateSSHKey string
 	port          int
-	log           logr.Logger
 }
 
 var _ = Client(&sshClient{})
 
 // GetHostName implements the GetHostName method of the SSHClient interface.
-func (c *sshClient) GetHostName() Output {
-	return c.runSSH("hostname")
+func (c *sshClient) GetHostName(ctx context.Context) Output {
+	return c.runSSH(ctx, "hostname")
 }
 
 // GetHardwareDetailsRAM implements the GetHardwareDetailsRAM method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsRAM() Output {
-	return c.runSSH("grep MemTotal /proc/meminfo | awk '{print $2}'")
+func (c *sshClient) GetHardwareDetailsRAM(ctx context.Context) Output {
+	return c.runSSH(ctx, "grep MemTotal /proc/meminfo | awk '{print $2}'")
 }
 
 // GetHardwareDetailsNics implements the GetHardwareDetailsNics method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsNics() Output {
-	return c.runSSH(fmt.Sprintf(`cat >/root/nic-info.sh <<'EOF_VIA_SSH'
+func (c *sshClient) GetHardwareDetailsNics(ctx context.Context) Output {
+	return c.runSSH(ctx, fmt.Sprintf(`cat >/root/nic-info.sh <<'EOF_VIA_SSH'
 %s
 EOF_VIA_SSH
 chmod a+rx /root/nic-info.sh
@@ -264,33 +263,33 @@ chmod a+rx /root/nic-info.sh
 }
 
 // GetHardwareDetailsStorage implements the GetHardwareDetailsStorage method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsStorage() Output {
-	return c.runSSH(`lsblk -b -P -o "NAME,TYPE,SIZE,VENDOR,MODEL,SERIAL,WWN,HCTL,ROTA"`)
+func (c *sshClient) GetHardwareDetailsStorage(ctx context.Context) Output {
+	return c.runSSH(ctx, `lsblk -b -P -o "NAME,TYPE,SIZE,VENDOR,MODEL,SERIAL,WWN,HCTL,ROTA"`)
 }
 
 // GetHardwareDetailsCPUArch implements the GetHardwareDetailsCPUArch method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUArch() Output {
-	return c.runSSH(`lscpu | grep "Architecture:" | awk '{print $2}'`)
+func (c *sshClient) GetHardwareDetailsCPUArch(ctx context.Context) Output {
+	return c.runSSH(ctx, `lscpu | grep "Architecture:" | awk '{print $2}'`)
 }
 
 // GetHardwareDetailsCPUModel implements the GetHardwareDetailsCPUModel method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUModel() Output {
-	return c.runSSH(`lscpu | grep "Model name:" | awk '{$1=$2=""; print $0}' | sed "s/^[ \t]*//"`)
+func (c *sshClient) GetHardwareDetailsCPUModel(ctx context.Context) Output {
+	return c.runSSH(ctx, `lscpu | grep "Model name:" | awk '{$1=$2=""; print $0}' | sed "s/^[ \t]*//"`)
 }
 
 // GetHardwareDetailsCPUClockGigahertz implements the GetHardwareDetailsCPUClockGigahertz method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUClockGigahertz() Output {
-	return c.runSSH(`lscpu | grep "CPU max MHz:" |  awk '{printf "%.1f", $4/1000}'`)
+func (c *sshClient) GetHardwareDetailsCPUClockGigahertz(ctx context.Context) Output {
+	return c.runSSH(ctx, `lscpu | grep "CPU max MHz:" |  awk '{printf "%.1f", $4/1000}'`)
 }
 
 // GetHardwareDetailsCPUFlags implements the GetHardwareDetailsCPUFlags method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUFlags() Output {
-	return c.runSSH(`lscpu | grep "Flags:" |  awk '{ $1=""; print $0}' | sed "s/^[ \t]*//"`)
+func (c *sshClient) GetHardwareDetailsCPUFlags(ctx context.Context) Output {
+	return c.runSSH(ctx, `lscpu | grep "Flags:" |  awk '{ $1=""; print $0}' | sed "s/^[ \t]*//"`)
 }
 
 // GetCloudInitOutput implements the GetCloudInitOutput method of the SSHClient interface.
-func (c *sshClient) GetCloudInitOutput() Output {
-	out := c.runSSH(`cat /var/log/cloud-init-output.log`)
+func (c *sshClient) GetCloudInitOutput(ctx context.Context) Output {
+	out := c.runSSH(ctx, `cat /var/log/cloud-init-output.log`)
 	if out.Err == nil {
 		out.StdOut = removeUselessLinesFromCloudInitOutput(out.StdOut)
 	}
@@ -298,36 +297,36 @@ func (c *sshClient) GetCloudInitOutput() Output {
 }
 
 // GetHardwareDetailsCPUThreads implements the GetHardwareDetailsCPUThreads method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUThreads() Output {
-	return c.runSSH(`lscpu | grep "CPU(s):" | head -1 |  awk '{ print $2}'`)
+func (c *sshClient) GetHardwareDetailsCPUThreads(ctx context.Context) Output {
+	return c.runSSH(ctx, `lscpu | grep "CPU(s):" | head -1 |  awk '{ print $2}'`)
 }
 
 // GetHardwareDetailsCPUCores implements the GetHardwareDetailsCPUCores method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsCPUCores() Output {
-	return c.runSSH(`grep 'cpu cores' /proc/cpuinfo | uniq | awk '{print $4}'`)
+func (c *sshClient) GetHardwareDetailsCPUCores(ctx context.Context) Output {
+	return c.runSSH(ctx, `grep 'cpu cores' /proc/cpuinfo | uniq | awk '{print $4}'`)
 }
 
 // GetHardwareDetailsDebug implements the GetHardwareDetailsDebug method of the SSHClient interface.
-func (c *sshClient) GetHardwareDetailsDebug() Output {
-	return c.runSSH(`ip a; echo ==========----------==========;
+func (c *sshClient) GetHardwareDetailsDebug(ctx context.Context) Output {
+	return c.runSSH(ctx, `ip a; echo ==========----------==========;
 	ethtool "*"; echo ==========----------==========;
 	lspci; echo ==========----------==========;
 	`)
 }
 
 // CreateAutoSetup implements the CreateAutoSetup method of the SSHClient interface.
-func (c *sshClient) CreateAutoSetup(data string) Output {
-	return c.runSSH(fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /autosetup
+func (c *sshClient) CreateAutoSetup(ctx context.Context, data string) Output {
+	return c.runSSH(ctx, fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /autosetup
 %s
 EOF_VIA_SSH`, data))
 }
 
 // DownloadImage implements the DownloadImage method of the SSHClient interface.
-func (c *sshClient) DownloadImage(path, url string) Output {
+func (c *sshClient) DownloadImage(ctx context.Context, path, url string) Output {
 	if !strings.HasPrefix(url, "oci://") {
-		return c.runSSH(fmt.Sprintf(`curl -sLo "%q" "%q"`, path, url))
+		return c.runSSH(ctx, fmt.Sprintf(`curl -sLo "%q" "%q"`, path, url))
 	}
-	return c.runSSH(fmt.Sprintf(`cat << 'ENDOFSCRIPT' > /root/download-from-oci.sh
+	return c.runSSH(ctx, fmt.Sprintf(`cat << 'ENDOFSCRIPT' > /root/download-from-oci.sh
 %s
 ENDOFSCRIPT
 chmod a+rx /root/download-from-oci.sh
@@ -337,20 +336,20 @@ OCI_REGISTRY_AUTH_TOKEN=%s /root/download-from-oci.sh %s %s`, downloadFromOciShe
 }
 
 // CreatePostInstallScript implements the CreatePostInstallScript method of the SSHClient interface.
-func (c *sshClient) CreatePostInstallScript(data string) Output {
-	out := c.runSSH(fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /root/post-install.sh
+func (c *sshClient) CreatePostInstallScript(ctx context.Context, data string) Output {
+	out := c.runSSH(ctx, fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /root/post-install.sh
 %s
 EOF_VIA_SSH`, data))
 
 	if out.Err != nil || out.StdErr != "" {
 		return out
 	}
-	return c.runSSH(`chmod +x /root/post-install.sh`)
+	return c.runSSH(ctx, `chmod +x /root/post-install.sh`)
 }
 
 // GetInstallImageState returns the running installimage processes.
-func (c *sshClient) GetInstallImageState() (InstallImageState, error) {
-	out := c.runSSH(`ps aux| grep installimage | grep -v grep; true`)
+func (c *sshClient) GetInstallImageState(ctx context.Context) (InstallImageState, error) {
+	out := c.runSSH(ctx, `ps aux| grep installimage | grep -v grep; true`)
 	if out.Err != nil {
 		return "", fmt.Errorf("failed to run `ps aux` to get running installimage process: %w", out.Err)
 	}
@@ -359,7 +358,7 @@ func (c *sshClient) GetInstallImageState() (InstallImageState, error) {
 		return InstallImageStateRunning, nil
 	}
 
-	out = c.runSSH(`[ -e /root/installimage-wrapper.sh.log ]`)
+	out = c.runSSH(ctx, `[ -e /root/installimage-wrapper.sh.log ]`)
 	exitStatus, err := out.ExitStatus()
 	if err != nil {
 		return "", fmt.Errorf("failed to check if installimage-wrapper.sh.log exists: %w", err)
@@ -373,7 +372,7 @@ func (c *sshClient) GetInstallImageState() (InstallImageState, error) {
 }
 
 // ExecuteInstallImage implements the ExecuteInstallImage method of the SSHClient interface.
-func (c *sshClient) ExecuteInstallImage(hasPostInstallScript bool) Output {
+func (c *sshClient) ExecuteInstallImage(ctx context.Context, hasPostInstallScript bool) Output {
 	var cmd string
 	if hasPostInstallScript {
 		cmd = `/root/hetzner-installimage/installimage -a -c /autosetup -x /root/post-install.sh`
@@ -381,7 +380,7 @@ func (c *sshClient) ExecuteInstallImage(hasPostInstallScript bool) Output {
 		cmd = `/root/hetzner-installimage/installimage -a -c /autosetup`
 	}
 
-	out := c.runSSH(fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /root/installimage-wrapper.sh
+	out := c.runSSH(ctx, fmt.Sprintf(`cat << 'EOF_VIA_SSH' > /root/installimage-wrapper.sh
 #!/bin/bash
 export TERM=xterm
 
@@ -392,24 +391,24 @@ EOF_VIA_SSH`, cmd))
 		return out
 	}
 
-	out = c.runSSH(`chmod +x /root/installimage-wrapper.sh . `)
+	out = c.runSSH(ctx, `chmod +x /root/installimage-wrapper.sh . `)
 	if out.Err != nil || out.StdErr != "" {
 		return out
 	}
 
-	return c.runSSH(`nohup /root/installimage-wrapper.sh >/root/installimage-wrapper.sh.log 2>&1 </dev/null &`)
+	return c.runSSH(ctx, `nohup /root/installimage-wrapper.sh >/root/installimage-wrapper.sh.log 2>&1 </dev/null &`)
 }
 
 // GetResultOfInstallImage returns the logs of install-image.
 // Before calling this method be sure that installimage is already terminated.
-func (c *sshClient) GetResultOfInstallImage() (string, error) {
-	out := c.runSSH(`cat /root/debug.txt`)
+func (c *sshClient) GetResultOfInstallImage(ctx context.Context) (string, error) {
+	out := c.runSSH(ctx, `cat /root/debug.txt`)
 	if out.Err != nil {
 		return "", fmt.Errorf("failed to get debug.txt: %w", out.Err)
 	}
 	debugTxt := out.StdOut
 
-	out = c.runSSH(`cat /root/installimage-wrapper.sh.log`)
+	out = c.runSSH(ctx, `cat /root/installimage-wrapper.sh.log`)
 	if out.Err != nil {
 		return "", fmt.Errorf("failed to get installimage-wrapper.sh.log: %w", out.Err)
 	}
@@ -428,8 +427,8 @@ func (c *sshClient) GetResultOfInstallImage() (string, error) {
 }
 
 // Reboot implements the Reboot method of the SSHClient interface.
-func (c *sshClient) Reboot() Output {
-	out := c.runSSH(`reboot`)
+func (c *sshClient) Reboot(ctx context.Context) Output {
+	out := c.runSSH(ctx, `reboot`)
 	if out.Err != nil && strings.Contains(out.Err.Error(), ErrCommandExitedWithoutExitSignal.Error()) {
 		return Output{}
 	}
@@ -437,13 +436,13 @@ func (c *sshClient) Reboot() Output {
 }
 
 // CloudInitStatus implements the CloudInitStatus method of the SSHClient interface.
-func (c *sshClient) CloudInitStatus() Output {
-	return c.runSSH("cloud-init status")
+func (c *sshClient) CloudInitStatus(ctx context.Context) Output {
+	return c.runSSH(ctx, "cloud-init status")
 }
 
 // CheckCloudInitLogsForSigTerm implements the CheckCloudInitLogsForSigTerm method of the SSHClient interface.
-func (c *sshClient) CheckCloudInitLogsForSigTerm() Output {
-	out := c.runSSH(`cat /var/log/cloud-init.log | grep "SIGTERM"`)
+func (c *sshClient) CheckCloudInitLogsForSigTerm(ctx context.Context) Output {
+	out := c.runSSH(ctx, `cat /var/log/cloud-init.log | grep "SIGTERM"`)
 	if out.Err != nil {
 		exitStatus, err := out.ExitStatus()
 		if err == nil && exitStatus == 1 {
@@ -456,19 +455,19 @@ func (c *sshClient) CheckCloudInitLogsForSigTerm() Output {
 }
 
 // CleanCloudInitLogs implements the CleanCloudInitLogs method of the SSHClient interface.
-func (c *sshClient) CleanCloudInitLogs() Output {
-	return c.runSSH(`cloud-init clean --logs`)
+func (c *sshClient) CleanCloudInitLogs(ctx context.Context) Output {
+	return c.runSSH(ctx, `cloud-init clean --logs`)
 }
 
 // CleanCloudInitInstances implements the CleanCloudInitInstances method of the SSHClient interface.
-func (c *sshClient) CleanCloudInitInstances() Output {
-	return c.runSSH(`rm -rf /var/lib/cloud/instances`)
+func (c *sshClient) CleanCloudInitInstances(ctx context.Context) Output {
+	return c.runSSH(ctx, `rm -rf /var/lib/cloud/instances`)
 }
 
 // ResetKubeadm implements the ResetKubeadm method of the SSHClient interface.
-func (c *sshClient) ResetKubeadm() Output {
+func (c *sshClient) ResetKubeadm(ctx context.Context) Output {
 	// if `kubeadm reset` fails, we disable all pods and related services explicitly.
-	output := c.runSSH(`kubeadm reset -f 2>&1
+	output := c.runSSH(ctx, `kubeadm reset -f 2>&1
 	echo
 	echo ========= stopping all pods =========
 	crictl pods -q | while read -r podid; do
@@ -485,8 +484,8 @@ func (c *sshClient) ResetKubeadm() Output {
 	return output
 }
 
-func (c *sshClient) DetectLinuxOnAnotherDisk(sliceOfWwns []string) Output {
-	return c.runSSH(fmt.Sprintf(`cat >/root/detect-linux-on-another-disk.sh <<'EOF_VIA_SSH'
+func (c *sshClient) DetectLinuxOnAnotherDisk(ctx context.Context, sliceOfWwns []string) Output {
+	return c.runSSH(ctx, fmt.Sprintf(`cat >/root/detect-linux-on-another-disk.sh <<'EOF_VIA_SSH'
 %s
 EOF_VIA_SSH
 chmod a+rx /root/detect-linux-on-another-disk.sh
@@ -510,7 +509,7 @@ func (c *sshClient) WipeDisk(ctx context.Context, sliceOfWwns []string) (string,
 		return "", nil
 	}
 	if slices.Contains(sliceOfWwns, "all") {
-		out := c.runSSH("lsblk --nodeps --noheadings -o WWN | sort -u")
+		out := c.runSSH(ctx, "lsblk --nodeps --noheadings -o WWN | sort -u")
 		if out.Err != nil {
 			return "", fmt.Errorf("failed to find WWNs of all disks: %w", out.Err)
 		}
@@ -525,7 +524,7 @@ func (c *sshClient) WipeDisk(ctx context.Context, sliceOfWwns []string) (string,
 			}
 		}
 	}
-	out := c.runSSH(fmt.Sprintf(`cat >/root/wipe-disk.sh <<'EOF_VIA_SSH'
+	out := c.runSSH(ctx, fmt.Sprintf(`cat >/root/wipe-disk.sh <<'EOF_VIA_SSH'
 %s
 EOF_VIA_SSH
 chmod a+rx /root/wipe-disk.sh
@@ -537,12 +536,12 @@ chmod a+rx /root/wipe-disk.sh
 	return out.String(), nil
 }
 
-func (c *sshClient) CheckDisk(_ context.Context, sliceOfWwns []string) (info string, err error) {
+func (c *sshClient) CheckDisk(ctx context.Context, sliceOfWwns []string) (info string, err error) {
 	if len(sliceOfWwns) == 0 {
 		return "", nil
 	}
 
-	out := c.runSSH(fmt.Sprintf(`cat >/root/check-disk.sh <<'EOF_VIA_SSH'
+	out := c.runSSH(ctx, fmt.Sprintf(`cat >/root/check-disk.sh <<'EOF_VIA_SSH'
 %s
 EOF_VIA_SSH
 chmod a+rx /root/check-disk.sh
@@ -565,7 +564,7 @@ chmod a+rx /root/check-disk.sh
 	return "", fmt.Errorf("CheckDisk for %+v failed: %s. %s: %w", sliceOfWwns, out.StdOut, out.StdErr, out.Err)
 }
 
-func (c *sshClient) UntarTGZ() Output {
+func (c *sshClient) UntarTGZ(ctx context.Context) Output {
 	// read tgz from container image.
 	fileName := "/installimage.tgz"
 	data, err := os.ReadFile(fileName)
@@ -574,7 +573,7 @@ func (c *sshClient) UntarTGZ() Output {
 	}
 
 	// send base64 encoded binary to machine via ssh.
-	return c.runSSH(fmt.Sprintf("echo %s | base64 -d | tar -xzf-",
+	return c.runSSH(ctx, fmt.Sprintf("echo %s | base64 -d | tar -xzf-",
 		base64.StdEncoding.EncodeToString(data)))
 }
 
@@ -598,7 +597,7 @@ func IsTimeoutError(err error) bool {
 	return strings.Contains(err.Error(), ErrTimeout.Error())
 }
 
-func (c *sshClient) getSSHClient() (*ssh.Client, error) {
+func (c *sshClient) getSSHClient(ctx context.Context) (*ssh.Client, error) {
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey([]byte(c.privateSSHKey))
 	if err != nil {
@@ -615,33 +614,62 @@ func (c *sshClient) getSSHClient() (*ssh.Client, error) {
 		Timeout:         sshTimeOut,
 	}
 
-	// Connect to the remote server and perform the SSH handshake.
-	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%v", c.ip, c.port), config)
+	addr := net.JoinHostPort(c.ip, strconv.Itoa(c.port))
+
+	// ctx-aware TCP dial.
+	d := net.Dialer{Timeout: sshTimeOut}
+	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
+		// Return ctx.Err() unwrapped so os.IsTimeout detects it.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("failed to dial ssh (%s): %w", c.connectionDetails(), err)
 	}
 
-	return client, nil
+	// If ctx fires during the SSH handshake, close the underlying conn so
+	// NewClientConn returns. stop() deregisters the callback on normal exit.
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stop()
+
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("failed ssh handshake (%s): %w", c.connectionDetails(), err)
+	}
+	return ssh.NewClient(sshConn, chans, reqs), nil
 }
 
-func (c *sshClient) runSSH(command string) Output {
-	client, err := c.getSSHClient()
+func (c *sshClient) runSSH(ctx context.Context, command string) Output {
+	logger := ctrl.LoggerFrom(ctx).WithName("ssh-client")
+
+	client, err := c.getSSHClient(ctx)
 	if err != nil {
 		return Output{Err: err}
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			c.log.Error(err, "failed to close ssh client")
+			logger.Error(err, "failed to close ssh client")
 		}
 	}()
 
+	// If ctx fires, close the transport so any in-flight call (NewSession,
+	// sess.Run) returns. stop() deregisters the callback on normal exit.
+	stop := context.AfterFunc(ctx, func() { _ = client.Close() })
+	defer stop()
+
 	sess, err := client.NewSession()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return Output{Err: ctxErr}
+		}
 		return Output{Err: fmt.Errorf("unable to create new ssh session (%s): %w", c.connectionDetails(), err)}
 	}
 	defer func() {
 		if err := sess.Close(); err != nil {
-			c.log.Error(err, "failed to close ssh session")
+			logger.Error(err, "failed to close ssh session")
 		}
 	}()
 
@@ -652,6 +680,13 @@ func (c *sshClient) runSSH(command string) Output {
 	sess.Stderr = &stderrBuffer
 
 	err = sess.Run(command)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return Output{
+			StdOut: stdoutBuffer.String(),
+			StdErr: stderrBuffer.String(),
+			Err:    ctxErr,
+		}
+	}
 	if err != nil {
 		err = fmt.Errorf("ssh command failed (%s): %w", c.connectionDetails(), err)
 	}
@@ -715,13 +750,15 @@ func removeUselessLinesFromCloudInitOutput(s string) string {
 }
 
 func (c *sshClient) ExecutePreProvisionCommand(ctx context.Context, command string) (int, string, error) {
-	client, err := c.getSSHClient()
+	logger := ctrl.LoggerFrom(ctx).WithName("ssh-client")
+
+	client, err := c.getSSHClient(ctx)
 	if err != nil {
 		return 0, "", err
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			c.log.Error(err, "failed to close ssh client")
+			logger.Error(err, "failed to close ssh client")
 		}
 	}()
 
@@ -744,7 +781,7 @@ func (c *sshClient) ExecutePreProvisionCommand(ctx context.Context, command stri
 		return 0, "", fmt.Errorf("error copying file %q to %s:%d:%s %w", command, c.ip, c.port, dest, err)
 	}
 
-	out := c.runSSH(dest)
+	out := c.runSSH(ctx, dest)
 	exitStatus, err := out.ExitStatus()
 	if err != nil {
 		return 0, "", fmt.Errorf("error executing %q on %s:%d: %w", dest, c.ip, c.port, err)
@@ -757,6 +794,8 @@ func (c *sshClient) ExecutePreProvisionCommand(ctx context.Context, command stri
 }
 
 func (c *sshClient) StartImageURLCommand(ctx context.Context, command, imageURL string, bootstrapData []byte, machineName string, deviceNames []string) (int, string, error) {
+	logger := ctrl.LoggerFrom(ctx).WithName("ssh-client")
+
 	// validate deviceNames
 	for _, dn := range deviceNames {
 		if strings.Contains(dn, "/") {
@@ -780,17 +819,17 @@ func (c *sshClient) StartImageURLCommand(ctx context.Context, command, imageURL 
 	}
 	defer func() {
 		if err := fdCommand.Close(); err != nil {
-			c.log.Error(err, "failed to close image-url-command file", "path", command)
+			logger.Error(err, "failed to close image-url-command file", "path", command)
 		}
 	}()
 
-	client, err := c.getSSHClient()
+	client, err := c.getSSHClient(ctx)
 	if err != nil {
 		return 0, "", err
 	}
 	defer func() {
 		if err := client.Close(); err != nil {
-			c.log.Error(err, "failed to close ssh client")
+			logger.Error(err, "failed to close ssh client")
 		}
 	}()
 
@@ -821,7 +860,7 @@ echo $! > /root/image-url-command.pid
 `, os.Getenv("OCI_REGISTRY_AUTH_TOKEN"), imageURL, machineName, strings.Join(deviceNames, " "),
 		imageURLCommandLog)
 
-	out := c.runSSH(cmd)
+	out := c.runSSH(ctx, cmd)
 
 	exitStatus, err := out.ExitStatus()
 	if err != nil {
@@ -834,8 +873,8 @@ echo $! > /root/image-url-command.pid
 	return exitStatus, s, nil
 }
 
-func (c *sshClient) StateOfImageURLCommand() (state ImageURLCommandState, stdoutStderr string, err error) {
-	out := c.runSSH(`[ -e /root/image-url-command.pid ]`)
+func (c *sshClient) StateOfImageURLCommand(ctx context.Context) (state ImageURLCommandState, stdoutStderr string, err error) {
+	out := c.runSSH(ctx, `[ -e /root/image-url-command.pid ]`)
 	exitStatus, err := out.ExitStatus()
 	if err != nil {
 		return ImageURLCommandStateNotStarted, "", fmt.Errorf("getting exit status of image-url-command failed: %w", err)
@@ -845,13 +884,13 @@ func (c *sshClient) StateOfImageURLCommand() (state ImageURLCommandState, stdout
 		return ImageURLCommandStateNotStarted, "", nil
 	}
 
-	out = c.runSSH(`ps -p "$(cat /root/image-url-command.pid)" -o args= | grep -q image-url-command`)
+	out = c.runSSH(ctx, `ps -p "$(cat /root/image-url-command.pid)" -o args= | grep -q image-url-command`)
 	exitStatus, err = out.ExitStatus()
 	if err != nil {
 		return ImageURLCommandStateNotStarted, "", fmt.Errorf("detecting if image-url-command is still running failed: %w", err)
 	}
 
-	logFile, err := c.getImageURLCommandOutput()
+	logFile, err := c.getImageURLCommandOutput(ctx)
 	if err != nil {
 		return ImageURLCommandStateFailed, logFile, err
 	}
@@ -860,7 +899,7 @@ func (c *sshClient) StateOfImageURLCommand() (state ImageURLCommandState, stdout
 		return ImageURLCommandStateRunning, logFile, nil
 	}
 
-	out = c.runSSH(fmt.Sprintf("tail -n 1 %s | grep -q IMAGE_URL_DONE", imageURLCommandLog))
+	out = c.runSSH(ctx, fmt.Sprintf("tail -n 1 %s | grep -q IMAGE_URL_DONE", imageURLCommandLog))
 	exitStatus, err = out.ExitStatus()
 	if err != nil {
 		return ImageURLCommandStateNotStarted, logFile, fmt.Errorf("detecting if image-url-command was successful failed: %w", err)
@@ -873,8 +912,8 @@ func (c *sshClient) StateOfImageURLCommand() (state ImageURLCommandState, stdout
 	return ImageURLCommandStateFinishedSuccessfully, logFile, nil
 }
 
-func (c *sshClient) getImageURLCommandOutput() (string, error) {
-	out := c.runSSH(fmt.Sprintf("cat %s", imageURLCommandLog)) // TODO: implement getFile for sshClient.
+func (c *sshClient) getImageURLCommandOutput(ctx context.Context) (string, error) {
+	out := c.runSSH(ctx, fmt.Sprintf("cat %s", imageURLCommandLog)) // TODO: implement getFile for sshClient.
 	exitStatus, err := out.ExitStatus()
 	if err != nil {
 		return "", fmt.Errorf("getting logs of image-url-command failed: %w", err)

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -239,10 +239,10 @@ func (s *Service) actionPreparing(ctx context.Context) actionResult {
 		})
 
 		// Check hostname with sshClient
-		out := sshClient.GetHostName()
+		out := sshClient.GetHostName(ctx)
 		if trimLineBreak(out.StdOut) != "" {
 			// we managed access with ssh - we can do an ssh reboot
-			if err := handleSSHError(sshClient.Reboot()); err != nil {
+			if err := handleSSHError(sshClient.Reboot(ctx)); err != nil {
 				return actionError{err: fmt.Errorf("failed to reboot server via ssh (actionPreparing): %w", err)}
 			}
 			msg := "Rebooting into rescue mode."
@@ -602,7 +602,7 @@ func (s *Service) actionRegistering(ctx context.Context) actionResult {
 	sshClient := s.scope.SSHClientFactory.NewClient(in)
 
 	// Check hostname with sshClient
-	out := sshClient.GetHostName()
+	out := sshClient.GetHostName(ctx)
 	hostName := trimLineBreak(out.StdOut)
 
 	if hostName != rescue {
@@ -639,7 +639,7 @@ func (s *Service) actionRegistering(ctx context.Context) actionResult {
 	// we are in resuce mode i.e. reboot was successful, now clear the RebootTriggeredAt timestamp.
 	s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
 
-	output := sshClient.GetHardwareDetailsDebug()
+	output := sshClient.GetHardwareDetailsDebug(ctx)
 	if output.Err != nil {
 		return actionError{err: fmt.Errorf("failed to obtain hardware for debugging: %w", output.Err)}
 	}
@@ -651,7 +651,7 @@ func (s *Service) actionRegistering(ctx context.Context) actionResult {
 	record.Eventf(s.scope.HetznerBareMetalHost, "GetHardwareDetails", msg)
 
 	if s.scope.HetznerBareMetalHost.Spec.Status.HardwareDetails == nil {
-		hardwareDetails, err := getHardwareDetails(sshClient)
+		hardwareDetails, err := getHardwareDetails(ctx, sshClient)
 		if err != nil {
 			return actionError{err: fmt.Errorf("failed to get hardware details: %w", err)}
 		}
@@ -741,18 +741,18 @@ func validateRootDeviceWwnsAreSubsetOfExistingWwns(rootDeviceHints *infrav1.Root
 	return nil
 }
 
-func getHardwareDetails(sshClient sshclient.Client) (infrav1.HardwareDetails, error) {
-	mebiBytes, err := obtainHardwareDetailsRAM(sshClient)
+func getHardwareDetails(ctx context.Context, sshClient sshclient.Client) (infrav1.HardwareDetails, error) {
+	mebiBytes, err := obtainHardwareDetailsRAM(ctx, sshClient)
 	if err != nil {
 		return infrav1.HardwareDetails{}, fmt.Errorf("failed to obtain hardware details RAM: %w", err)
 	}
 
-	nics, err := obtainHardwareDetailsNics(sshClient)
+	nics, err := obtainHardwareDetailsNics(ctx, sshClient)
 	if err != nil {
 		return infrav1.HardwareDetails{}, fmt.Errorf("failed to obtain hardware details Nics: %w", err)
 	}
 
-	storage, err := obtainHardwareDetailsStorage(sshClient)
+	storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
 	if err != nil {
 		return infrav1.HardwareDetails{}, fmt.Errorf("failed to obtain hardware details storage: %w", err)
 	}
@@ -762,7 +762,7 @@ func getHardwareDetails(sshClient sshclient.Client) (infrav1.HardwareDetails, er
 		storage[i].Name = ""
 	}
 
-	cpu, err := obtainHardwareDetailsCPU(sshClient)
+	cpu, err := obtainHardwareDetailsCPU(ctx, sshClient)
 	if err != nil {
 		return infrav1.HardwareDetails{}, fmt.Errorf("failed to obtain hardware details CPU: %w", err)
 	}
@@ -828,8 +828,8 @@ func (s *Service) rebootTriggered() (bool, error) {
 	return !rescue.Active, nil
 }
 
-func obtainHardwareDetailsRAM(sshClient sshclient.Client) (int, error) {
-	out := sshClient.GetHardwareDetailsRAM()
+func obtainHardwareDetailsRAM(ctx context.Context, sshClient sshclient.Client) (int, error) {
+	out := sshClient.GetHardwareDetailsRAM(ctx)
 	if err := handleSSHError(out); err != nil {
 		return 0, err
 	}
@@ -847,7 +847,7 @@ func obtainHardwareDetailsRAM(sshClient sshclient.Client) (int, error) {
 	return mebiBytes, nil
 }
 
-func obtainHardwareDetailsNics(sshClient sshclient.Client) ([]infrav1.NIC, error) {
+func obtainHardwareDetailsNics(ctx context.Context, sshClient sshclient.Client) ([]infrav1.NIC, error) {
 	type originalNic struct {
 		Name      string `json:"name,omitempty"`
 		Model     string `json:"model,omitempty"`
@@ -856,7 +856,7 @@ func obtainHardwareDetailsNics(sshClient sshclient.Client) ([]infrav1.NIC, error
 		SpeedMbps string `json:"speedMbps,omitempty"`
 	}
 
-	out := sshClient.GetHardwareDetailsNics()
+	out := sshClient.GetHardwareDetailsNics(ctx)
 	if err := handleSSHError(out); err != nil {
 		return nil, err
 	}
@@ -907,7 +907,7 @@ func obtainHardwareDetailsNics(sshClient sshclient.Client) ([]infrav1.NIC, error
 	return nicsArray, nil
 }
 
-func obtainHardwareDetailsStorage(sshClient sshclient.Client) ([]infrav1.Storage, error) {
+func obtainHardwareDetailsStorage(ctx context.Context, sshClient sshclient.Client) ([]infrav1.Storage, error) {
 	type originalStorage struct {
 		Name         string `json:"name,omitempty"`
 		Type         string `json:"type,omitempty"`
@@ -922,7 +922,7 @@ func obtainHardwareDetailsStorage(sshClient sshclient.Client) ([]infrav1.Storage
 		Rota         string `json:"rota,omitempty"`
 	}
 
-	out := sshClient.GetHardwareDetailsStorage()
+	out := sshClient.GetHardwareDetailsStorage(ctx)
 	if err := handleSSHError(out); err != nil {
 		return nil, err
 	}
@@ -977,28 +977,28 @@ func obtainHardwareDetailsStorage(sshClient sshclient.Client) ([]infrav1.Storage
 	return storageArray, nil
 }
 
-func obtainHardwareDetailsCPU(sshClient sshclient.Client) (cpu infrav1.CPU, err error) {
-	cpu.Arch, err = getCPUArch(sshClient)
+func obtainHardwareDetailsCPU(ctx context.Context, sshClient sshclient.Client) (cpu infrav1.CPU, err error) {
+	cpu.Arch, err = getCPUArch(ctx, sshClient)
 	if err != nil {
 		return infrav1.CPU{}, fmt.Errorf("failed to get CPU arch: %w", err)
 	}
 
-	cpu.Model, err = getCPUModel(sshClient)
+	cpu.Model, err = getCPUModel(ctx, sshClient)
 	if err != nil {
 		return infrav1.CPU{}, fmt.Errorf("failed to get CPU model: %w", err)
 	}
 
-	cpu.ClockGigahertz, err = getCPUClockGigahertz(sshClient)
+	cpu.ClockGigahertz, err = getCPUClockGigahertz(ctx, sshClient)
 	if err != nil {
 		return infrav1.CPU{}, fmt.Errorf("failed to get CPU clock speed: %w", err)
 	}
 
-	cpu.Threads, err = getCPUThreads(sshClient)
+	cpu.Threads, err = getCPUThreads(ctx, sshClient)
 	if err != nil {
 		return infrav1.CPU{}, fmt.Errorf("failed to get CPU threads: %w", err)
 	}
 
-	cpu.Flags, err = getCPUFlags(sshClient)
+	cpu.Flags, err = getCPUFlags(ctx, sshClient)
 	if err != nil {
 		return infrav1.CPU{}, fmt.Errorf("failed to get CPU flags: %w", err)
 	}
@@ -1006,8 +1006,8 @@ func obtainHardwareDetailsCPU(sshClient sshclient.Client) (cpu infrav1.CPU, err 
 	return cpu, nil
 }
 
-func getCPUArch(sshClient sshclient.Client) (string, error) {
-	out := sshClient.GetHardwareDetailsCPUArch()
+func getCPUArch(ctx context.Context, sshClient sshclient.Client) (string, error) {
+	out := sshClient.GetHardwareDetailsCPUArch(ctx)
 	if err := handleSSHError(out); err != nil {
 		return "", err
 	}
@@ -1020,8 +1020,8 @@ func getCPUArch(sshClient sshclient.Client) (string, error) {
 	return stdOut, nil
 }
 
-func getCPUModel(sshClient sshclient.Client) (string, error) {
-	out := sshClient.GetHardwareDetailsCPUModel()
+func getCPUModel(ctx context.Context, sshClient sshclient.Client) (string, error) {
+	out := sshClient.GetHardwareDetailsCPUModel(ctx)
 	if err := handleSSHError(out); err != nil {
 		return "", err
 	}
@@ -1033,8 +1033,8 @@ func getCPUModel(sshClient sshclient.Client) (string, error) {
 	return stdOut, nil
 }
 
-func getCPUClockGigahertz(sshClient sshclient.Client) (infrav1.ClockSpeed, error) {
-	out := sshClient.GetHardwareDetailsCPUClockGigahertz()
+func getCPUClockGigahertz(ctx context.Context, sshClient sshclient.Client) (infrav1.ClockSpeed, error) {
+	out := sshClient.GetHardwareDetailsCPUClockGigahertz(ctx)
 	if err := handleSSHError(out); err != nil {
 		return infrav1.ClockSpeed(""), err
 	}
@@ -1047,8 +1047,8 @@ func getCPUClockGigahertz(sshClient sshclient.Client) (infrav1.ClockSpeed, error
 	return infrav1.ClockSpeed(stdOut), nil
 }
 
-func getCPUThreads(sshClient sshclient.Client) (int, error) {
-	out := sshClient.GetHardwareDetailsCPUThreads()
+func getCPUThreads(ctx context.Context, sshClient sshclient.Client) (int, error) {
+	out := sshClient.GetHardwareDetailsCPUThreads(ctx)
 	if err := handleSSHError(out); err != nil {
 		return 0, err
 	}
@@ -1066,8 +1066,8 @@ func getCPUThreads(sshClient sshclient.Client) (int, error) {
 	return threads, nil
 }
 
-func getCPUFlags(sshClient sshclient.Client) ([]string, error) {
-	out := sshClient.GetHardwareDetailsCPUFlags()
+func getCPUFlags(ctx context.Context, sshClient sshclient.Client) ([]string, error) {
+	out := sshClient.GetHardwareDetailsCPUFlags(ctx)
 	if err := handleSSHError(out); err != nil {
 		return nil, err
 	}
@@ -1122,7 +1122,7 @@ func (s *Service) actionPreProvisioning(ctx context.Context) actionResult {
 	}
 	sshClient := s.scope.SSHClientFactory.NewClient(in)
 
-	out := sshClient.GetHostName()
+	out := sshClient.GetHostName(ctx)
 	if out.Err != nil || out.StdErr != "" {
 		ctrl.LoggerFrom(ctx).Info("pre-provision: rescue system not reachable. Will try again",
 			"sshOutput", out.String())
@@ -1170,7 +1170,7 @@ func (s *Service) actionImageInstalling(ctx context.Context) actionResult {
 	}
 	sshClient := s.scope.SSHClientFactory.NewClient(in)
 
-	out := sshClient.GetHostName()
+	out := sshClient.GetHostName(ctx)
 	if out.Err != nil || out.StdErr != "" {
 		ctrl.LoggerFrom(ctx).Info("image-installing: rescue system not reachable. Will try again",
 			"sshOutput", out.String())
@@ -1194,7 +1194,7 @@ func (s *Service) actionImageInstalling(ctx context.Context) actionResult {
 	if s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.UsesImageURLCommand() {
 		return s.actionImageInstallingImageURLCommand(ctx, sshClient)
 	}
-	state, err := sshClient.GetInstallImageState()
+	state, err := sshClient.GetInstallImageState(ctx)
 	if err != nil {
 		return actionError{err: fmt.Errorf("failed to get state of installimage processes: %w", err)}
 	}
@@ -1217,7 +1217,7 @@ func (s *Service) actionImageInstalling(ctx context.Context) actionResult {
 func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshClient sshclient.Client) actionResult {
 	host := s.scope.HetznerBareMetalHost
 
-	state, logFile, err := sshClient.StateOfImageURLCommand()
+	state, logFile, err := sshClient.StateOfImageURLCommand(ctx)
 	if err != nil {
 		return actionError{err: fmt.Errorf("StateOfImageURLCommand failed: %w", err)}
 	}
@@ -1255,7 +1255,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		}
 
 		// Reboot via SSH
-		if err := sshClient.Reboot().Err; err != nil {
+		if err := sshClient.Reboot(ctx).Err; err != nil {
 			err = fmt.Errorf("failed to reboot server (after install-image): %w", err)
 			record.Warn(s.scope.HetznerBareMetalHost, "RebootFailed", err.Error())
 			return actionError{err: err}
@@ -1309,7 +1309,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 
 		// get the information about storage devices again to have the latest names.
 		// Device names can change during restart.
-		storage, err := obtainHardwareDetailsStorage(sshClient)
+		storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
 		if err != nil {
 			return actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
 		}
@@ -1435,7 +1435,7 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 	// If there is a Linux OS on an other disk, then the reboot after the provisioning
 	// will likely fail, because the machine boots into the other operating system.
 	// We want detect that early, and not start the provisioning process.
-	out := sshClient.DetectLinuxOnAnotherDisk(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN())
+	out := sshClient.DetectLinuxOnAnotherDisk(ctx, s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN())
 	if out.Err != nil {
 		var exitErr *ssh.ExitError
 		if errors.As(out.Err, &exitErr) && exitErr.ExitStatus() > 0 {
@@ -1476,14 +1476,14 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 
 	record.Event(s.scope.HetznerBareMetalHost, "InstallImagePreflightCheckSuccessful", "Rescue system reachable, disks look good.")
 
-	autoSetupInput, actionRes := s.createAutoSetupInput(sshClient)
+	autoSetupInput, actionRes := s.createAutoSetupInput(ctx, sshClient)
 	if actionRes != nil {
 		return actionRes
 	}
 
 	autoSetup := buildAutoSetup(s.scope.HetznerBareMetalHost.Spec.Status.InstallImage, autoSetupInput)
 
-	out = sshClient.CreateAutoSetup(autoSetup)
+	out = sshClient.CreateAutoSetup(ctx, autoSetup)
 	if out.Err != nil {
 		return actionError{err: fmt.Errorf("failed to create autosetup: %q %q %w", out.StdOut, out.StdErr, out.Err)}
 	}
@@ -1525,14 +1525,14 @@ echo %q
 # end of install cloud-init data
 `, postInstallScript, s.scope.Hostname(), cloudInitData, PostInstallScriptFinished)
 
-	if err := handleSSHError(sshClient.CreatePostInstallScript(postInstallScript)); err != nil {
+	if err := handleSSHError(sshClient.CreatePostInstallScript(ctx, postInstallScript)); err != nil {
 		return actionError{err: fmt.Errorf("failed to create post install script %s: %w", postInstallScript, err)}
 	}
 
 	record.Event(s.scope.HetznerBareMetalHost, "InstallingMachineImageStarted",
 		s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.Image.String())
 
-	out = sshClient.UntarTGZ()
+	out = sshClient.UntarTGZ(ctx)
 	if out.Err != nil {
 		record.Warnf(s.scope.HetznerBareMetalHost, "UntarInstallimageTgzFailed", "err: %s, stderr: %s", out.Err.Error(), out.StdErr)
 		return actionError{err: fmt.Errorf("UntarInstallimageTgzFailed: %w", out.Err)}
@@ -1541,7 +1541,7 @@ echo %q
 		s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.Image.String())
 
 	// Execute install image
-	out = sshClient.ExecuteInstallImage(postInstallScript != "")
+	out = sshClient.ExecuteInstallImage(ctx, postInstallScript != "")
 	if out.Err != nil {
 		record.Warnf(s.scope.HetznerBareMetalHost, "ExecuteInstallImageFailed", out.String())
 		return actionError{err: fmt.Errorf("failed to execute installimage: %w", out.Err)}
@@ -1551,7 +1551,7 @@ echo %q
 }
 
 func (s *Service) actionImageInstallingFinished(ctx context.Context, sshClient sshclient.Client) actionResult {
-	output, err := sshClient.GetResultOfInstallImage()
+	output, err := sshClient.GetResultOfInstallImage(ctx)
 	if err != nil {
 		return actionError{
 			err: fmt.Errorf("GetResultOfInstallImage failed: %w", err),
@@ -1581,7 +1581,7 @@ func (s *Service) actionImageInstallingFinished(ctx context.Context, sshClient s
 		return actionError{err: fmt.Errorf("failed to update name of host in robot API: %w", err)}
 	}
 
-	out := sshClient.Reboot()
+	out := sshClient.Reboot(ctx)
 	if err := handleSSHError(out); err != nil {
 		err = fmt.Errorf("failed to reboot server (after install-image): %w", err)
 		record.Warn(s.scope.HetznerBareMetalHost, "RebootFailed", err.Error())
@@ -1597,7 +1597,7 @@ func (s *Service) actionImageInstallingFinished(ctx context.Context, sshClient s
 	return actionComplete{}
 }
 
-func (s *Service) createAutoSetupInput(sshClient sshclient.Client) (autoSetupInput, actionResult) {
+func (s *Service) createAutoSetupInput(ctx context.Context, sshClient sshclient.Client) (autoSetupInput, actionResult) {
 	image := s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.Image
 	imagePath, needsDownload, errorMessage := image.GetDetails()
 	if errorMessage != "" {
@@ -1612,7 +1612,7 @@ func (s *Service) createAutoSetupInput(sshClient sshclient.Client) (autoSetupInp
 		return autoSetupInput{}, s.recordActionFailure(infrav1.ProvisioningError, errorMessage)
 	}
 	if needsDownload {
-		out := sshClient.DownloadImage(imagePath, image.URL)
+		out := sshClient.DownloadImage(ctx, imagePath, image.URL)
 		if err := handleSSHError(out); err != nil {
 			err := fmt.Errorf("failed to download image: %s %s %w", out.StdOut, out.StdErr, err)
 			v1beta1conditions.MarkFalse(
@@ -1629,7 +1629,7 @@ func (s *Service) createAutoSetupInput(sshClient sshclient.Client) (autoSetupInp
 
 	// get the information about storage devices again to have the latest names which are then taken for installimage
 	// Device names can change during restart.
-	storage, err := obtainHardwareDetailsStorage(sshClient)
+	storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
 	if err != nil {
 		return autoSetupInput{}, actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
 	}
@@ -1669,7 +1669,7 @@ func getDeviceNames(wwn []string, storageDevices []infrav1.Storage) []string {
 	return deviceNames
 }
 
-func analyzeSSHOutputInstallImage(out sshclient.Output, sshClient sshclient.Client, port int) (isTimeout, isConnectionRefused bool, reterr error) {
+func analyzeSSHOutputInstallImage(ctx context.Context, out sshclient.Output, sshClient sshclient.Client, port int) (isTimeout, isConnectionRefused bool, reterr error) {
 	// check err
 	if out.Err != nil {
 		switch {
@@ -1677,12 +1677,12 @@ func analyzeSSHOutputInstallImage(out sshclient.Output, sshClient sshclient.Clie
 			isTimeout = true
 			return isTimeout, false, nil
 		case sshclient.IsAuthenticationFailedError(out.Err):
-			if err := handleAuthenticationFailed(sshClient, port); err != nil {
+			if err := handleAuthenticationFailed(ctx, sshClient, port); err != nil {
 				return false, false, fmt.Errorf("original ssh error: %w. err: %w", out.Err, err)
 			}
-			return false, false, handleAuthenticationFailed(sshClient, port)
+			return false, false, handleAuthenticationFailed(ctx, sshClient, port)
 		case sshclient.IsConnectionRefusedError(out.Err):
-			return false, verifyConnectionRefused(sshClient, port), nil
+			return false, verifyConnectionRefused(ctx, sshClient, port), nil
 		}
 
 		return false, false, fmt.Errorf("unhandled ssh error while getting hostname: %w", out.Err)
@@ -1709,10 +1709,10 @@ func analyzeSSHOutputInstallImage(out sshclient.Output, sshClient sshclient.Clie
 	return false, false, fmt.Errorf("%w: %s", errUnexpectedHostName, hostname)
 }
 
-func handleAuthenticationFailed(sshClient sshclient.Client, port int) error {
+func handleAuthenticationFailed(ctx context.Context, sshClient sshclient.Client, port int) error {
 	// Check whether we are in the wrong system in the case that rescue and os system might be running on the same port.
 	if port == rescuePort {
-		if sshClient.GetHostName().Err == nil {
+		if sshClient.GetHostName(ctx).Err == nil {
 			// We are in the wrong system, so return false, false, nil
 			return nil
 		}
@@ -1720,11 +1720,11 @@ func handleAuthenticationFailed(sshClient sshclient.Client, port int) error {
 	return errWrongSSHKey
 }
 
-func verifyConnectionRefused(sshClient sshclient.Client, port int) bool {
+func verifyConnectionRefused(ctx context.Context, sshClient sshclient.Client, port int) bool {
 	// Check whether we are in the wrong system in the case that rescue and os system might be running on the same port.
 	if port != rescuePort {
 		// Check whether we are in the wrong system
-		if sshClient.GetHostName().Err == nil {
+		if sshClient.GetHostName(ctx).Err == nil {
 			// We are in the wrong system - this error is not temporary
 			return false
 		}
@@ -1755,7 +1755,7 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 	// Check hostname with sshClient
 	wantHostName := s.scope.Hostname()
 
-	out := sshClient.GetHostName()
+	out := sshClient.GetHostName(ctx)
 	hostname := trimLineBreak(out.StdOut)
 	if hostname != wantHostName {
 		// give the reboot some time until it takes effect
@@ -1818,7 +1818,7 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 			s.scope.Info("Unhandled type of actionResult",
 				"actionResult", ar)
 		}
-		out := sshClient.GetCloudInitOutput()
+		out := sshClient.GetCloudInitOutput(ctx)
 		exitStatus, exitError := out.ExitStatus()
 		if exitError != nil {
 			err = fmt.Errorf("failed to get cloud init output (ssh connection failed): %w", errors.Join(exitError, err))
@@ -1868,7 +1868,7 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 }
 
 func (s *Service) checkCloudInitStatus(ctx context.Context, sshClient sshclient.Client) (actionResult, string) {
-	out := sshClient.CloudInitStatus()
+	out := sshClient.CloudInitStatus(ctx)
 
 	status, err := out.ExitStatus()
 	if err != nil {
@@ -1890,7 +1890,7 @@ func (s *Service) checkCloudInitStatus(ctx context.Context, sshClient sshclient.
 
 	case strings.Contains(stdOut, "status: disabled"):
 		// Reboot needs to be triggered again - did not start yet
-		out = sshClient.Reboot()
+		out = sshClient.Reboot(ctx)
 		msg := "cloud-init-status was 'disabled'"
 		if err := handleSSHError(out); err != nil {
 			return actionError{err: fmt.Errorf("failed to reboot (%s): %w", msg, err)}, ""
@@ -1923,22 +1923,22 @@ func (s *Service) handleCloudInitNotStarted(ctx context.Context) actionResult {
 		Port:       s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage,
 		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
 	})
-	out := oldSSHClient.CheckCloudInitLogsForSigTerm()
+	out := oldSSHClient.CheckCloudInitLogsForSigTerm(ctx)
 	if err := handleSSHError(out); err != nil {
 		return actionError{err: fmt.Errorf("failed to CheckCloudInitLogsForSigTerm: %w", err)}
 	}
 
 	if trimLineBreak(out.StdOut) != "" {
 		// it was not successful. Prepare and reboot again
-		out = oldSSHClient.CleanCloudInitLogs()
+		out = oldSSHClient.CleanCloudInitLogs(ctx)
 		if err := handleSSHError(out); err != nil {
 			return actionError{err: fmt.Errorf("failed to CleanCloudInitLogs: %w", err)}
 		}
-		out = oldSSHClient.CleanCloudInitInstances()
+		out = oldSSHClient.CleanCloudInitInstances(ctx)
 		if err := handleSSHError(out); err != nil {
 			return actionError{err: fmt.Errorf("failed to CleanCloudInitInstances: %w", err)}
 		}
-		out = oldSSHClient.Reboot()
+		out = oldSSHClient.Reboot(ctx)
 		if err := handleSSHError(out); err != nil {
 			return actionError{err: fmt.Errorf("failed to reboot (handleCloudInitNotStarted): %w", err)}
 		}
@@ -2155,7 +2155,7 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 
 			sshClient := s.scope.SSHClientFactory.NewClient(in)
 
-			out := sshClient.Reboot()
+			out := sshClient.Reboot(ctx)
 			if err := handleSSHError(out); err != nil {
 				v1beta1conditions.MarkFalse(host, infrav1.RebootSucceededCondition,
 					"RebootViaSSHFailed",
@@ -2247,7 +2247,7 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 }
 
 // next: None
-func (s *Service) actionDeprovisioning(_ context.Context) actionResult {
+func (s *Service) actionDeprovisioning(ctx context.Context) actionResult {
 	// Update name in robot API
 	if _, err := s.scope.RobotClient.SetBMServerName(
 		s.scope.HetznerBareMetalHost.Spec.ServerID,
@@ -2293,7 +2293,7 @@ func (s *Service) actionDeprovisioning(_ context.Context) actionResult {
 				Port:       s.scope.HetznerBareMetalHost.Spec.Status.SSHSpec.PortAfterInstallImage,
 				IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
 			})
-			out := sshClient.ResetKubeadm()
+			out := sshClient.ResetKubeadm(ctx)
 			s.scope.V(1).Info("Output of ResetKubeadm", "stdout", out.StdOut, "stderr", out.StdErr, "err", out.Err)
 			if out.Err != nil {
 				record.Warnf(s.scope.HetznerBareMetalHost, "FailedResetKubeAdm", "failed to reset kubeadm: %s", out.Err.Error())

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1680,7 +1680,7 @@ func analyzeSSHOutputInstallImage(ctx context.Context, out sshclient.Output, ssh
 			if err := handleAuthenticationFailed(ctx, sshClient, port); err != nil {
 				return false, false, fmt.Errorf("original ssh error: %w. err: %w", out.Err, err)
 			}
-			return false, false, handleAuthenticationFailed(ctx, sshClient, port)
+			return false, false, nil
 		case sshclient.IsConnectionRefusedError(out.Err):
 			return false, verifyConnectionRefused(ctx, sshClient, port), nil
 		}

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -135,8 +135,8 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 	It("returns continue when command is running", func() {
 		host := newBaseHost()
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateRunning, "", nil)
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 
@@ -149,9 +149,9 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 	It("reboots and completes when command finished successfully", func() {
 		host := newBaseHost()
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "LOGFILE-CONTENT", nil)
-		sshMock.On("Reboot").Return(sshclient.Output{})
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "LOGFILE-CONTENT", nil)
+		sshMock.On("Reboot", mock.Anything).Return(sshclient.Output{})
 
 		robot := robotmock.Client{}
 		robot.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
@@ -160,7 +160,7 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 
 		res := svc.actionImageInstalling(ctx)
 		Expect(res).To(BeAssignableToTypeOf(actionComplete{}))
-		Expect(sshMock.AssertCalled(GinkgoT(), "Reboot")).To(BeTrue())
+		Expect(sshMock.AssertCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 		Expect(robot.AssertCalled(GinkgoT(), "SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name)).To(BeTrue())
 		// error should be cleared
 		Expect(host.Spec.Status.ErrorMessage).To(Equal(""))
@@ -171,8 +171,8 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 	It("returns error when command failed", func() {
 		host := newBaseHost()
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateFailed, "some logs", nil)
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFailed, "some logs", nil)
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 		res := svc.actionImageInstalling(ctx)
@@ -191,8 +191,8 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 
 		// Build service with fake client containing the bootstrap secret
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 		commandPath := filepath.Join(baremetalImageURLCommandDir, host.Spec.Status.InstallImage.ImageURLCommand)
@@ -201,7 +201,7 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
 		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
 
-		sshMock.On("GetHardwareDetailsStorage").Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
+		sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
 		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
 			WWN: "eui.0025388801b4dff2",
 		}
@@ -218,8 +218,8 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		host.Spec.Status.UserData = &corev1.SecretReference{Name: "bootstrap-secret", Namespace: host.Namespace}
 
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 		commandPath := filepath.Join(baremetalImageURLCommandDir, host.Spec.Status.InstallImage.ImageURLCommand)
@@ -228,7 +228,7 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
 		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
 
-		sshMock.On("GetHardwareDetailsStorage").Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
+		sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
 		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
 			WWN: "eui.0025388801b4dff2",
 		}
@@ -244,8 +244,8 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		host.Spec.Status.RebootTriggeredAt = &sevenPlus
 
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-		sshMock.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateRunning, "", nil)
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 
@@ -306,9 +306,9 @@ var _ = Describe("obtainHardwareDetailsNics", func() {
 	DescribeTable("Complete successfully",
 		func(tc testCaseObtainHardwareDetailsNics) {
 			sshMock := &sshmock.Client{}
-			sshMock.On("GetHardwareDetailsNics").Return(sshclient.Output{StdOut: tc.stdout})
+			sshMock.On("GetHardwareDetailsNics", mock.Anything).Return(sshclient.Output{StdOut: tc.stdout})
 
-			Expect(obtainHardwareDetailsNics(sshMock)).Should(Equal(tc.expectedOutput))
+			Expect(obtainHardwareDetailsNics(context.Background(), sshMock)).Should(Equal(tc.expectedOutput))
 		},
 		Entry("proper response", testCaseObtainHardwareDetailsNics{
 			stdout: `name="eth0" model="Realtek Semiconductor Co." mac="a8:a1:59:94:19:42" ip="23.88.6.239/26" speedMbps="1000"
@@ -341,9 +341,9 @@ var _ = Describe("obtainHardwareDetailsStorage", func() {
 	DescribeTable("Complete successfully",
 		func(tc testCaseObtainHardwareDetailsStorage) {
 			sshMock := &sshmock.Client{}
-			sshMock.On("GetHardwareDetailsStorage").Return(sshclient.Output{StdOut: tc.stdout})
+			sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{StdOut: tc.stdout})
 
-			storageDevices, err := obtainHardwareDetailsStorage(sshMock)
+			storageDevices, err := obtainHardwareDetailsStorage(context.Background(), sshMock)
 			Expect(storageDevices).Should(Equal(tc.expectedOutput))
 			if tc.expectedErrorMessage != nil {
 				Expect(err.Error()).Should(ContainSubstring(*tc.expectedErrorMessage))
@@ -910,7 +910,7 @@ var _ = Describe("actionPreparing", func() {
 		robotMock.On("RebootBMServer", mock.Anything, infrav1.RebootTypeSoftware).Return(&models.ResetPost{}, nil)
 
 		sshMock := &sshmock.Client{}
-		sshMock.On("GetHostName").Return(sshclient.Output{})
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{})
 
 		service := newTestService(
 			host,
@@ -1114,9 +1114,9 @@ var _ = Describe("analyzeSSHOutputInstallImage", func() {
 			if !tc.errFromGetHostNameNil {
 				errFromGetHostName = errTest
 			}
-			sshMock.On("GetHostName").Return(sshclient.Output{Err: errFromGetHostName})
+			sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{Err: errFromGetHostName})
 
-			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(sshclient.Output{Err: tc.err}, sshMock, tc.port)
+			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(context.Background(), sshclient.Output{Err: tc.err}, sshMock, tc.port)
 			Expect(isTimeout).To(Equal(tc.expectedIsTimeout))
 			Expect(isConnectionRefused).To(Equal(tc.expectedIsConnectionRefused))
 			if tc.expectedErrMessage != "" {
@@ -1207,7 +1207,7 @@ var _ = Describe("analyzeSSHOutputInstallImage", func() {
 				StdErr: tc.stdErr,
 				Err:    err,
 			}
-			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(out, nil, 22)
+			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(context.Background(), out, nil, 22)
 			Expect(isTimeout).To(Equal(false))
 			Expect(isConnectionRefused).To(Equal(false))
 			if tc.expectedErrMessage != "" {
@@ -1256,7 +1256,7 @@ var _ = Describe("analyzeSSHOutputInstallImage", func() {
 				StdErr: tc.stdErr,
 				Err:    err,
 			}
-			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(out, nil, 22)
+			isTimeout, isConnectionRefused, err := analyzeSSHOutputInstallImage(context.Background(), out, nil, 22)
 			Expect(isTimeout).To(Equal(false))
 			Expect(isConnectionRefused).To(Equal(false))
 			if tc.expectedErrMessage != "" {
@@ -1471,7 +1471,7 @@ var _ = Describe("actionRegistering", func() {
 			)
 
 			sshMock := &sshmock.Client{}
-			sshMock.On("GetHostName").Return(tc.getHostNameOutput)
+			sshMock.On("GetHostName", mock.Anything).Return(tc.getHostNameOutput)
 
 			robotMock := robotmock.Client{}
 			robotMock.On("GetBootRescue", mock.Anything).Return(&models.Rescue{Active: false}, nil)
@@ -1497,22 +1497,22 @@ var _ = Describe("actionRegistering", func() {
 
 func registeringSSHMock(storageStdOut string) *sshmock.Client {
 	sshMock := &sshmock.Client{}
-	sshMock.On("GetHostName").Return(sshclient.Output{StdOut: "rescue"})
-	sshMock.On("GetHardwareDetailsRAM").Return(sshclient.Output{StdOut: "10000"})
-	sshMock.On("GetHardwareDetailsStorage").Return(sshclient.Output{
+	sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+	sshMock.On("GetHardwareDetailsRAM", mock.Anything).Return(sshclient.Output{StdOut: "10000"})
+	sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{
 		StdOut: storageStdOut,
 	})
-	sshMock.On("GetHardwareDetailsNics").Return(sshclient.Output{
+	sshMock.On("GetHardwareDetailsNics", mock.Anything).Return(sshclient.Output{
 		StdOut: `name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)" mac="a8:a1:59:94:19:42" ipv4="23.88.6.239/26" speedMbps="1000"
 name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller (rev 15)" mac="a8:a1:59:94:19:42" ip="2a01:4f8:272:3e0f::2/64" speedMbps="1000"`,
 	})
-	sshMock.On("GetHardwareDetailsCPUArch").Return(sshclient.Output{StdOut: "myarch"})
-	sshMock.On("GetHardwareDetailsCPUModel").Return(sshclient.Output{StdOut: "mymodel"})
-	sshMock.On("GetHardwareDetailsCPUClockGigahertz").Return(sshclient.Output{StdOut: "42654"})
-	sshMock.On("GetHardwareDetailsCPUFlags").Return(sshclient.Output{StdOut: "flag1 flag2 flag3"})
-	sshMock.On("GetHardwareDetailsCPUThreads").Return(sshclient.Output{StdOut: "123"})
-	sshMock.On("GetHardwareDetailsCPUCores").Return(sshclient.Output{StdOut: "12"})
-	sshMock.On("GetHardwareDetailsDebug").Return(sshclient.Output{StdOut: "Dummy output"})
+	sshMock.On("GetHardwareDetailsCPUArch", mock.Anything).Return(sshclient.Output{StdOut: "myarch"})
+	sshMock.On("GetHardwareDetailsCPUModel", mock.Anything).Return(sshclient.Output{StdOut: "mymodel"})
+	sshMock.On("GetHardwareDetailsCPUClockGigahertz", mock.Anything).Return(sshclient.Output{StdOut: "42654"})
+	sshMock.On("GetHardwareDetailsCPUFlags", mock.Anything).Return(sshclient.Output{StdOut: "flag1 flag2 flag3"})
+	sshMock.On("GetHardwareDetailsCPUThreads", mock.Anything).Return(sshclient.Output{StdOut: "123"})
+	sshMock.On("GetHardwareDetailsCPUCores", mock.Anything).Return(sshclient.Output{StdOut: "12"})
+	sshMock.On("GetHardwareDetailsDebug", mock.Anything).Return(sshclient.Output{StdOut: "Dummy output"})
 	return sshMock
 }
 
@@ -1648,20 +1648,20 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				helpers.WithConsumerRef(),
 			)
 			sshMock := &sshmock.Client{}
-			sshMock.On("GetHostName").Return(in.outSSHClientGetHostName)
-			sshMock.On("CloudInitStatus").Return(in.outSSHClientCloudInitStatus)
-			sshMock.On("CheckCloudInitLogsForSigTerm").Return(in.outSSHClientCheckSigterm)
-			sshMock.On("CleanCloudInitLogs").Return(sshclient.Output{})
-			sshMock.On("CleanCloudInitInstances").Return(sshclient.Output{})
-			sshMock.On("Reboot").Return(sshclient.Output{})
-			sshMock.On("GetCloudInitOutput").Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
+			sshMock.On("GetHostName", mock.Anything).Return(in.outSSHClientGetHostName)
+			sshMock.On("CloudInitStatus", mock.Anything).Return(in.outSSHClientCloudInitStatus)
+			sshMock.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(in.outSSHClientCheckSigterm)
+			sshMock.On("CleanCloudInitLogs", mock.Anything).Return(sshclient.Output{})
+			sshMock.On("CleanCloudInitInstances", mock.Anything).Return(sshclient.Output{})
+			sshMock.On("Reboot", mock.Anything).Return(sshclient.Output{})
+			sshMock.On("GetCloudInitOutput", mock.Anything).Return(sshclient.Output{StdOut: "dummy content of /var/log/cloud-init-output.log"})
 
 			oldSSHMock := &sshmock.Client{}
-			oldSSHMock.On("CloudInitStatus").Return(in.outOldSSHClientCloudInitStatus)
-			oldSSHMock.On("CheckCloudInitLogsForSigTerm").Return(in.outOldSSHClientCheckSigterm)
-			oldSSHMock.On("CleanCloudInitLogs").Return(sshclient.Output{})
-			oldSSHMock.On("CleanCloudInitInstances").Return(sshclient.Output{})
-			oldSSHMock.On("Reboot").Return(sshclient.Output{})
+			oldSSHMock.On("CloudInitStatus", mock.Anything).Return(in.outOldSSHClientCloudInitStatus)
+			oldSSHMock.On("CheckCloudInitLogsForSigTerm", mock.Anything).Return(in.outOldSSHClientCheckSigterm)
+			oldSSHMock.On("CleanCloudInitLogs", mock.Anything).Return(sshclient.Output{})
+			oldSSHMock.On("CleanCloudInitInstances", mock.Anything).Return(sshclient.Output{})
+			oldSSHMock.On("Reboot", mock.Anything).Return(sshclient.Output{})
 
 			robotMock := robotmock.Client{}
 			robotMock.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
@@ -1674,34 +1674,34 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				Expect(host.Spec.Status.ErrorType).To(Equal(in.expectedErrorType))
 			}
 			if in.expectsSSHClientCallCloudInitStatus {
-				Expect(sshMock.AssertCalled(GinkgoT(), "CloudInitStatus")).To(BeTrue())
+				Expect(sshMock.AssertCalled(GinkgoT(), "CloudInitStatus", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(sshMock.AssertNotCalled(GinkgoT(), "CloudInitStatus")).To(BeTrue())
+				Expect(sshMock.AssertNotCalled(GinkgoT(), "CloudInitStatus", mock.Anything)).To(BeTrue())
 			}
 			if in.expectsSSHClientCallCheckSigterm {
-				Expect(sshMock.AssertCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm")).To(BeTrue())
+				Expect(sshMock.AssertCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(sshMock.AssertNotCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm")).To(BeTrue())
+				Expect(sshMock.AssertNotCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm", mock.Anything)).To(BeTrue())
 			}
 			if in.expectsSSHClientCallReboot {
-				Expect(sshMock.AssertCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(sshMock.AssertCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(sshMock.AssertNotCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(sshMock.AssertNotCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			}
 			if in.expectsOldSSHClientCallCloudInitStatus {
-				Expect(oldSSHMock.AssertCalled(GinkgoT(), "CloudInitStatus")).To(BeTrue())
+				Expect(oldSSHMock.AssertCalled(GinkgoT(), "CloudInitStatus", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "CloudInitStatus")).To(BeTrue())
+				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "CloudInitStatus", mock.Anything)).To(BeTrue())
 			}
 			if in.expectsOldSSHClientCallCheckSigterm {
-				Expect(oldSSHMock.AssertCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm")).To(BeTrue())
+				Expect(oldSSHMock.AssertCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm")).To(BeTrue())
+				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "CheckCloudInitLogsForSigTerm", mock.Anything)).To(BeTrue())
 			}
 			if in.expectsOldSSHClientCallReboot {
-				Expect(oldSSHMock.AssertCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(oldSSHMock.AssertCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(oldSSHMock.AssertNotCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			}
 		},
 		Entry("correct hostname, cloud init running",
@@ -1855,8 +1855,8 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {
 			} else {
 				hostNameOutput = sshclient.Output{Err: timeout}
 			}
-			sshMock.On("GetHostName").Return(hostNameOutput)
-			sshMock.On("Reboot").Return(sshclient.Output{})
+			sshMock.On("GetHostName", mock.Anything).Return(hostNameOutput)
+			sshMock.On("Reboot", mock.Anything).Return(sshclient.Output{})
 
 			service := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 
@@ -1870,9 +1870,9 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {
 			// Phase 1 (storedBootID == ""): SSH Reboot should be called.
 			// Phase 2 (storedBootID != ""): SSH Reboot should not be called again.
 			if tc.shouldHaveRebootAnnotation && !tc.rebooted {
-				Expect(sshMock.AssertCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(sshMock.AssertCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			} else {
-				Expect(sshMock.AssertNotCalled(GinkgoT(), "Reboot")).To(BeTrue())
+				Expect(sshMock.AssertNotCalled(GinkgoT(), "Reboot", mock.Anything)).To(BeTrue())
 			}
 		},
 		Entry("reboot desired, but not performed yet", testCaseActionProvisioned{

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -489,7 +489,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 
 	// There is a delay between the server reporting StatusRunning and SSH actually becoming
 	// reachable. During this window, ECONNREFUSED is expected, so we retry on that error.
-	err = sshClient.Reboot().Err
+	err = sshClient.Reboot(ctx).Err
 	if err != nil {
 		if errors.Is(err, syscall.ECONNREFUSED) {
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
@@ -553,7 +553,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (waiting for rescue running): %w", err)
 	}
 
-	output := sshClient.GetHostName()
+	output := sshClient.GetHostName(ctx)
 	err = output.Err
 	if err != nil {
 		var msg string
@@ -650,7 +650,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (wait for image-url-command): %w", err)
 	}
 
-	state, logFile, err := hcloudSSHClient.StateOfImageURLCommand()
+	state, logFile, err := hcloudSSHClient.StateOfImageURLCommand(ctx)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("StateOfImageURLCommand failed: %w", err)
 	}
@@ -683,7 +683,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// The image got installed. Now reboot in the real operating system.
-		if hcloudSSHClient.Reboot().Err != nil {
+		if hcloudSSHClient.Reboot(ctx).Err != nil {
 			return reconcile.Result{}, fmt.Errorf("reboot after ImageURLCommand failed: %w",
 				err)
 		}

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -683,9 +683,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// The image got installed. Now reboot in the real operating system.
-		if hcloudSSHClient.Reboot(ctx).Err != nil {
-			return reconcile.Result{}, fmt.Errorf("reboot after ImageURLCommand failed: %w",
-				err)
+		if rebootErr := hcloudSSHClient.Reboot(ctx).Err; rebootErr != nil {
+			return reconcile.Result{}, fmt.Errorf("reboot after ImageURLCommand failed: %w", rebootErr)
 		}
 
 		hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1129,7 +1129,7 @@ var _ = Describe("Reconcile", func() {
 			Status:        hcloud.ServerStatusRunning,
 		}, nil).Once()
 
-		testEnv.HCloudSSHClient.On("Reboot").Return(sshclient.Output{
+		testEnv.HCloudSSHClient.On("Reboot", mock.Anything).Return(sshclient.Output{
 			Err:    nil,
 			StdOut: "ok",
 			StdErr: "",
@@ -1147,7 +1147,7 @@ var _ = Describe("Reconcile", func() {
 			Name:   "hcloudmachinenameWithRescueEnabled",
 			Status: hcloud.ServerStatusRunning,
 		}, nil).Once()
-		testEnv.HCloudSSHClient.On("GetHostName").Return(sshclient.Output{
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: "rescue",
 			StdErr: "",
 			Err:    nil,
@@ -1162,12 +1162,12 @@ var _ = Describe("Reconcile", func() {
 		startImageURLCommandMock.Parent.AssertNumberOfCalls(GinkgoT(), "StartImageURLCommand", 1)
 
 		By("reconcile again --------------------------------------------------------")
-		testEnv.HCloudSSHClient.On("GetHostName").Return(sshclient.Output{
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: "rescue",
 			StdErr: "",
 			Err:    nil,
 		})
-		testEnv.HCloudSSHClient.On("StateOfImageURLCommand").Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "output-of-image-url-command", nil)
+		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "output-of-image-url-command", nil)
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:            1,
 			Name:          "hcloudmachinenameWithRescueEnabled",


### PR DESCRIPTION
**What this PR does / why we need it**:

The ssh client used by caph did not respect `context.Context`, so it could not honor cancellation or deadlines. This PR adds `ctx context.Context` as the first parameter on every method of the `Client` interface (option 2 from the discussion in #1816). Internally, the dial uses `net.Dialer.DialContext` and `context.AfterFunc` closes the transport when ctx fires, cancelling the SSH handshake, `NewSession`, and `sess.Run`. 

**Which issue(s) this PR fixes**
Fixes #1816

**Special notes for your reviewer**:

- The two drive-by bug fixes are a separate commit (`:bug:`) for easy review:
  - `server.go` (`handleBootStateRunningImageCommand`): wrapped a stale `nil` err from `StateOfImageURLCommand` instead of the actual `Reboot` error.
  - `host.go` (`analyzeSSHOutputInstallImage`): called `handleAuthenticationFailed` twice on the success path.



**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests