### PR TITLE
:seedling: k8s deps in go.mod: Renovate should not update Go packages which reflect the Kubernetes Version

### DIFF
--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -31,7 +31,7 @@
     {
       description: "Disable update k8s packages",
       matchManagers: ["gomod"],
-      matchDepNames: ["k8s.io/api", "k8s.io/apiextensions-apiserver", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl"],
+      matchDepNames: ["k8s.io/api", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl", "k8s.io/code-generator"],
       enabled: false,
     },
     {

--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -31,13 +31,13 @@
     {
       description: "Disable update k8s packages",
       matchManagers: ["gomod"],
-      matchDepNames: ["k8s.io/api", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl", "k8s.io/code-generator"],
+      matchPackagePrefixes: ["k8s.io/"],
       enabled: false,
     },
     {
-      description: "Disable update cluster-api",
+      description: "Disable update cluster-api and kind",
       matchManagers: ["gomod"],
-      matchDepNames: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"],
+      matchDepNames: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test", "sigs.k8s.io/kind"],
       enabled: false,
     },
   ],

--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -31,13 +31,13 @@
     {
       description: "Disable update k8s packages",
       matchManagers: ["gomod"],
-      matchDepNames: ["k8s.io/api", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl", "k8s.io/code-generator"],
+      matchDepNames: ["k8s.io/api", "k8s.io/apiextensions-apiserver", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl"],
       enabled: false,
     },
     {
-      description: "Disable update cluster-api and kind",
+      description: "Disable update cluster-api",
       matchManagers: ["gomod"],
-      matchDepNames: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test", "sigs.k8s.io/kind"],
+      matchDepNames: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"],
       enabled: false,
     },
   ],

--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -31,7 +31,7 @@
     {
       description: "Disable update k8s packages",
       matchManagers: ["gomod"],
-      matchPackagePrefixes: ["k8s.io/"],
+      matchDepNames: ["k8s.io/api", "k8s.io/apiextensions-apiserver", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl"],
       enabled: false,
     },
     {

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -1,6 +1,17 @@
 {
   packageRules: [
     {
+      description: "Update k8s.io packages together (they must all stay at the same version)",
+      groupName: "k8s.io packages",
+      groupSlug: "k8s-io-packages",
+      matchManagers: ["gomod"],
+      matchPackagePrefixes: ["k8s.io/"],
+      commitMessageTopic: "k8s.io packages group",
+      separateMajorMinor: false,
+      separateMultipleMajor: false,
+      separateMinorPatch: false,
+    },
+    {
       description: "Update Builder Image",
       groupName: "Builder Image",
       groupSlug: "caph-builder-image",

--- a/.github/renovate/groups.json5
+++ b/.github/renovate/groups.json5
@@ -1,17 +1,6 @@
 {
   packageRules: [
     {
-      description: "Update k8s.io packages together (they must all stay at the same version)",
-      groupName: "k8s.io packages",
-      groupSlug: "k8s-io-packages",
-      matchManagers: ["gomod"],
-      matchPackagePrefixes: ["k8s.io/"],
-      commitMessageTopic: "k8s.io packages group",
-      separateMajorMinor: false,
-      separateMultipleMajor: false,
-      separateMinorPatch: false,
-    },
-    {
       description: "Update Builder Image",
       groupName: "Builder Image",
       groupSlug: "caph-builder-image",


### PR DESCRIPTION
Renovate should not update Go packages which reflect the Kubernetes Version.

Reason: PR #2069 tried to bump one dependency, which failed:

> go: github.com/syself/cluster-api-provider-hetzner/controllers tested by
	github.com/syself/cluster-api-provider-hetzner/controllers.test imports
	k8s.io/kubectl/pkg/scheme imports
	k8s.io/api/scheduling/v1alpha1: cannot find module providing package k8s.io/api/scheduling/v1alpha1

The list of packages to ignore was created by:

```console 
❯ grep k8s.io go.mod | grep -v indirect | grep  0.35 
    k8s.io/api v0.35.5
    k8s.io/apiextensions-apiserver v0.35.5
    k8s.io/apimachinery v0.35.5
    k8s.io/apiserver v0.35.5
    k8s.io/client-go v0.35.5
    k8s.io/kubectl v0.35.4
```

---


We want to update these by hand.