### PR TITLE
🌱 Improve Quick Start Guide 

### DIFF
--- a/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
+++ b/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
@@ -22,7 +22,7 @@ There are several tasks that have to be completed before a workload cluster can 
 
 1. Create a new [HCloud project](https://console.hetzner.cloud/projects).
 1. Generate an API token with read and write access. You'll find this if you click on the project and go to "security".
-1. If you want to use it, generate an SSH key, upload the public key to HCloud (also via "security"), and give it a name. Read more about [Managing SSH Keys](/docs/caph/02-topics/01-managing-ssh-keys.md).
+2. Generate an SSH key, upload the public key to HCloud (also via "security"), and give it a name. Read more about [Managing SSH Keys](/docs/caph/02-topics/01-managing-ssh-keys.md).
 
 ## Bootstrap or Management Cluster Installation
 
@@ -107,7 +107,9 @@ Optional Variables:
   - WORKER_MACHINE_COUNT         (defaults to 0)
 ```
 
-## Create a secret for hcloud only
+## Create the HCloud secret
+
+This guide covers the pure HCloud flow (no bare metal), so we only create the HCloud secret here.
 
 In order for the provider integration hetzner to communicate with the Hetzner API ([HCloud API](https://docs.hetzner.cloud/)), we need to create a secret with the access data. The secret must be in the same namespace as the other CRs.
 
@@ -118,13 +120,23 @@ In order for the provider integration hetzner to communicate with the Hetzner AP
 Use the below command to create the required secret with the access data:
 
 ```shell
-kubectl create secret generic hetzner --from-literal=hcloud=$HCLOUD_TOKEN
+kubectl create secret generic hcloud --from-literal=hcloud=$HCLOUD_TOKEN
 ```
 
 Patch the created secret so that it can be automatically moved to the target cluster later. The following command helps you do that:
 
 ```shell
-kubectl patch secret hetzner -p '{"metadata":{"labels":{"clusterctl.cluster.x-k8s.io/move":""}}}'
+kubectl patch secret hcloud -p '{"metadata":{"labels":{"clusterctl.cluster.x-k8s.io/move":""}}}'
 ```
 
-The secret name and the tokens can also be customized in the cluster template.
+Why one secret with one key (`hcloud`) is enough: the cluster template's `hetznerSecretRef` is configured to read the token from key `hcloud`. CAPH then auto-syncs this secret into the workload cluster's `kube-system` namespace and, for backward compatibility, also exposes the token under key `token`. That single secret therefore satisfies the Syself CCM (reads file `hcloud`), the upstream HCloud CCM, and the Hetzner CSI driver (both expect key `token`) — without any per-component overrides. You do not need to create a secret in the workload cluster manually.
+
+## Verify the secret
+
+Before applying the cluster, confirm the secret exists with a non-empty value:
+
+```shell
+kubectl get secret hcloud -o jsonpath='{.data.hcloud}' | base64 -d | wc -c
+```
+
+You should see roughly 64 (the length of an HCloud token). An empty output means the secret name or key is wrong, and the controller will fail to reconcile the cluster.

--- a/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
+++ b/docs/caph/01-getting-started/02-quickstart/02-management-cluster-setup.md
@@ -129,7 +129,7 @@ Patch the created secret so that it can be automatically moved to the target clu
 kubectl patch secret hcloud -p '{"metadata":{"labels":{"clusterctl.cluster.x-k8s.io/move":""}}}'
 ```
 
-Why one secret with one key (`hcloud`) is enough: the cluster template's `hetznerSecretRef` is configured to read the token from key `hcloud`. CAPH then auto-syncs this secret into the workload cluster's `kube-system` namespace and, for backward compatibility, also exposes the token under key `token`. That single secret therefore satisfies the Syself CCM (reads file `hcloud`), the upstream HCloud CCM, and the Hetzner CSI driver (both expect key `token`) — without any per-component overrides. You do not need to create a secret in the workload cluster manually.
+This is the only secret you need to create. CAPH will copy it into the workload cluster automatically once the cluster is up, so the CCM and CSI installs on the next page can use it directly.
 
 ## Verify the secret
 

--- a/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
+++ b/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
@@ -56,65 +56,81 @@ To verify the first control plane is up, use the following command:
 kubectl get kubeadmcontrolplane
 ```
 
+Wait until the `INITIALIZED` column reports `True` before moving on. The `READY` column will stay `False` until we install a CNI in the next step — that is expected. If you'd like to follow the progression live, run `kubectl get kubeadmcontrolplane -w`.
+
 {% callout %}
 
-The control plane won’t be `ready` until we install a CNI in the next step.
+If you fetch the kubeconfig (next step) before `INITIALIZED` is `True`, kube-apiserver will not be listening yet and `helm` / `kubectl` calls will fail with `Kubernetes cluster unreachable: ... EOF`.
 
 {% /callout %}
 
-After the first control plane node is up and running, we can retrieve the kubeconfig of the workload cluster with:
+Once initialized, retrieve the kubeconfig of the workload cluster:
 
 ```shell
 export CAPH_WORKER_CLUSTER_KUBECONFIG=/tmp/workload-kubeconfig
 clusterctl get kubeconfig my-cluster > $CAPH_WORKER_CLUSTER_KUBECONFIG
 ```
 
+A quick reachability check before installing the CNI:
+
+```shell
+KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG kubectl get --raw='/readyz'
+```
+
+You should see `ok` (a few component-level failures are still acceptable at this stage). If the call hangs or returns an EOF, give it another minute and retry.
+
 ## Deploying the CNI solution
 
-Cilium is used as a CNI solution in this guide. The following command deploys it to your cluster:
-
-The file `templates/cilium/values.yaml` is a repo-provided Helm values file in this repository.
-Before running the command, make sure this file exists at that path in your working environment
-(for example, by using it from a local checkout of this repo or copying it from
-`templates/cilium/values.yaml` into your working directory setup).
+Cilium is used as a CNI solution in this guide. The values file lives in this repo at `templates/cilium/values.yaml`; we install it directly from the raw URL:
 
 ```shell
 helm repo add cilium https://helm.cilium.io/
 
 KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install cilium cilium/cilium \
 --namespace kube-system \
--f templates/cilium/values.yaml
+-f https://raw.githubusercontent.com/syself/cluster-api-provider-hetzner/main/templates/cilium/values.yaml
 ```
 
 You can, of course, also install an alternative CNI, e.g., calico.
 
-## Deploy the CCM
+## Deploy the Cloud Controller Manager (CCM)
 
-The CCM (Cloud Controller Manager) runs in the workload cluster and integrates Kubernetes with the
-Hetzner APIs. In practice, it is responsible for tasks such as setting the `ProviderID` on nodes
-and managing load balancers.
+The CCM runs in the workload cluster and integrates Kubernetes with the Hetzner APIs. In practice, it is responsible for tasks such as setting the `ProviderID` on nodes and managing load balancers. You need to install a CCM in this flow so the workload cluster can properly interact with Hetzner infrastructure.
 
-You need to install a CCM in this flow so the workload cluster can properly interact with Hetzner
-infrastructure.
+CAPH already syncs the `hcloud` secret you created on the previous page into the workload cluster's `kube-system` namespace, so the CCM only needs to be pointed at it (the chart default is `hetzner`, so we override `secret.name`):
 
-### Deploy Syself Cloud Controller Manager
+```shell
+helm repo add syself https://charts.syself.com
+helm repo update syself
 
-The following `make` command will install the Syself CCM in your workload cluster:
+KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install ccm syself/ccm-hetzner \
+  --version 2.0.6 \
+  --namespace kube-system \
+  --set secret.name=hcloud
+```
 
-`make install-ccm-in-wl-cluster`
+### Using the upstream Hetzner CCM instead
 
-For upstream HCloud CCM instructions and bare-metal ProviderID format details, see [Baremetal
-Docs](/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md#deploying-the-hetzner-cloud-controller-manager)
+The upstream `hcloud-cloud-controller-manager` static manifest (`deploy/ccm.yaml`) is hardcoded to read the token from secret `hcloud` with key `token`. Even though the management secret you created on the previous page only has the key `hcloud`, CAPH's compatibility shim writes the workload-cluster copy with **both** keys (`hcloud` and `token`) — so the upstream manifest works as-is, no patching required:
+
+```shell
+KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG kubectl apply \
+  -f https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/main/deploy/ccm.yaml
+```
+
+If you install the upstream CCM via its Helm chart instead, the defaults also point at secret `hcloud` / key `token`, so no `--set` overrides are needed.
+
+For upstream CCM details and bare-metal `ProviderID` format, see the [Baremetal Docs](/docs/caph/02-topics/05-baremetal/03-creating-workload-cluster.md#deploying-the-hetzner-cloud-controller-manager).
 
 ## Deploying the CSI (optional)
 
+The Hetzner CSI chart lives in the `hcloud` Helm repo, which we add first. The chart's default `controller.hcloudToken.existingSecret` already points at secret `hcloud` with key `token`, which matches what CAPH wrote into the workload cluster — so no overrides are needed beyond the storage class definition:
+
 ```shell
+helm repo add hcloud https://charts.hetzner.cloud
+helm repo update hcloud
+
 cat << EOF > csi-values.yaml
-controller:
-  hcloudToken:
-    existingSecret:
-      name: hetzner
-      key: hcloud
 storageClasses:
 - name: hcloud-volumes
   defaultStorageClass: true

--- a/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
+++ b/docs/caph/01-getting-started/02-quickstart/03-creating-a-workload-cluster.md
@@ -97,6 +97,13 @@ You can, of course, also install an alternative CNI, e.g., calico.
 
 The CCM runs in the workload cluster and integrates Kubernetes with the Hetzner APIs. In practice, it is responsible for tasks such as setting the `ProviderID` on nodes and managing load balancers. You need to install a CCM in this flow so the workload cluster can properly interact with Hetzner infrastructure.
 
+You have two options here:
+
+- **Syself CCM**: the `ccm-hetzner` chart maintained by Syself.
+- **Hetzner CCM**: the upstream `hcloud-cloud-controller-manager` from Hetzner Cloud.
+
+### Syself CCM
+
 CAPH already syncs the `hcloud` secret you created on the previous page into the workload cluster's `kube-system` namespace, so the CCM only needs to be pointed at it (the chart default is `hetzner`, so we override `secret.name`):
 
 ```shell
@@ -109,7 +116,7 @@ KUBECONFIG=$CAPH_WORKER_CLUSTER_KUBECONFIG helm upgrade --install ccm syself/ccm
   --set secret.name=hcloud
 ```
 
-### Using the upstream Hetzner CCM instead
+### Hetzner CCM(upstream)
 
 The upstream `hcloud-cloud-controller-manager` static manifest (`deploy/ccm.yaml`) is hardcoded to read the token from secret `hcloud` with key `token`. Even though the management secret you created on the previous page only has the key `hcloud`, CAPH's compatibility shim writes the workload-cluster copy with **both** keys (`hcloud` and `token`) — so the upstream manifest works as-is, no patching required:
 

--- a/docs/caph/01-getting-started/02-quickstart/04-next-steps.md
+++ b/docs/caph/01-getting-started/02-quickstart/04-next-steps.md
@@ -27,7 +27,7 @@ For a specific version, use the flag `--infrastructure hetzner:vX.X.X` with the 
 
 {% /callout %}
 
-You can switch back to the management cluster with the following command:
+You can switch back to the management cluster with the following command. This assumes the management cluster's kubeconfig is at `~/.kube/config` (which is the default when you set up the bootstrap cluster with `kind`). If your management kubeconfig lives elsewhere, point `KUBECONFIG` at that file instead.
 
 ```shell
 export KUBECONFIG=~/.kube/config

--- a/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-network.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-network.yaml
@@ -20,6 +20,6 @@ spec:
   hetznerSecretRef:
     name: hcloud
     key:
-      hcloudToken: token
+      hcloudToken: hcloud
       hetznerRobotPassword: robot-password
       hetznerRobotUser: robot-user

--- a/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-network.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster-network.yaml
@@ -20,6 +20,9 @@ spec:
   hetznerSecretRef:
     name: hcloud
     key:
+      # "hcloud" is used here for backward compatibility with the Syself CCM,
+      # so that the same template works with both the Syself fork and the
+      # upstream CCM. Once Syself CCM is dropped, this should be set to "token".
       hcloudToken: hcloud
       hetznerRobotPassword: robot-password
       hetznerRobotUser: robot-user

--- a/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
@@ -20,6 +20,6 @@ spec:
   hetznerSecretRef:
     name: hcloud
     key:
-      hcloudToken: token
+      hcloudToken: hcloud
       hetznerRobotPassword: robot-password
       hetznerRobotUser: robot-user

--- a/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml
@@ -20,6 +20,9 @@ spec:
   hetznerSecretRef:
     name: hcloud
     key:
+      # "hcloud" is used here for backward compatibility with the Syself CCM,
+      # so that the same template works with both the Syself fork and the
+      # upstream CCM. Once Syself CCM is dropped, this should be set to "token".
       hcloudToken: hcloud
       hetznerRobotPassword: robot-password
       hetznerRobotUser: robot-user

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/secret.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  token: |
+  hcloud: |
     hcloud_secret_placeholder
 kind: Secret
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

The Quick Start Guide does not produce a working cluster as written. The main reason is that the cluster template, the secret the guide tells the user to create, and the Syself CCM all expect a different secret name or key. A user who follows the guide ends up with `HCloudCredentialsInvalid` on the HetznerCluster and a Syself CCM that crash loops with `secret "hetzner" not found`.

This PR makes the guide work end to end by aligning everything on one secret shape: `name: hcloud`, `key: hcloud`. This is what the Syself CCM (the default in the guide) supports. CAPH already has a helper that, when the secret is named `hcloud`, also writes the token under key `token` in the workload cluster, so the upstream HCloud CCM and the hcloud-csi chart also work without any extra setup.

The PR also fixes a few smaller issues in the same flow that were tripping up new users.

<details>
<summary><strong>Why secret name <code>hcloud</code> and key <code>hcloud</code> (and not the upstream pattern <code>hcloud</code> / <code>token</code>)</strong></summary>

The upstream Hetzner pattern is `hcloud` / `token`, and that was the first proposal in the team discussion. The blocker is that the Syself CCM v2 chart hardcodes the token file name to `hcloud` and does not let the user override it. Since the quickstart installs the Syself CCM by default, we have to use a key the chart can actually read.

CAPH's compatibility helper in `controllers/hetznercluster_controller.go` (`keysForWorkloadClusterSecret`) saves us from picking sides: when the secret is named `hcloud`, it writes the token under both the configured key and a hardcoded `token` key in the workload cluster. Note that this duplication only triggers when the configured key is not already `token`, which is why we set the key to `hcloud` instead. So one secret with one key satisfies all three downstream consumers without any per component overrides:

- Syself CCM reads the file `hcloud`
- Upstream HCloud CCM reads env var `HCLOUD_TOKEN` from key `token`
- hcloud-csi reads env var `HCLOUD_TOKEN` from key `token`
</details>

<details>
<summary><strong>List of changes</strong></summary>

**Templates**

- `templates/cluster-templates/v1beta1/bases/hcloud-hetznerCluster.yaml` and `hcloud-hetznerCluster-network.yaml`: change `hcloudToken: token` to `hcloudToken: hcloud` so the template matches the secret the guide creates.

**Page 02 (`02-management-cluster-setup.md`)**

- Fix the secret create and patch commands to use name `hcloud` and key `hcloud`.
- Mark the SSH key step as required (the template hardcodes `${SSH_KEY_NAME}`).
- Add a short paragraph explaining that CAPH auto syncs this secret to the workload cluster, so the user knows they do not need to create it again later.
- Add a small verify step that prints the token length.

**Page 03 (`03-creating-a-workload-cluster.md`)**

- Tell the user to wait for `INITIALIZED: True` on the KCP before fetching the workload kubeconfig, with a callout for the `EOF` error users hit when they fetch too early.
- Replace `make install-ccm-in-wl-cluster` with the equivalent `helm` command. The make target reads the wrong env var and forces the user to be inside a repo checkout.
- Install the Cilium values from a raw GitHub URL so the user does not need a repo checkout.
- Add a short subsection on using the upstream Hetzner CCM, which works as is because of CAPH's key duplication.
- CSI: drop the `existingSecret` overrides (chart defaults already match) and add the missing `helm repo add hcloud` step.

**Page 04 (`04-next-steps.md`)**

- Make the `~/.kube/config` assumption explicit when switching back to the management cluster.
</details>



**Which issue(s) this PR fixes:**
Fixes #

**Special notes for your reviewer**:
See the dropdowns above.

**TODOs**:
- [ ] squash commits
- [ ] include documentation
