### PR TITLE
:seedling: baremetal e2e: use hbmh list from main branch

### DIFF
--- a/.github/workflows/e2e-basic-baremetal.yaml
+++ b/.github/workflows/e2e-basic-baremetal.yaml
@@ -41,6 +41,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Use hbmh list from main branch
+        run: |
+          git fetch origin main
+          git checkout FETCH_HEAD -- test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
       - name: Run e2e Test
         id: e2e
         uses: ./.github/actions/e2e

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -94,6 +94,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Use hbmh list from main branch
+        run: |
+          git fetch origin main
+          git checkout FETCH_HEAD -- test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
       - name: Run e2e Test
         id: e2e-bm
         uses: ./.github/actions/e2e


### PR DESCRIPTION
## Summary

- Baremetal e2e jobs now always fetch `hetznerbaremetalhosts.yaml` from `origin/main` after checkout, overriding the PR branch copy
- This ensures that servers disabled on main (e.g. `maintenanceMode: true`) are immediately respected by all open PRs, even those that haven't rebased yet
- Applies to both `pr-e2e.yaml` (PR-blocking) and `e2e-basic-baremetal.yaml` (manual dispatch)

## Context

PR #2082 disabled `bm-e2e-1670788` on main while many open PRs still have it enabled. Without this fix those PRs will keep trying to provision the stuck server.

## Test plan

- [ ] Trigger a baremetal E2E run from a branch that predates #2082 and verify the job picks up the `maintenanceMode: true` from main

🤖 Generated with [Claude Code](https://claude.ai/claude-code)