### PR TITLE
:seedling: use tar.zst base images, tar.gz no longer exists in rescue system.

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachine_types_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types_test.go
@@ -252,9 +252,9 @@ func Test_Image_String(t *testing.T) {
 		{
 			Image{
 				Name: "nfs",
-				Path: "/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz",
+				Path: "/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst",
 			},
-			"nfs (/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz)",
+			"nfs (/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst)",
 		},
 	} {
 		require.Equal(t, row.expected, row.image.String())

--- a/api/v1beta2/hetznerbaremetalmachine_types_test.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types_test.go
@@ -252,9 +252,9 @@ func Test_Image_String(t *testing.T) {
 		{
 			Image{
 				Name: "nfs",
-				Path: "/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz",
+				Path: "/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst",
 			},
-			"nfs (/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz)",
+			"nfs (/root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst)",
 		},
 	} {
 		require.Equal(t, row.expected, row.image.String())

--- a/docs/caph/03-reference/06-hetzner-bare-metal-machine-template.md
+++ b/docs/caph/03-reference/06-hetzner-bare-metal-machine-template.md
@@ -94,7 +94,7 @@ Example of an image provided by Hetzner via NFS:
 
 ```yaml
 image:
-  path: /root/.oldroot/nfs//images/Ubuntu-2404-noble-amd64-base.tar.gz
+  path: /root/.oldroot/nfs//images/Ubuntu-2404-noble-amd64-base.tar.zst
 ```
 
 Example of an image provided by you via https. The script installimage of Hetzner parses the name to detect the version. It is

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-control-plane-ubuntu.yaml
@@ -10,7 +10,7 @@ spec:
           baremetal-pool: "${BAREMETAL_POOL}"
       installImage:
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst
         partitions:
           - fileSystem: esp
             mount: /boot/efi

--- a/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
+++ b/templates/cluster-templates/v1beta1/bases/hetznerbaremetal-mt-md-1-ubuntu.yaml
@@ -10,7 +10,7 @@ spec:
           baremetal-pool: "${BAREMETAL_POOL}"
       installImage:
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst
         partitions:
           - fileSystem: esp
             mount: /boot/efi

--- a/templates/cluster-templates/v1beta1/cluster-class.yaml
+++ b/templates/cluster-templates/v1beta1/cluster-class.yaml
@@ -641,7 +641,7 @@ spec:
         swraid: 0
         swraidLevel: 1
         image:
-          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.gz
+          path: /root/.oldroot/nfs/images/Ubuntu-2404-noble-amd64-base.tar.zst
         partitions:
           - fileSystem: esp
             mount: /boot/efi


### PR DESCRIPTION
In the rescue system the tar.gz images no longer exist.

Example:

```console 
root@rescue ~ # ls -ltr /root/.oldroot/nfs/images/ | grep noble| grep amd

-rw-r--r-- 1 root root  833  2. Jun 12:00 Ubuntu-2404-noble-amd64-base.tar.zst.sig -rw-r--r-- 1 root root 1,2G  2. Jun 12:00 Ubuntu-2404-noble-amd64-base.tar.zst
lrwxrwxrwx 1 root root   36  8. Jun 10:51 Ubuntu-noble-latest-amd64-base.tar.zst -> Ubuntu-2404-noble-amd64-base.tar.zst
lrwxrwxrwx 1 root root   36  8. Jun 10:51 Ubuntu-noble-latest-amd64-base.tar.gz -> Ubuntu-2404-noble-amd64-base.tar.zst
```

