### PR TITLE
:seedling: In the final phase caph did way too many reconciles.

### DIFF
--- a/pkg/services/baremetal/host/action_result.go
+++ b/pkg/services/baremetal/host/action_result.go
@@ -52,13 +52,23 @@ func (r actionContinue) Result() (reconcile.Result, error) {
 	return reconcile.Result{RequeueAfter: time.Second}, nil
 }
 
-// actionComplete is a result indicating that the current action has completed,
-// and that the resource should transition to the next state.
+// actionComplete is a result indicating that the current action has completed, and that the
+// resource should transition to the next state. If you want to not reconcile again (end of last
+// phase), use actionFinished instead.
 type actionComplete struct{}
 
 func (actionComplete) Result() (reconcile.Result, error) {
 	// One phase is done. Go to the next phase in the next reconcile.
 	return reconcile.Result{RequeueAfter: time.Second}, nil
+}
+
+// actionFinished is a result indicating that the host has reached a stable
+// steady state and no further reconciliation is needed until an external
+// event (e.g. a watch) triggers a new reconcile.
+type actionFinished struct{}
+
+func (actionFinished) Result() (reconcile.Result, error) {
+	return reconcile.Result{}, nil
 }
 
 // deleteComplete is a result indicating that the deletion action has

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2015,6 +2015,14 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 
 	host := s.scope.HetznerBareMetalHost
 
+	// Fast path: no reboot requested and boot ID already captured.
+	// No need to contact the workload cluster; nothing can change.
+	if !rebootDesired && host.Spec.Status.NodeBootID != "" {
+		host.Spec.Status.Rebooted = false
+		host.Spec.Status.RebootTriggeredAt = nil
+		return actionFinished{}
+	}
+
 	// Connect to the workload cluster to read node state.
 	wlClient, err := s.scope.WorkloadClusterClientFactory.NewWorkloadClient(ctx)
 	if err != nil {

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1919,6 +1919,27 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {
 			expectedNodeBootID:              fakeBootID,
 		}),
 	)
+
+	It("fast path: no reboot and NodeBootID already set returns actionFinished", func() {
+		ctx := context.Background()
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithSSHSpecInclPorts(23),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+		)
+		host.Spec.Status.NodeBootID = fakeBootID
+
+		sshMock := &sshmock.Client{}
+		service := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+
+		actResult := service.actionProvisioned(ctx)
+		Expect(actResult).Should(BeAssignableToTypeOf(actionFinished{}))
+		Expect(host.Spec.Status.Rebooted).To(BeFalse())
+		Expect(host.Spec.Status.RebootTriggeredAt).To(BeNil())
+		Expect(host.Spec.Status.NodeBootID).To(Equal(fakeBootID))
+	})
 })
 
 var _ = Describe("actionProvisioned NoSSHAfterInstallImage=true", func() {


### PR DESCRIPTION
In steady state (no reboot requested, boot ID already captured), `actionProvisioned` was calling into the workload cluster on every reconcile and then requeuing after 5 minutes — unnecessary work.

**Fix:** short-circuit early with the new `actionFinished` type, which returns an empty `reconcile.Result{}` and lets watch triggers drive the next reconcile instead of polling.

- Add `actionFinished` to `action_result.go` (no requeue, distinct from `actionStop` which signals a permanent error)
- Fast-path in `actionProvisioned`: if no reboot is desired and `NodeBootID` is already set, return `actionFinished{}` without touching the workload cluster
- Test that the fast path returns `actionFinished`