### PR TITLE
:book: add hint about kubernetes version limitations for CAPH `v1.0.x`

### DIFF
--- a/docs/caph/01-getting-started/01-introduction.md
+++ b/docs/caph/01-getting-started/01-introduction.md
@@ -50,6 +50,8 @@ Related:
 
 Compatibility notes:
 
+- We recommend to use CAPH `v1.1.x` for Kubernetes versions `> 1.33.11`, `> 1.34.7`, `> 1.35.4` and `> 1.36.0`, as they [require a new ClusterRole `system:kubelet-api-admin`](https://github.com/kubernetes-sigs/cluster-api/blob/6c70a17c7f343442238fc695e66884e6c84cfa01/docs/book/src/user/troubleshooting.md#kubeadm-join-fails-after-upgrading-to-kubernetes-patch-releases) which is only created in CAPI versions `>= v1.11.11`, `>= v1.12.8` or `>= v1.13.2`.  
+If you want to use CAPH `v1.0.x` with these versions, you need to create the required `ClusterRoleBinding` yourself. See the link for more details.
 - CAPH `v1.1.x` still implements the deprecated `v1beta1` contract. On CAPI `v1.11.x` through `v1.15.x`, this should keep working via the temporary compatibility layer for the deprecated `v1beta1` contract, but upstream documents limitations and does not recommend staying on `v1beta1` long term. That compatibility is planned to end when `v1beta1` stops being served in CAPI `v1.16.x`. See the upstream [version support page](https://cluster-api.sigs.k8s.io/reference/versions), the upstream [v1.10 to v1.11 migration guide](https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11), the upstream [InfraMachine contract notes](https://cluster-api.sigs.k8s.io/developer/providers/contracts/infra-machine), and the upstream [removal plan](https://github.com/kubernetes-sigs/cluster-api/issues/11920).
 - CAPH `v1.2.x` will be the `v1beta2` line and aligns with CAPI `v1.11.x` and later `v1beta2` releases.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We stumbled upon an error when upgrading to the newest patch versions of Kubernetes on versions `v1.33`, `v1.34`, `v1.35` as well as `v1.36` when using CAPH `v1.0.x` and wanted to update the docs on the supported version, so that others don't run into this issue.

There is a hint to this problem in the cluster-api book:  
https://github.com/kubernetes-sigs/cluster-api/blob/6c70a17c7f343442238fc695e66884e6c84cfa01/docs/book/src/user/troubleshooting.md#kubeadm-join-fails-after-upgrading-to-kubernetes-patch-releases

See also hints in the release notes

> Kubeadm: use a dedicated ClusterRole 'system:kubelet-api-admin' for the kube-apiserver kubelet client.

- [v1.33.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#changelog-since-v13311) 
- [v1.34.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1347)
- [v1.35.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#changelog-since-v1354)
- [v1.36.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md#changelog-since-v1360)

**TODOs**:

- [x] squash commits
- [x] include documentation
- [ ] add unit tests

