### PR TITLE
:seedling: Break the loop to increment condition's observedGeneration

### DIFF
--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -381,6 +381,30 @@ func (host *HetznerBareMetalHost) GetV1Beta2Conditions() []metav1.Condition {
 
 // SetV1Beta2Conditions sets v1beta2 conditions for a HetznerBareMetalHost API object.
 func (host *HetznerBareMetalHost) SetV1Beta2Conditions(conditions []metav1.Condition) {
+	// HetznerBareMetalHost stores its conditions inside Spec (not in a status subresource).
+	// The CAPI conditions library always sets ObservedGeneration = metadata.generation when
+	// writing a condition. Because the conditions are part of the spec, writing them bumps
+	// metadata.generation, which makes ObservedGeneration stale on the very next reconcile,
+	// which triggers another write, which bumps generation again, this is a loop that
+	// increments metadata.generation on every reconcile loop.
+	//
+	// To break the loop: if a condition's Status, Reason, and Message are unchanged from
+	// what is already stored, keep the existing ObservedGeneration instead of overwriting it
+	// with the current (higher) generation. ObservedGeneration will still advance whenever
+	// the condition itself actually changes.
+	existing := host.GetV1Beta2Conditions()
+	existingByType := make(map[string]metav1.Condition, len(existing))
+	for _, c := range existing {
+		existingByType[c.Type] = c
+	}
+	for i := range conditions {
+		if ex, ok := existingByType[conditions[i].Type]; ok &&
+			conditions[i].Status == ex.Status &&
+			conditions[i].Reason == ex.Reason &&
+			conditions[i].Message == ex.Message {
+			conditions[i].ObservedGeneration = ex.ObservedGeneration
+		}
+	}
 	if host.Spec.Status.V1Beta2 == nil {
 		host.Spec.Status.V1Beta2 = &HetznerBareMetalHostV1Beta2Status{}
 	}

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -376,7 +376,13 @@ func (host *HetznerBareMetalHost) GetV1Beta2Conditions() []metav1.Condition {
 	if host.Spec.Status.V1Beta2 == nil {
 		return nil
 	}
-	return host.Spec.Status.V1Beta2.Conditions
+	// Return a deep copy so callers cannot modify the stored slice in-place via a shared
+	// backing array. SetV1Beta2Conditions relies on reading the pre-modification stored
+	// values to detect when only ObservedGeneration changed; that check only works if
+	// the stored slice was not already mutated before SetV1Beta2Conditions runs.
+	out := make([]metav1.Condition, len(host.Spec.Status.V1Beta2.Conditions))
+	copy(out, host.Spec.Status.V1Beta2.Conditions)
+	return out
 }
 
 // SetV1Beta2Conditions sets v1beta2 conditions for a HetznerBareMetalHost API object.


### PR DESCRIPTION


<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
HetznerBareMetalHost stores its conditions inside Spec (not in a status subresource). The CAPI conditions library always sets ObservedGeneration = metadata.generation when writing a condition. Because the conditions are part of the spec, writing them bumps metadata.generation, which makes ObservedGeneration stale on the very next reconcile, which triggers another write, which bumps generation again, this is a loop that increments metadata.generation on every reconcile loop. To break the loop: if a condition's Status, Reason, and Message are unchanged from what is already stored, keep the existing ObservedGeneration instead of overwriting it with the current (higher) generation. ObservedGeneration will still advance whenever the condition itself actually changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

