### PR TITLE
:seedling: Remove early return when reboot is not requested

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2192,14 +2192,6 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 
 	host := s.scope.HetznerBareMetalHost
 
-	// Fast path: no reboot requested and boot ID already captured.
-	// No need to contact the workload cluster; nothing can change.
-	if !rebootDesired && host.Spec.Status.NodeBootID != "" {
-		host.Spec.Status.Rebooted = false
-		host.Spec.Status.RebootTriggeredAt = nil
-		return actionFinished{}
-	}
-
 	// Connect to the workload cluster to read node state.
 	wlClient, err := s.scope.WorkloadClusterClientFactory.NewWorkloadClient(ctx)
 	if err != nil {
@@ -2318,7 +2310,7 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 			host.Spec.Status.NodeBootID = currentBootID
 		}
 
-		return actionComplete{}
+		return actionFinished{}
 	}
 
 	// --- Reboot via annotation ---
@@ -2483,7 +2475,7 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 		host.ClearRebootAnnotations()
 		host.ClearError()
 
-		return actionComplete{}
+		return actionFinished{}
 	}
 
 	// BootID has not changed yet. The node is either still rebooting or the reboot

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1902,7 +1902,7 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {
 			shouldHaveRebootAnnotation:      true,
 			rebooted:                        true,
 			storedBootID:                    "old-boot-id", // Phase 2: differs from fakeBootID the node reports
-			expectedActionResult:            actionComplete{},
+			expectedActionResult:            actionFinished{},
 			expectRebootAnnotation:          false,
 			expectRebootInStatus:            false,
 			expectRebootTriggeredAtInStatus: false,
@@ -1912,34 +1912,13 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {
 			shouldHaveRebootAnnotation:      false,
 			rebooted:                        false,
 			storedBootID:                    fakeBootID,
-			expectedActionResult:            actionComplete{},
+			expectedActionResult:            actionFinished{},
 			expectRebootAnnotation:          false,
 			expectRebootInStatus:            false,
 			expectRebootTriggeredAtInStatus: false,
 			expectedNodeBootID:              fakeBootID,
 		}),
 	)
-
-	It("fast path: no reboot and NodeBootID already set returns actionFinished", func() {
-		ctx := context.Background()
-		host := helpers.BareMetalHost(
-			"test-host",
-			"default",
-			helpers.WithSSHSpecInclPorts(23),
-			helpers.WithIPv4(),
-			helpers.WithConsumerRef(),
-		)
-		host.Spec.Status.NodeBootID = fakeBootID
-
-		sshMock := &sshmock.Client{}
-		service := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
-
-		actResult := service.actionProvisioned(ctx)
-		Expect(actResult).Should(BeAssignableToTypeOf(actionFinished{}))
-		Expect(host.Spec.Status.Rebooted).To(BeFalse())
-		Expect(host.Spec.Status.RebootTriggeredAt).To(BeNil())
-		Expect(host.Spec.Status.NodeBootID).To(Equal(fakeBootID))
-	})
 })
 
 var _ = Describe("actionProvisioned NoSSHAfterInstallImage=true", func() {
@@ -2026,7 +2005,7 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=true", func() {
 
 		// Call actionProvisioned
 		actResult := service.actionProvisioned(ctx)
-		Expect(actResult).Should(BeAssignableToTypeOf(actionComplete{}))
+		Expect(actResult).Should(BeAssignableToTypeOf(actionFinished{}))
 
 		// Condition should be fine
 		c := v1beta1conditions.Get(host, infrav1.RebootSucceededCondition)


### PR DESCRIPTION


<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Remove the early return when reboot is not requested because a server might be reboot due to some other reason than the presence of reboot annotation. And in that case, the new boot id won't be set on the host object. This creates a mismatch between the actual boot id on the node and the host object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

