### PR TITLE
fix: use env to avoid ENAMETOOLONG in Renovate post-upgrade command

### DIFF
--- a/.github/workflows/schedule-update-bot.yaml
+++ b/.github/workflows/schedule-update-bot.yaml
@@ -49,7 +49,7 @@ jobs:
           RENOVATE_HOST_RULES: '[{"hostType": "docker", "matchHost": "ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
           RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '[".*"]'
           BUILDER_IMAGE: 'ghcr.io/syself/caph'
-          RENOVATE_POST_UPGRADE_TASKS: '{ commands: ["BUILD_IMAGE_TOKEN=${{ secrets.GITHUB_TOKEN }} BUILD_IMAGE_USER=${{ github.actor }} CI=true ./hack/upgrade-builder-image.sh"], fileFilters: ["Makefile", ".github/**/*.yml", ".builder-image-version.txt", ".github/**/*.yaml"], executionMode: "branch"}'
+          RENOVATE_POST_UPGRADE_TASKS: '{ commands: ["env BUILD_IMAGE_TOKEN=${{ secrets.GITHUB_TOKEN }} BUILD_IMAGE_USER=${{ github.actor }} CI=true ./hack/upgrade-builder-image.sh"], fileFilters: ["Makefile", ".github/**/*.yml", ".builder-image-version.txt", ".github/**/*.yaml"], executionMode: "branch"}'
         with:
           configurationFile: ${{ env.RENOVATE_CONFIG_FILE }}
           token: "x-access-token:${{ steps.generate-token.outputs.token }}"


### PR DESCRIPTION
## Summary

- The \`BUILD_IMAGE_TOKEN\` (a GitHub JWT) can be hundreds of characters long
- When Renovate runs the post-upgrade command \`BUILD_IMAGE_TOKEN=<token> ./hack/upgrade-builder-image.sh\`, execa splits on spaces and treats \`BUILD_IMAGE_TOKEN=<long-token>\` as the **executable filename**
- Linux enforces a 255-char limit on filenames → \`ENAMETOOLONG\` crash
- This crashed the Renovate run silently (the workflow shows ✅ green because Node.js logs \`unhandledRejection\` without exiting non-zero). To see it: open [job 79120213214](https://github.com/syself/cluster-api-provider-hetzner/actions/runs/26833267466/job/79120213214#step:5:9079) and search for \`ENAMETOOLONG\`.
- The crash prevented all remaining branches from being processed (e.g. \`renovate/golang-deps\` was never recreated after being closed)

**Fix:** prefix with \`env\` so the executable is just \`env\` (3 chars) and the long token becomes an argument (no filename-length limit on arguments).

## Test plan

- [ ] Merge this PR
- [ ] Trigger the Renovate workflow manually
- [ ] Confirm no \`ENAMETOOLONG\` in the run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)