### PR TITLE
:seedling: Avoid logging an error when NodeRef is empty

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2053,7 +2053,6 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 			return actionStop{}
 		}
 
-		s.scope.Info(msg + ", requeueing")
 		return actionContinue{}
 	}
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2044,15 +2044,16 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 	// The machine would be remediated.
 	if machine.Status.NodeRef.Name == "" {
 		msg := "machine.Status.NodeRef.Name is empty"
-		s.scope.Error(errors.New(msg), "")
 
 		// Without looking at the node object we can't confirm whether a reboot completed, so that is fatal error.
 		// When no reboot is requested the boot ID is non-critical; requeue and wait for kubelet to populate it.
 		if rebootDesired {
+			s.scope.Error(errors.New(msg), "")
 			s.scope.HetznerBareMetalHost.SetError(infrav1.FatalError, msg)
 			return actionStop{}
 		}
 
+		s.scope.Info(msg + ", requeueing")
 		return actionContinue{}
 	}
 


### PR DESCRIPTION
`machine.Status.NodeRef.Name is empty` logged as ERROR unconditionally

[`pkg/services/baremetal/host/host.go` line 2045](https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/host/host.go#L2045)


When `machine.Status.NodeRef.Name == ""`, the code logs at ERROR level unconditionally, even in the non-fatal case where it just requeues and waits for kubelet to populate the NodeRef.

```go
if machine.Status.NodeRef.Name == "" {
    msg := "machine.Status.NodeRef.Name is empty"
    s.scope.Error(errors.New(msg), "")   // ERROR logged here regardless

    if rebootDesired {
        s.scope.HetznerBareMetalHost.SetError(infrav1.FatalError, msg)
        return actionStop{}
    }
    return actionContinue{}   // non-fatal: just waiting for kubelet
}
```

When `rebootDesired` is false, the function returns `actionContinue{}` — it is simply waiting for kubelet to register the node and populate `machine.Status.NodeRef.Name`. This is a normal transient state, not an error.


Only log at ERROR level in the fatal (`rebootDesired`) branch. Use Info or Warning for the transient wait case:

```go
if machine.Status.NodeRef.Name == "" {
    msg := "machine.Status.NodeRef.Name is empty"

    if rebootDesired {
        s.scope.Error(errors.New(msg), "")
        s.scope.HetznerBareMetalHost.SetError(infrav1.FatalError, msg)
        return actionStop{}
    }

    s.scope.Info(msg + ", requeueing")
    return actionContinue{}
}
```

log:

```yaml
level: ERROR
time: "2026-05-06T11:06:45.372Z"
file: host/host.go:2047
message: ""
controller: hetznerbaremetalhost
controllerGroup: infrastructure.cluster.x-k8s.io
controllerKind: HetznerBareMetalHost
HetznerBareMetalHost:
  name: bm-8
  namespace: org-testing
namespace: org-testing
name: bm-8
reconcileID: fdb03f83-8526-4c06-8e99-22e144b8c980
HetznerCluster:
  name: test-cpclass-update-6bpzd
  namespace: org-testing
Cluster:
  name: test-cpclass-update
  namespace: org-testing
HetznerBareMetalMachine:
  name: test-cpclass-update-zcwks-pmqz2
  namespace: org-testing
error: machine.Status.NodeRef.Name is empty
stacktrace: |
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*Service).actionProvisioned
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/host/host.go#L2047
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*hostStateMachine).handleProvisioned
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/host/state_machine.go#L335
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*hostStateMachine).ReconcileState
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/host/state_machine.go#L70
  github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/host.(*Service).Reconcile
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/pkg/services/baremetal/host/host.go#L120
  github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerBareMetalHostReconciler).reconcile
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/controllers/hetznerbaremetalhost_controller.go#L312
  github.com/syself/cluster-api-provider-hetzner/controllers.(*HetznerBareMetalHostReconciler).Reconcile
    # https://github.com/syself/cluster-api-provider-hetzner/blob/d3eef77f5/controllers/hetznerbaremetalhost_controller.go#L305
```

