### PR TITLE
:seedling: (Cherry-Pick) Remove broken "Sign SBOM Images" step 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,18 +131,11 @@ jobs:
         run: |
           cosign attest --yes --type=spdxjson --predicate sbom_caph_staging_${{ steps.meta.outputs.version }}-spdx.json ghcr.io/syself/caph-staging@${{ steps.docker_build_release.outputs.digest }}
 
-      - name: Sign SBOM Images
-        run: |
-          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
-          image_name="ghcr.io/syself/caph-staging:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign --yes "ghcr.io/syself/caph-staging@${docker_build_release_sbom_digest}"
-
       - name: Image Releases digests
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "ghcr.io/syself/caph-staging:{{ steps.meta.outputs.tags }}@${{ steps.docker_build_release.outputs.digest }}" >> image-digest/caph.txt
+          echo "ghcr.io/syself/caph-staging:${{ steps.meta.outputs.tags }}@${{ steps.docker_build_release.outputs.digest }}" >> image-digest/caph.txt
 
       # Upload artifact digests
       - name: Upload artifact digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,20 +95,11 @@ jobs:
         run: |
           cosign attest --yes --type=spdxjson --predicate sbom_ci_main_caph_${{ steps.meta.outputs.version }}-spdx.json ghcr.io/syself/caph@${{ steps.docker_build_release.outputs.digest }}
 
-      - name: Sign SBOM Images
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          docker_build_release_digest="${{ steps.docker_build_release.outputs.digest }}"
-          image_name="ghcr.io/syself/caph:${docker_build_release_digest/:/-}.sbom"
-          docker_build_release_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
-          cosign sign --yes "ghcr.io/syself/caph@${docker_build_release_sbom_digest}"
-
       - name: Image Releases digests
         shell: bash
         run: |
           mkdir -p image-digest/
-          echo "ghcr.io/syself/caph:{{ steps.meta.outputs.version }}@${{ steps.docker_build_release.outputs.digest }}" >> image-digest/caph.txt
+          echo "ghcr.io/syself/caph:${{ steps.meta.outputs.version }}@${{ steps.docker_build_release.outputs.digest }}" >> image-digest/caph.txt
 
       # Upload artifact digests
       - name: Upload artifact digests


### PR DESCRIPTION
This PR cherry-picks the commit `156af4434f94be3894a3eabaf8ef3df5cf3cc6bc`  (#2049) from main to `release-1.1` branch


The "Sign SBOM Images" step was failing because it expected a `.sbom` tag (created by `cosign attach
sbom`), but the workflow uses `cosign attest`,
which stores the SBOM as a referrer manifest — no
`.sbom` tag is ever created. This caused `docker
buildx imagetools inspect` to return nothing,
resulting in the empty-string digest `e3b0c442...` being signed instead of the actual SBOM.

The step is also redundant: `cosign attest`
already signs the SBOM as part of the attestation
via Sigstore keyless signing.

Also fixes a missing `$` in the image digest echo
line.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

