### PR TITLE
:seedling: Set hostname to stripped bm- version of desired name

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2248,10 +2248,11 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 
 // next: None
 func (s *Service) actionDeprovisioning(ctx context.Context) actionResult {
-	// Update name in robot API
+	// Update server name via RobotAPI, strip "bm-" from the desired hostname.
+	// Example: If the hostname is "bm-abc-1-2356799" it should be renamed to "abc-1-2356799".
 	if _, err := s.scope.RobotClient.SetBMServerName(
 		s.scope.HetznerBareMetalHost.Spec.ServerID,
-		s.scope.HetznerBareMetalHost.Spec.ConsumerRef.Name,
+		strings.TrimPrefix(s.scope.Hostname(), infrav1.BareMetalHostNamePrefix),
 	); err != nil {
 		if models.IsError(err, models.ErrorCodeUnauthorized) {
 			// If Robot API returned "unauthorized" error while trying to set baremetal server name, then


### PR DESCRIPTION

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, during deprovisioning the hostname is changed to the name of the HBMM. However, while provisioning the host we check if a stable/constant hostname should be used and explicitly set it accordingly. By switching back to the HBMM name during deprovisioning, we lose this deterministic naming and end up with inconsistent hostnames across the lifecycle of the machine.
Using the stripped "bm-" version preserves the stable hostname format introduced for node recognition (for example by TopoLVM) while still making it clear in the Hetzner UI that the machine is no longer actively provisioned.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

