### PR TITLE
:seedling: Ignore EOF error when closing ssh session.

### DIFF
--- a/pkg/services/baremetal/client/ssh/ssh_client.go
+++ b/pkg/services/baremetal/client/ssh/ssh_client.go
@@ -25,6 +25,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -668,7 +669,7 @@ func (c *sshClient) runSSH(ctx context.Context, command string) Output {
 		return Output{Err: fmt.Errorf("unable to create new ssh session (%s): %w", c.connectionDetails(), err)}
 	}
 	defer func() {
-		if err := sess.Close(); err != nil {
+		if err := sess.Close(); err != nil && !errors.Is(err, io.EOF) {
 			logger.Error(err, "failed to close ssh session")
 		}
 	}()


### PR DESCRIPTION

After `sess.Run()` completes normally, the deferred `sess.Close()` call returns `io.EOF` because the SSH server already closed the session from its side. This is expected Go `crypto/ssh` library behavior — the session ended cleanly. The code logs this `EOF` unconditionally as ERROR, producing hundreds of false-positive error entries per reconcile loop.

```go
defer func() {
    if err := sess.Close(); err != nil {
        logger.Error(err, "failed to close ssh session")  // EOF logged as ERROR
    }
}()
```

## Fix

Skip logging when the error is `io.EOF`:

```go
defer func() {
    if err := sess.Close(); err != nil && !errors.Is(err, io.EOF) {
        logger.Error(err, "failed to close ssh session")
    }
}()
```

## Example Log Entry

```yaml
level: ERROR
time: "2026-05-06T09:48:14.206Z"
logger: ssh-client
file: ssh/ssh_client.go:672
message: failed to close ssh session
controller: hcloudmachine
controllerGroup: infrastructure.cluster.x-k8s.io
controllerKind: HCloudMachine
HCloudMachine:
  name: tcs-guettli-qke-1-34-v6-t75zp-7b7wg
  namespace: org-testing
namespace: org-testing
name: tcs-guettli-qke-1-34-v6-t75zp-7b7wg
reconcileID: 6474f64b-f036-4df2-8e8d-b6b941eefccb
Machine:
  name: tcs-guettli-qke-1-34-v6-t75zp-7b7wg
  namespace: org-testing
Cluster:
  name: tcs-guettli-qke-1-34-v6
  namespace: org-testing
HetznerCluster:
  name: tcs-guettli-qke-1-34-v6-vjbj6
  namespace: org-testing
error: EOF
stacktrace: |
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh.(*sshClient).runSSH.func3
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/client/ssh/ssh_client.go#L672
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh.(*sshClient).runSSH
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/client/ssh/ssh_client.go#L646
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh.(*sshClient).StateOfImageURLCommand
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/client/ssh/ssh_client.go#L210
  github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/server.(*Service).handleBootStateRunningImageCommand
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/hcloud/server/server.go#L647
  github.com/syself/cluster-api-provider-hetzner/controllers.(*HCloudMachineReconciler).reconcileNormal
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/controllers/hcloudmachine_controller.go
  github.com/syself/cluster-api-provider-hetzner/controllers.(*HCloudMachineReconciler).Reconcile
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/controllers/hcloudmachine_controller.go
```
