### PR TITLE
✨ Apply md-0 KubeletConfiguration security hardening to control-plane

### DIFF
--- a/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hcloud-kcp-ubuntu.yaml
@@ -28,20 +28,43 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: max-pods
-            value: "120"
-          - name: resolv-conf
-            value: /etc/kubernetes/resolv.conf
+          - name: config
+            value: /etc/kubernetes/kubelet/config.yaml
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: max-pods
-            value: "120"
-          - name: resolv-conf
-            value: /etc/kubernetes/resolv.conf
+          - name: config
+            value: /etc/kubernetes/kubelet/config.yaml
     files:
+      - path: /etc/kubernetes/kubelet/config.yaml
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          eventRecordQPS: 5
+          maxPods: 120
+          readOnlyPort: 0
+          resolvConf: /etc/kubernetes/resolv.conf
+          serverTLSBootstrap: true
+          tlsCipherSuites:
+            - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+            - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+            - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            - TLS_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_RSA_WITH_AES_128_GCM_SHA256
       - path: /etc/sysctl.d/99-cilium.conf
         owner: "root:root"
         permissions: "0744"

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-kcp-ubuntu.yaml
@@ -28,20 +28,43 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: max-pods
-            value: "120"
-          - name: resolv-conf
-            value: /etc/kubernetes/resolv.conf
+          - name: config
+            value: /etc/kubernetes/kubelet/config.yaml
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: max-pods
-            value: "120"
-          - name: resolv-conf
-            value: /etc/kubernetes/resolv.conf
+          - name: config
+            value: /etc/kubernetes/kubelet/config.yaml
     files:
+      - path: /etc/kubernetes/kubelet/config.yaml
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          eventRecordQPS: 5
+          maxPods: 120
+          readOnlyPort: 0
+          resolvConf: /etc/kubernetes/resolv.conf
+          serverTLSBootstrap: true
+          tlsCipherSuites:
+            - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+            - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+            - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+            - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            - TLS_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_RSA_WITH_AES_128_GCM_SHA256
       - path: /etc/systemd/system/sys-fs-bpf.mount
         owner: "root:root"
         permissions: "0744"


### PR DESCRIPTION
kct-md-0-ubuntu.yaml ships a /etc/kubernetes/kubelet/config.yaml file with the modern KubeletConfiguration shape and a hardened default profile — anonymous=false, webhook auth/authz, eventRecordQPS=5, readOnlyPort=0, serverTLSBootstrap=true, an explicit TLS cipher-suite allow-list. The control-plane KCP templates (hcloud-kcp-ubuntu.yaml, hetznerbaremetal-kcp-ubuntu.yaml) just have a minimal kubeletExtraArgs list — no hardening, no KubeletConfiguration file.

Apply the same KubeletConfiguration file on the control plane:

  - Replace the max-pods + resolv-conf kubeletExtraArgs entries with a single --config pointer at /etc/kubernetes/kubelet/config.yaml.
  - Add the new file under spec.kubeadmConfigSpec.files, identical in shape to md-0's, with maxPods set to 120 (control-plane-appropriate) instead of md-0's 220.
  - Keep --cloud-provider=external as a kubeletExtraArg since it isn't expressible via KubeletConfiguration and is set the same way upstream in md-0.

Both initConfiguration and joinConfiguration get the same treatment in each file, so a fresh init and a subsequent control-plane join land on the same kubelet config.

Why this matters:
  - md-0 nodes refuse anonymous kubelet API requests, run with serverTLSBootstrap, and restrict event-record QPS; control-plane nodes (which run the most sensitive workloads on the cluster) do not. That asymmetry has no defensible reason.
  - Single file is easier to audit than a flag-list. KubeletConfiguration also gives access to fields without CLI flag equivalents (event record QPS, server TLS bootstrap), so the hardening profile is expressible end-to-end.
  - max-pods stays at 120 (vs md-0's 220) because control-plane nodes are sized smaller and typically only run system pods; bumping further has historically caused etcd pressure.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

