### PR TITLE
docs: add docstring to TestScope function

### DIFF
--- a/pkg/scope/suite_test.go
+++ b/pkg/scope/suite_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// TestScope runs the scope test suite.
 func TestScope(t *testing.T) {
 	RegisterFailHandler(Fail)
 


### PR DESCRIPTION
### 问题背景
公共测试函数 `TestScope` 缺少文档注释，这违反了代码文档标准，降低了代码可读性和维护性，特别是在开源项目中，良好的文档有助于新贡献者快速理解代码。

### 修改内容
- 在 `pkg/scope/suite_test.go` 文件中，为 `TestScope` 函数添加了文档注释：`// TestScope runs the scope test suite.`
- 为什么这样改：遵循 Go 语言的最佳实践，所有公共函数应有文档注释，以提高代码一致性和开发者体验。修改仅添加注释，不改变任何功能。
- 提升：改善代码可读性，确保文档完整性，有助于团队协作和代码审查，符合生产级别的质量标准。

### 验证方式
- 现有测试：由于仅添加注释，不影响代码行为，所有现有测试应继续通过。可以通过运行 `go test ./pkg/scope/...` 验证。
- 新测试：无，这是纯文档修改，无需添加新测试。
- 手动验证：检查修改后的文件，确认注释正确添加且符合仓库的代码风格（如使用 `//` 注释格式）。

### 其他信息
- Breaking changes：无，修改仅涉及文档，不改变公共 API 或功能。
- 文档更新：无需更新外部文档，因为这是内部代码注释改进。
- 已知限制：无。