### PR TITLE
🌱 Bump Go to 1.25

### DIFF
--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -4,7 +4,7 @@
   },
   // https://docs.renovatebot.com/configuration-options/#constraints
   "constraints": {
-    "go": "1.22"
+    "go": "1.25"
   },
   packageRules: [
     {

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.22"
+  go: "1.25"
   modules-download-mode: readonly
   allow-parallel-runners: true
 linters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syself/cluster-api-provider-hetzner
 
-go 1.24.5
+go 1.25.7
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/images/caph/Dockerfile
+++ b/images/caph/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.24.5-bullseye@sha256:62ba6b19de03e891f7fa1001326bd48411f2626ff35e7ba5b9d890711ce581d9 \
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.25.9-bookworm@sha256:298734aec230b5f3e8cee450ce6d7eccc39f1797ba548ee90d57e9803030c6c3 \
     AS build
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump Go from 1.24.5 to 1.25.0

**Which issue(s) this PR fixes:**
None.

**Special notes for your reviewer**:
None.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
