### PR TITLE
:seedling: add manual baremetal server recovery workflow

### DIFF
--- a/.github/workflows/baremetal-check-server.yaml
+++ b/.github/workflows/baremetal-check-server.yaml
@@ -11,6 +11,7 @@ jobs:
     name: Check BM Server (${{ inputs.server_name }})
     concurrency: ci-e2e-baremetal-global
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/baremetal-check-server.yaml
+++ b/.github/workflows/baremetal-check-server.yaml
@@ -1,0 +1,45 @@
+name: Baremetal Check Server (Recovery)
+on:
+  workflow_dispatch:
+    inputs:
+      server_name:
+        description: "HetznerBareMetalHost metadata.name (e.g. bm-e2e-1670788)"
+        required: true
+
+jobs:
+  check-bm-server:
+    name: Check BM Server (${{ inputs.server_name }})
+    concurrency: ci-e2e-baremetal-global
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Use hbmh list from main branch
+        run: |
+          git fetch origin main
+          git checkout FETCH_HEAD -- test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+
+      - name: Enable maintenanceMode for check
+        run: |
+          sed -i 's/maintenanceMode: false/maintenanceMode: true/g' \
+            test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
+
+      - name: Run caphcli check-bm-server
+        env:
+          HETZNER_ROBOT_USER: ${{ secrets.HETZNER_ROBOT_USER }}
+          HETZNER_ROBOT_PASSWORD: ${{ secrets.HETZNER_ROBOT_PASSWORD }}
+          HETZNER_SSH_PUB: ${{ secrets.HETZNER_SSH_PUB }}
+          HETZNER_SSH_PRIV: ${{ secrets.HETZNER_SSH_PRIV }}
+          SSH_KEY_NAME: ${{ secrets.SSH_KEY_NAME }}
+        run: |
+          go run github.com/syself/caphcli@latest check-bm-server \
+            test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml \
+            --name "${{ inputs.server_name }}" \
+            --force


### PR DESCRIPTION
## Summary

- Adds `baremetal-check-server.yaml`: a `workflow_dispatch` that runs `caphcli check-bm-server` for a given server by name
- Required input: `server_name` (e.g. `bm-e2e-1670788`)
- Uses `concurrency: ci-e2e-baremetal-global` — same group as the E2E test — so it cannot race with a running CI run
- Always fetches `hetznerbaremetalhosts.yaml` from `origin/main` for canonical server config
- Sets `maintenanceMode: true` on all servers before running (required by `caphcli check-bm-server`)
- Runs with `--force` to skip interactive confirmation prompts

## Usage

Go to **Actions → Baremetal Check Server (Recovery) → Run workflow**, enter the server name, and run. The job will boot the server into rescue, install Ubuntu fresh, and verify the server is healthy — leaving it ready for the next E2E run.

## Test plan

- [ ] Trigger manually for `bm-e2e-1670788` and verify it completes without racing an E2E test

🤖 Generated with [Claude Code](https://claude.ai/claude-code)