### PR TITLE
:seedling: Remove metadata key with empty value in cluster template

### DIFF
--- a/templates/cluster-templates/v1beta1/cluster-class-topology-example.yaml
+++ b/templates/cluster-templates/v1beta1/cluster-class-topology-example.yaml
@@ -14,7 +14,6 @@ spec:
     classRef:
       name: quick-start
     controlPlane:
-      metadata: {}
       replicas: 3
     variables:
       # All Variables:


### PR DESCRIPTION

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
'In `v1beta2` the `metadata` field present in Cluster object's `.spec.topology.controlPlane.metadata` and
`.spec.topology.workers.machineDeployments[].metadata` should not be specified with a zero value `{}`. As the field now contains the marker `omitzero`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

