### PR TITLE
:seedling: Move bm-e2e-1716772 to ci-pool to restore E2E CI

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -19,7 +19,7 @@ kind: HetznerBareMetalHost
 metadata:
   name: "bm-e2e-1716772"
   labels:
-    baremetal-pool: free-pool
+    baremetal-pool: ci-pool
     name: bm-e2e-1716772
 spec:
   serverID: 1716772 # ip: 136.243.69.24

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -1,4 +1,3 @@
-# 2026-06-08: Disabled after CI hit repeated rescue-mode reboot timeouts.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -10,7 +9,7 @@ spec:
   serverID: 1670788 # ip: 136.243.69.167
   rootDeviceHints:
     wwn: "0x5002538c0004413f"
-  maintenanceMode: true #### < --- set to false, when ok.
+  maintenanceMode: false
   description: Test Machine 1670788
 ---
 # Feb 2026: worked.


### PR DESCRIPTION
## Root Cause

On 2026-06-08, PR #2082 put `bm-e2e-1670788` in maintenance mode because it was stuck in a provisioning loop. This left only **one** available `ci-pool` host (`bm-e2e-1724024`).

The baremetal E2E test (`cluster-template-hetzner-baremetal`) requires **two** `ci-pool` hosts:
- One for the control-plane
- One for the worker (MachineDeployment `md-1`)

After `bm-e2e-1724024` was taken by the control-plane, the worker MachineDeployment could not find a second host, producing:
```
no available host (No available host of 5 found: hbmh-in-maintenance-mode: 2, label-selector-does-not-match: 3)
```

## Fix

Two changes:
1. **Re-enable `bm-e2e-1670788`** — take it out of maintenance mode so it can be used again.
2. **Move `bm-e2e-1716772` from `free-pool` to `ci-pool`** — adds a third `ci-pool` host as a buffer so a single host going bad no longer breaks CI entirely.

## Test plan

- [ ] E2E baremetal CI (`Test Hetzner Baremetal Basic`) passes after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)