### PR TITLE
:seedling: Refactor action EnsureProvisioned

### DIFF
--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -1010,10 +1010,17 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 })
 
 func configureRescueSSHClient(sshClient *sshmock.Client) {
-	sshClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+	// GetHostName is called once during actionRegistering, once during pre-provisioning
+	// and once during actionImageInstalling.
+	// After image installation the host reboots into the OS.
+	sshClient.On("GetHostName", mock.Anything).Times(3).Return(sshclient.Output{
 		StdOut: "rescue",
 		StdErr: "",
 		Err:    nil,
+	})
+	// Calling GetHostName with rescue SSH client when host is booted into desired OS should lead to error.
+	sshClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+		Err: sshclient.ErrAuthenticationFailed,
 	})
 	sshClient.On("GetHardwareDetailsRAM", mock.Anything).Return(sshclient.Output{
 		StdOut: "100000",

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -1017,10 +1017,17 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 })
 
 func configureRescueSSHClient(sshClient *sshmock.Client) {
-	sshClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+	// GetHostName is called once during actionRegistering, once during pre-provisioning
+	// and once during actionImageInstalling.
+	// After image installation the host reboots into the OS.
+	sshClient.On("GetHostName", mock.Anything).Times(3).Return(sshclient.Output{
 		StdOut: "rescue",
 		StdErr: "",
 		Err:    nil,
+	})
+	// Calling GetHostName with rescue SSH client when host is booted into desired OS should lead to error.
+	sshClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+		Err: sshclient.ErrAuthenticationFailed,
 	})
 	sshClient.On("GetHardwareDetailsRAM", mock.Anything).Return(sshclient.Output{
 		StdOut: "100000",

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1907,9 +1907,156 @@ func verifyConnectionRefused(ctx context.Context, sshClient sshclient.Client, po
 func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult) {
 	markProvisionPending(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned)
 
+	// If hardware reboot was triggered, then move to Step-2 i.e. ensuring host is booted into the desired OS.
+	// Otherwise, move to Step-1 i.e. check if the host is still in rescue mode.
+	if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType != infrav1.ErrorTypeHardwareRebootTriggered {
+		if ar := s.checkRescueAndTriggerReboot(ctx); ar != nil {
+			return ar
+		}
+	}
+
+	// Step-2
+	return s.verifyProvisionedOS(ctx)
+}
+
+// checkRescueAndTriggerReboot checks if the host is still in rescue mode, if it is still in rescue mode
+// it triggers a reboot. First a software reboot and if it fails then a hardware reboot.
+func (s *Service) checkRescueAndTriggerReboot(ctx context.Context) actionResult {
+	// If software reboot has timed out, escalate to hardware reboot immediately. No need to
+	// confirm rescue reachability, the host may be in a state where neither the rescue mode nor
+	// the desired OS might be reachable.
+	if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSoftwareRebootTriggered &&
+		hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, softwareResetTimeout) {
+		// Ensure that rescue mode is disabled for the next reboot.
+		if err := s.unsetRescueIfActive(); err != nil {
+			return actionError{err: fmt.Errorf("failed to ensure that rescue mode is disabled for the next boot: %w", err)}
+		}
+
+		// trigger a hardware reboot.
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, infrav1.RebootTypeHardware); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, infrav1.RebootTypeHardware, "Software reboot timed out, triggered a hardware reboot.")
+		s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeHardwareRebootTriggered, msg)
+
+		// move to step-2
+		return nil
+	}
+
+	creds := sshclient.CredentialsFromSecret(s.scope.RescueSSHSecret, s.scope.HetznerCluster.Spec.SSHKeys.RobotRescueSecretRef)
+	in := sshclient.Input{
+		PrivateKey: creds.PrivateKey,
+		Port:       rescuePort,
+		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
+	}
+	sshClient := s.scope.SSHClientFactory.NewClient(in)
+
+	// Check hostname with sshClient.
+	out := sshClient.GetHostName(ctx)
+	if out.Err != nil || out.StdErr != "" {
+		// Rescue system is not reachable, we can move to step-2 i.e. verifying if host is booted into provisioned OS.
+		return nil
+	}
+
+	hostname := trimLineBreak(out.StdOut)
+	if hostname != rescue {
+		// Host is not in rescue mode, we can move to step-2 i.e. verifying if host is booted into provisioned OS.
+		//
+		// NOTE: We are not analyzing the SSH errors because in this step we only need to detect if the host is in rescue mode.
+		// Any SSH error would mean that we cannot confirm if the host is in rescue mode so we fall through to step-2.
+		// connection-refused/timeout: host is between boots or already in the OS (step-2 will verify).
+		// auth failed: host rebooted into OS, so rescue key is no longer valied (step-2 will verify).
+		// non-rescue hostname: host booted into OS (step-2 will verify).
+
+		return nil
+	}
+
+	// Host is in rescue mode.
+
+	// If it was not rebooted in the last 15s then we should trigger a reboot.
+	if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt != nil &&
+		!hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, rebootWaitTime) {
+		// reboot was recently triggered (possibly from image-installing), give it some time.
+		return actionContinue{delay: 5 * time.Second}
+	}
+
+	// Ensure that rescue mode is disabled for the next reboot.
+	if err := s.unsetRescueIfActive(); err != nil {
+		return actionError{err: fmt.Errorf("failed to ensure that rescue mode is disabled for the next boot: %w", err)}
+	}
+
+	// Check which reboot was triggered previously, if a software reboot was triggered in the previous run
+	// and it has timed out now then trigger a hardware reboot.
+	var emptyErrorType infrav1.ErrorType
+	switch s.scope.HetznerBareMetalHost.Spec.Status.ErrorType {
+	case emptyErrorType:
+		// pick the available reboot type (software or hardware) and trigger it (preferred order software > hardware).
+		rebootType, errorType := rebootAndErrorTypeAfterTimeout(s.scope.HetznerBareMetalHost)
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, rebootType); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, rebootType, "Rebooting out of rescue mode into the provisioned OS.")
+		s.scope.HetznerBareMetalHost.SetError(errorType, msg)
+
+		// if the hardware reboot was triggered then move to step-2, otherwise reque with delay.
+		if rebootType == infrav1.RebootTypeHardware {
+			return nil
+		}
+
+		return actionContinue{delay: 5 * time.Second}
+
+	case infrav1.ErrorTypeSoftwareRebootTriggered:
+		// If the software reboot timed out, then trigger a hardware reboot, otherwise reque.
+		if !hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, softwareResetTimeout) {
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, "waiting for software reboot to complete")
+			return actionContinue{delay: 5 * time.Second}
+		}
+
+		// trigger a hardware reboot.
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, infrav1.RebootTypeHardware); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, infrav1.RebootTypeHardware, "Software reboot timed out, triggered a hardware reboot.")
+		s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeHardwareRebootTriggered, msg)
+
+		// move to step-2
+		return nil
+	}
+
+	return nil
+}
+
+// unsetRescueIfActive checks whether rescue boot is currently set for the next boot and unsets it if so.
+func (s *Service) unsetRescueIfActive() error {
+	rescue, err := s.scope.RobotClient.GetBootRescue(s.scope.HetznerBareMetalHost.Spec.ServerID)
+	if err != nil {
+		s.handleRobotRateLimitExceeded(err, "GetBootRescue")
+		return fmt.Errorf("failed to get boot rescue: %w", err)
+	}
+	if rescue.Active {
+		if _, err := s.scope.RobotClient.DeleteBootRescue(s.scope.HetznerBareMetalHost.Spec.ServerID); err != nil {
+			s.handleRobotRateLimitExceeded(err, "DeleteBootRescue")
+			return fmt.Errorf("failed to delete boot rescue: %w", err)
+		}
+	}
+	return nil
+}
+
+// verifyProvisionedOS verifies that the host has booted into the provisioned OS.
+func (s *Service) verifyProvisionedOS(ctx context.Context) actionResult {
+	// If SSHAfterInstallImage is disabled, we cannot SSH into the host and verify the OS.
+	// Therefore move to the next state.
 	if !s.scope.SSHAfterInstallImageEnabled() {
-		// SSH after installimage is disabled for this machine, so we skip the verification phase.
-		record.Event(s.scope.HetznerBareMetalHost, "ServerProvisioned", "server successfully provisioned ('ensure-provisioned' was skipped)")
+		record.Event(s.scope.HetznerBareMetalHost, "ServerProvisioned", "server successfully provisioned (verification was skipped)")
 		v1beta1conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.ProvisionSucceededCondition)
 		v1beta2conditions.Set(s.scope.HetznerBareMetalHost, metav1.Condition{
 			Type:   infrav1.HetznerBareMetalHostProvisionSucceededV1Beta2Condition,
@@ -1927,54 +2074,37 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
 	})
 
-	// Check hostname with sshClient
-	wantHostName := s.scope.Hostname()
-
+	// Check hostname with sshClient.
+	desiredHostName := s.scope.Hostname()
 	out := sshClient.GetHostName(ctx)
 	hostname := trimLineBreak(out.StdOut)
-	if hostname != wantHostName {
-		// give the reboot some time until it takes effect
+
+	if hostname != desiredHostName {
+		// if the host was just rebooted, give it some time.
 		if s.hasJustRebooted() {
 			s.scope.Info("ensureProvisioned: hasJustRebooted. Retrying...", "hostname", hostname)
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, "host has just rebooted")
-			return actionContinue{delay: 2 * time.Second}
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, "host has just rebooted")
+			return actionContinue{delay: 5 * time.Second}
 		}
 
-		isTimeout, isSSHConnectionRefusedError, err := analyzeSSHOutputProvisioned(out)
-		if err != nil {
-			if errors.Is(err, errUnexpectedHostName) {
-				// One possible reason: The machine gets used by a second wl-cluster.
-				record.Warnf(s.scope.HetznerBareMetalHost, "UnexpectedHostName",
-					"EnsureProvision: wanted %q. %s", wantHostName, err.Error())
+		// If the hardware reboot was triggered and it timed-out, then set a permanent error on the host.
+		// Otherwise reque.
+		if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeHardwareRebootTriggered &&
+			hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, hardwareResetTimeout) {
+			msg := fmt.Sprintf("hostname %q does not match expected %q after reboot", hostname, desiredHostName)
+
+			if sshclient.IsConnectionRefusedError(out.Err) || os.IsTimeout(out.Err) || sshclient.IsTimeoutError(out.Err) {
+				msg = fmt.Sprintf("hardware reboot timed out: OS unreachable via SSH after %s", hardwareResetTimeout)
 			}
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, err.Error())
-			return actionError{err: fmt.Errorf("failed to handle incomplete boot - actionEnsureProvisioned: %w", err)}
+
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, msg)
+			return s.recordActionFailure(infrav1.PermanentError, msg)
 		}
 
-		failed, err := s.handleIncompleteBoot(ctx, false, isTimeout, isSSHConnectionRefusedError)
-		if failed {
-			msg := "reboot handling failed"
-			if err != nil {
-				msg = err.Error()
-			}
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, msg)
-			return s.recordActionFailure(infrav1.ProvisioningError, msg)
-		}
-		if err != nil {
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, err.Error())
-			return actionError{err: fmt.Errorf(errMsgFailedHandlingIncompleteBoot, err)}
-		}
-		markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-			infrav1.StateEnsureProvisioned, "will retry")
-		return actionContinue{delay: 10 * time.Second}
+		return actionContinue{delay: 5 * time.Second}
 	}
 
-	// from now on we know that the machine is reachable and
-	// is no longer in the rescue system.
+	// Hostname matches, host is in the provisioned OS.
 
 	s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2102,7 +2102,10 @@ func (s *Service) checkRescueAndTriggerReboot(ctx context.Context) actionResult 
 	// and it has timed out now then trigger a hardware reboot.
 	var emptyErrorType infrav1.ErrorType
 	switch s.scope.HetznerBareMetalHost.Spec.Status.ErrorType {
-	case emptyErrorType:
+	case emptyErrorType, infrav1.ErrorTypeConnectionError:
+		// ErrorTypeConnectionError means verifyProvisionedOS previously couldn't reach
+		// the host via SSH. Now we've confirmed it's actually in rescue mode, so treat
+		// it the same as no reboot being tracked yet and trigger one.
 		// pick the available reboot type (software or hardware) and trigger it (preferred order software > hardware).
 		rebootType, errorType := rebootAndErrorTypeAfterTimeout(s.scope.HetznerBareMetalHost)
 		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, rebootType); err != nil {
@@ -2211,6 +2214,27 @@ func (s *Service) verifyProvisionedOS(ctx context.Context) actionResult {
 
 			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, msg)
 			return s.recordActionFailure(infrav1.FatalError, msg)
+		}
+
+		// If we have never managed to reach the host via SSH on either the rescue or the OS
+		// port for a long time, then we should mark the host as unreachable and set a fatal error.
+		var emptyErrorType infrav1.ErrorType
+		if out.Err != nil {
+			switch s.scope.HetznerBareMetalHost.Spec.Status.ErrorType {
+			case emptyErrorType:
+				s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+				s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeConnectionError, "ssh gave connection error")
+
+			case infrav1.ErrorTypeConnectionError:
+				if hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, connectionRefusedTimeout) {
+					msg := fmt.Sprintf("host unreachable via SSH on both rescue and OS ports for over %s", connectionRefusedTimeout)
+					markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, msg)
+					return s.recordActionFailure(infrav1.FatalError, msg)
+				}
+			}
+		} else if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeConnectionError {
+			// SSH succeeded now (just the wrong hostname), so the connection problem is gone.
+			s.scope.HetznerBareMetalHost.ClearError()
 		}
 
 		return actionContinue{delay: 10 * time.Second}

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1576,7 +1576,8 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 			// Neither the annotation nor the machine spec field is set. This is a permanent error.
 			msg := fmt.Sprintf(
 				"CheckDisk failed (permanent error): %s (set annotation %q on hbmh or skipCheckDisk on HetznerBareMetalMachine to skip)",
-				err.Error(), infrav1.IgnoreCheckDiskAnnotation)
+				err.Error(), infrav1.IgnoreCheckDiskAnnotation,
+			)
 			v1beta1conditions.MarkFalse(
 				s.scope.HetznerBareMetalHost,
 				infrav1.ProvisionSucceededCondition,
@@ -2001,9 +2002,171 @@ func verifyConnectionRefused(ctx context.Context, sshClient sshclient.Client, po
 func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult) {
 	markProvisionPending(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned)
 
+	// Now we need to ensure that the host is out of rescue mode and booted into the
+	// desired OS. This is done in two steps:
+	//
+	// Step-1: Check if the host is still in rescue mode, if it is then trigger a
+	// reboot. First try a software reboot and if the host is still in rescue mode
+	// after a timeout then trigger a hardware reboot.
+	//
+	// Step-2: Verify if the host is booted into the desired OS.
+
+	// If hardware reboot was triggered, then it means that we have reached the
+	// last phase of escalation of getting out of rescue mode already.
+	// Therefore move to Step-2 i.e. ensuring host is booted into the desired OS.
+	// Otherwise, move to Step-1 i.e. check if the host is still in rescue mode.
+	if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType != infrav1.ErrorTypeHardwareRebootTriggered {
+		if ar := s.checkRescueAndTriggerReboot(ctx); ar != nil {
+			return ar
+		}
+	}
+
+	// Step-2
+	return s.verifyProvisionedOS(ctx)
+}
+
+// checkRescueAndTriggerReboot checks if the host is still in rescue mode, if it is still in rescue mode
+// it triggers a reboot. First a software reboot and if it fails then a hardware reboot.
+func (s *Service) checkRescueAndTriggerReboot(ctx context.Context) actionResult {
+	// If software reboot has timed out, escalate to hardware reboot immediately. No need to
+	// confirm rescue reachability, the host may be in a state where neither the rescue mode nor
+	// the desired OS might be reachable.
+	if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSoftwareRebootTriggered &&
+		hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, softwareResetTimeout) {
+		// Ensure that rescue mode is disabled for the next reboot.
+		if err := s.unsetRescueIfActive(); err != nil {
+			return actionError{err: fmt.Errorf("failed to ensure that rescue mode is disabled for the next boot: %w", err)}
+		}
+
+		// trigger a hardware reboot.
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, infrav1.RebootTypeHardware); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, infrav1.RebootTypeHardware, "Software reboot timed out, triggered a hardware reboot.")
+		s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeHardwareRebootTriggered, msg)
+
+		// move to step-2
+		return nil
+	}
+
+	creds := sshclient.CredentialsFromSecret(s.scope.RescueSSHSecret, s.scope.HetznerCluster.Spec.SSHKeys.RobotRescueSecretRef)
+	in := sshclient.Input{
+		PrivateKey: creds.PrivateKey,
+		Port:       rescuePort,
+		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
+	}
+	sshClient := s.scope.SSHClientFactory.NewClient(in)
+
+	// Check hostname with sshClient.
+	out := sshClient.GetHostName(ctx)
+	if out.Err != nil || out.StdErr != "" {
+		// We failed to reach the server via ssh and assume that it is rebooting,
+		// or has rebooted already. Therefore, we can go to step 2 to verify that it
+		// is provisioned successfully.
+		//
+		// NOTE: We are not analyzing the SSH errors because in this step we only
+		// need to detect if the host is in rescue mode. Any SSH error would mean
+		// that we cannot confirm if the host is in rescue mode so we fall through
+		// to step-2.
+		// connection-refused/timeout error: host is between boots or already in the
+		// OS (step-2 will verify).
+		// auth failed: host rebooted into OS, so rescue key is no longer valid
+		// (step-2 will verify).
+		return nil
+	}
+
+	hostname := trimLineBreak(out.StdOut)
+	if hostname != rescue {
+		// Host is not in rescue mode, we can move to step-2 i.e. verifying if host is booted into provisioned OS.
+		return nil
+	}
+
+	// Host is in rescue mode.
+
+	// If it was not rebooted in the last 15s then we should trigger a reboot.
+	if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt != nil &&
+		!hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, rebootWaitTime) {
+		// reboot was recently triggered (possibly from image-installing), give it some time.
+		return actionContinue{delay: 10 * time.Second}
+	}
+
+	// Ensure that rescue mode is disabled for the next reboot.
+	if err := s.unsetRescueIfActive(); err != nil {
+		return actionError{err: fmt.Errorf("failed to ensure that rescue mode is disabled for the next boot: %w", err)}
+	}
+
+	// Check which reboot was triggered previously, if a software reboot was triggered in the previous run
+	// and it has timed out now then trigger a hardware reboot.
+	var emptyErrorType infrav1.ErrorType
+	switch s.scope.HetznerBareMetalHost.Spec.Status.ErrorType {
+	case emptyErrorType:
+		// pick the available reboot type (software or hardware) and trigger it (preferred order software > hardware).
+		rebootType, errorType := rebootAndErrorTypeAfterTimeout(s.scope.HetznerBareMetalHost)
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, rebootType); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, rebootType, "Rebooting out of rescue mode into the provisioned OS.")
+		s.scope.HetznerBareMetalHost.SetError(errorType, msg)
+
+		// if the hardware reboot was triggered then move to step-2, otherwise requeue with delay.
+		if rebootType == infrav1.RebootTypeHardware {
+			return nil
+		}
+
+		return actionContinue{delay: 10 * time.Second}
+
+	case infrav1.ErrorTypeSoftwareRebootTriggered:
+		// If the software reboot timed out, then trigger a hardware reboot, otherwise requeue.
+		if !hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, softwareResetTimeout) {
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, "waiting for software reboot to complete")
+			return actionContinue{delay: 10 * time.Second}
+		}
+
+		// trigger a hardware reboot.
+		if _, err := s.scope.RobotClient.RebootBMServer(s.scope.HetznerBareMetalHost.Spec.ServerID, infrav1.RebootTypeHardware); err != nil {
+			s.handleRobotRateLimitExceeded(err, rebootServerStr)
+			return actionError{err: fmt.Errorf(errMsgFailedReboot, err)}
+		}
+
+		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+		msg := createRebootEvent(ctx, s.scope.HetznerBareMetalHost, infrav1.RebootTypeHardware, "Software reboot timed out, triggered a hardware reboot.")
+		s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeHardwareRebootTriggered, msg)
+
+		// move to step-2
+		return nil
+	}
+
+	return nil
+}
+
+// unsetRescueIfActive checks whether rescue boot is currently set for the next boot and unsets it if so.
+func (s *Service) unsetRescueIfActive() error {
+	rescue, err := s.scope.RobotClient.GetBootRescue(s.scope.HetznerBareMetalHost.Spec.ServerID)
+	if err != nil {
+		s.handleRobotRateLimitExceeded(err, "GetBootRescue")
+		return fmt.Errorf("failed to get boot rescue: %w", err)
+	}
+	if rescue.Active {
+		if _, err := s.scope.RobotClient.DeleteBootRescue(s.scope.HetznerBareMetalHost.Spec.ServerID); err != nil {
+			s.handleRobotRateLimitExceeded(err, "DeleteBootRescue")
+			return fmt.Errorf("failed to delete boot rescue: %w", err)
+		}
+	}
+	return nil
+}
+
+// verifyProvisionedOS verifies that the host has booted into the provisioned OS.
+func (s *Service) verifyProvisionedOS(ctx context.Context) actionResult {
+	// If SSHAfterInstallImage is disabled, we cannot SSH into the host and verify the OS.
+	// Therefore move to the next state.
 	if !s.scope.SSHAfterInstallImageEnabled() {
-		// SSH after installimage is disabled for this machine, so we skip the verification phase.
-		record.Event(s.scope.HetznerBareMetalHost, "ServerProvisioned", "server successfully provisioned ('ensure-provisioned' was skipped)")
+		record.Event(s.scope.HetznerBareMetalHost, "ServerProvisioned", "server successfully provisioned (verification was skipped)")
 		v1beta1conditions.MarkTrue(s.scope.HetznerBareMetalHost, infrav1.ProvisionSucceededCondition)
 		v1beta2conditions.Set(s.scope.HetznerBareMetalHost, metav1.Condition{
 			Type:   infrav1.HetznerBareMetalHostProvisionSucceededV1Beta2Condition,
@@ -2021,54 +2184,39 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 		IP:         s.scope.HetznerBareMetalHost.Spec.Status.GetIPAddress(),
 	})
 
-	// Check hostname with sshClient
-	wantHostName := s.scope.Hostname()
-
+	// Check hostname with sshClient.
+	desiredHostName := s.scope.Hostname()
 	out := sshClient.GetHostName(ctx)
 	hostname := trimLineBreak(out.StdOut)
-	if hostname != wantHostName {
-		// give the reboot some time until it takes effect
+
+	if hostname != desiredHostName {
+		// if the host was just rebooted, give it some time.
 		if s.hasJustRebooted() {
 			s.scope.Info("ensureProvisioned: hasJustRebooted. Retrying...", "hostname", hostname)
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, "host has just rebooted")
-			return actionContinue{delay: 2 * time.Second}
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, "host has just rebooted")
+			return actionContinue{delay: 10 * time.Second}
 		}
 
-		isTimeout, isSSHConnectionRefusedError, err := analyzeSSHOutputProvisioned(out)
-		if err != nil {
-			if errors.Is(err, errUnexpectedHostName) {
-				// One possible reason: The machine gets used by a second wl-cluster.
-				record.Warnf(s.scope.HetznerBareMetalHost, "UnexpectedHostName",
-					"EnsureProvision: wanted %q. %s", wantHostName, err.Error())
+		// If the hardware reboot was triggered and it timed-out, then set a fatal error on the host.
+		if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeHardwareRebootTriggered &&
+			hasTimedOut(s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt, hardwareResetTimeout) {
+			// out.Err is set by sshClient.GetHostName when it fails to get the hostname.
+			// It can be a dial/handshake/auth failure, a context timeout, or the remote
+			// "hostname" command itself failing to run.
+			// Only out.Err == nil means out.StdOut is a real hostname.
+			msg := fmt.Sprintf("hardware reboot timed out: OS unreachable via SSH after %s", hardwareResetTimeout)
+			if out.Err == nil {
+				msg = fmt.Sprintf("hostname %q does not match expected %q after reboot", hostname, desiredHostName)
 			}
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, err.Error())
-			return actionError{err: fmt.Errorf("failed to handle incomplete boot - actionEnsureProvisioned: %w", err)}
-		}
 
-		failed, err := s.handleIncompleteBoot(ctx, false, isTimeout, isSSHConnectionRefusedError)
-		if failed {
-			msg := "reboot handling failed"
-			if err != nil {
-				msg = err.Error()
-			}
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, msg)
+			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost, infrav1.StateEnsureProvisioned, msg)
 			return s.recordActionFailure(infrav1.FatalError, msg)
 		}
-		if err != nil {
-			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-				infrav1.StateEnsureProvisioned, err.Error())
-			return actionError{err: fmt.Errorf(errMsgFailedHandlingIncompleteBoot, err)}
-		}
-		markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
-			infrav1.StateEnsureProvisioned, "will retry")
+
 		return actionContinue{delay: 10 * time.Second}
 	}
 
-	// from now on we know that the machine is reachable and
-	// is no longer in the rescue system.
+	// Hostname matches, host is in the provisioned OS.
 
 	s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
 
@@ -2350,7 +2498,8 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 				infrav1.NodeNotFoundReason,
 				clusterv1beta1.ConditionSeverityWarning,
 				"%s",
-				msg)
+				msg,
+			)
 			v1beta2conditions.Set(host, metav1.Condition{
 				Type:    infrav1.HetznerBareMetalHostNodeBootIDRetrievedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
@@ -2369,7 +2518,8 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 			infrav1.GetNodeInWorkloadClusterFailedReason,
 			clusterv1beta1.ConditionSeverityWarning,
 			"%s",
-			err.Error())
+			err.Error(),
+		)
 		v1beta2conditions.Set(host, metav1.Condition{
 			Type:    infrav1.HetznerBareMetalHostNodeBootIDRetrievedV1Beta2Condition,
 			Status:  metav1.ConditionUnknown,
@@ -2598,7 +2748,8 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 
 	// BootID has not changed yet. The node is either still rebooting or the reboot
 	// command hasn't taken effect yet.
-	v1beta1conditions.MarkFalse(host, infrav1.RebootSucceededCondition,
+	v1beta1conditions.MarkFalse(
+		host, infrav1.RebootSucceededCondition,
 		"WaitingForNodeToBeRebooted",
 		clusterv1beta1.ConditionSeverityInfo,
 		"Waiting for the node to be rebooted",

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2204,7 +2204,7 @@ func (s *Service) verifyProvisionedOS(ctx context.Context) actionResult {
 			// It can be a dial/handshake/auth failure, a context timeout, or the remote
 			// "hostname" command itself failing to run.
 			// Only out.Err == nil means out.StdOut is a real hostname.
-			msg := fmt.Sprintf("hardware reboot timed out: OS unreachable via SSH after %s", hardwareResetTimeout)
+			msg := fmt.Sprintf("hardware reboot (to node) timed out: OS unreachable via SSH after %s", hardwareResetTimeout)
 			if out.Err == nil {
 				msg = fmt.Sprintf("hostname %q does not match expected %q after reboot", hostname, desiredHostName)
 			}

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1625,7 +1625,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		hostRebootTriggeredAt *metav1.Time
 		// Rescue SSH client responses (Step-1: checkRescueAndTriggerReboot)
 		// Empty output (default) means non-rescue hostname so Step-1 passes through to Step-2.
-		outRescueSshClientGetHostName sshclient.Output
+		outRescueSSHClientGetHostName sshclient.Output
 		// OS SSH client responses (Step-2: verifyProvisionedOS)
 		outSSHClientGetHostName        sshclient.Output
 		outSSHClientCloudInitStatus    sshclient.Output
@@ -1662,9 +1662,9 @@ var _ = Describe("actionEnsureProvisioned", func() {
 
 			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
 
-			// rescueSshMock is used in Step-1 (checkRescueAndTriggerReboot).
-			rescueSshMock := &sshmock.Client{}
-			rescueSshMock.On("GetHostName", mock.Anything).Return(in.outRescueSshClientGetHostName)
+			// rescueSSHMock is used in Step-1 (checkRescueAndTriggerReboot).
+			rescueSSHMock := &sshmock.Client{}
+			rescueSSHMock.On("GetHostName", mock.Anything).Return(in.outRescueSSHClientGetHostName)
 
 			// sshMock is used in Step-2 (verifyProvisionedOS).
 			sshMock := &sshmock.Client{}
@@ -1687,7 +1687,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			robotMock.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
 
 			service := newTestService(host, &robotMock,
-				bmmock.NewSSHFactory(rescueSshMock, oldSSHMock, sshMock),
+				bmmock.NewSSHFactory(rescueSSHMock, oldSSHMock, sshMock),
 				helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
 				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
 
@@ -1729,7 +1729,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		},
 		Entry("correct hostname, cloud init running",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: running"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1747,7 +1747,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, no SIGTERM",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
@@ -1765,7 +1765,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, SIGTERM",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: "found SIGTERM in cloud init output logs"},
@@ -1783,7 +1783,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init error",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: error"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1801,7 +1801,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init disabled",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: disabled"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1821,7 +1821,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		// refused; returns actionContinue.
 		Entry("connectionFailed, same ports",
 			testCaseActionEnsureProvisioned{
-				outRescueSshClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
+				outRescueSSHClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientGetHostName:                sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientCloudInitStatus:            sshclient.Output{},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1842,7 +1842,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			testCaseActionEnsureProvisioned{
 				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
 				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
-				outRescueSshClientGetHostName:          sshclient.Output{}, // not called (Step-1 skipped)
+				outRescueSSHClientGetHostName:          sshclient.Output{}, // not called (Step-1 skipped)
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
@@ -1863,7 +1863,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			testCaseActionEnsureProvisioned{
 				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
 				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
 				outSSHClientCloudInitStatus:            sshclient.Output{},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1884,7 +1884,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			testCaseActionEnsureProvisioned{
 				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
 				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
-				outRescueSshClientGetHostName:          sshclient.Output{},
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
 				outSSHClientCloudInitStatus:            sshclient.Output{},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1914,18 +1914,18 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		host.Spec.Status.SSHSpec.NoSSHAfterInstallImage = true
 
 		robotMock := robotmock.Client{}
-		rescueSshMock := &sshmock.Client{}
-		osSshMock := &sshmock.Client{}
+		rescueSSHMock := &sshmock.Client{}
+		osSSHMock := &sshmock.Client{}
 
 		service := newTestService(host, &robotMock,
-			bmmock.NewSSHFactory(rescueSshMock, osSshMock, osSshMock),
+			bmmock.NewSSHFactory(rescueSSHMock, osSSHMock, osSSHMock),
 			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
 			helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
 
 		actResult := service.actionEnsureProvisioned(ctx)
 		Expect(actResult).Should(BeAssignableToTypeOf(actionComplete{}))
 		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.ErrorType("")))
-		Expect(osSshMock.AssertNotCalled(GinkgoT(), "GetHostName", mock.Anything)).To(BeTrue())
+		Expect(osSSHMock.AssertNotCalled(GinkgoT(), "GetHostName", mock.Anything)).To(BeTrue())
 	})
 })
 
@@ -1964,8 +1964,8 @@ var _ = Describe("checkRescueAndTriggerReboot", func() {
 
 			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
 
-			rescueSshMock := &sshmock.Client{}
-			rescueSshMock.On("GetHostName", mock.Anything).Return(tc.rescueSSHHostname)
+			rescueSSHMock := &sshmock.Client{}
+			rescueSSHMock.On("GetHostName", mock.Anything).Return(tc.rescueSSHHostname)
 
 			robotMock := robotmock.Client{}
 			robotMock.On("GetBootRescue", mock.Anything).Return(&models.Rescue{Active: tc.rescueActive}, nil)
@@ -1973,7 +1973,7 @@ var _ = Describe("checkRescueAndTriggerReboot", func() {
 			robotMock.On("RebootBMServer", mock.Anything, mock.Anything).Return(&models.ResetPost{}, nil)
 
 			service := newTestService(host, &robotMock,
-				bmmock.NewSSHFactory(rescueSshMock, &sshmock.Client{}, &sshmock.Client{}),
+				bmmock.NewSSHFactory(rescueSSHMock, &sshmock.Client{}, &sshmock.Client{}),
 				nil,
 				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
 

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1620,11 +1620,19 @@ var _ = Describe("getImageDetails", func() {
 
 var _ = Describe("actionEnsureProvisioned", func() {
 	type testCaseActionEnsureProvisioned struct {
-		outSSHClientGetHostName                sshclient.Output
-		outSSHClientCloudInitStatus            sshclient.Output
-		outSSHClientCheckSigterm               sshclient.Output
-		outOldSSHClientCloudInitStatus         sshclient.Output
-		outOldSSHClientCheckSigterm            sshclient.Output
+		// Initial host state
+		hostErrorType         infrav1.ErrorType
+		hostRebootTriggeredAt *metav1.Time
+		// Rescue SSH client responses (Step-1: checkRescueAndTriggerReboot)
+		// Empty output (default) means non-rescue hostname so Step-1 passes through to Step-2.
+		outRescueSshClientGetHostName sshclient.Output
+		// OS SSH client responses (Step-2: verifyProvisionedOS)
+		outSSHClientGetHostName        sshclient.Output
+		outSSHClientCloudInitStatus    sshclient.Output
+		outSSHClientCheckSigterm       sshclient.Output
+		outOldSSHClientCloudInitStatus sshclient.Output
+		outOldSSHClientCheckSigterm    sshclient.Output
+		// Expected results
 		expectedActionResult                   actionResult
 		expectedErrorType                      infrav1.ErrorType
 		expectsSSHClientCallCloudInitStatus    bool
@@ -1640,13 +1648,25 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			ctx := context.Background()
 			portAfterInstallImage := 24
 
-			host := helpers.BareMetalHost(
-				"test-host",
-				"default",
+			hostOpts := []helpers.HostOpts{
 				helpers.WithSSHSpecInclPorts(portAfterInstallImage),
 				helpers.WithIPv4(),
 				helpers.WithConsumerRef(),
-			)
+			}
+			if in.hostErrorType != infrav1.ErrorType("") {
+				hostOpts = append(hostOpts, helpers.WithError(in.hostErrorType, "test error", 1))
+			}
+			if in.hostRebootTriggeredAt != nil {
+				hostOpts = append(hostOpts, helpers.WithRebootTriggeredAt(*in.hostRebootTriggeredAt))
+			}
+
+			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
+
+			// rescueSshMock is used in Step-1 (checkRescueAndTriggerReboot).
+			rescueSshMock := &sshmock.Client{}
+			rescueSshMock.On("GetHostName", mock.Anything).Return(in.outRescueSshClientGetHostName)
+
+			// sshMock is used in Step-2 (verifyProvisionedOS).
 			sshMock := &sshmock.Client{}
 			sshMock.On("GetHostName", mock.Anything).Return(in.outSSHClientGetHostName)
 			sshMock.On("CloudInitStatus", mock.Anything).Return(in.outSSHClientCloudInitStatus)
@@ -1666,7 +1686,10 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			robotMock := robotmock.Client{}
 			robotMock.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
 
-			service := newTestService(host, &robotMock, bmmock.NewSSHFactory(sshMock, oldSSHMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), nil)
+			service := newTestService(host, &robotMock,
+				bmmock.NewSSHFactory(rescueSshMock, oldSSHMock, sshMock),
+				helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
 
 			actResult := service.actionEnsureProvisioned(ctx)
 			Expect(actResult).Should(BeAssignableToTypeOf(in.expectedActionResult))
@@ -1706,6 +1729,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		},
 		Entry("correct hostname, cloud init running",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: running"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1723,6 +1747,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, no SIGTERM",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
@@ -1740,6 +1765,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, SIGTERM",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: "found SIGTERM in cloud init output logs"},
@@ -1757,6 +1783,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init error",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: error"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1774,6 +1801,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init disabled",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: disabled"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1789,21 +1817,282 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				expectsOldSSHClientCallReboot:          false,
 			},
 		),
+		// connectionFailed: SSH error in Step-1, so passes through to Step-2, which also gets connection
+		// refused; returns actionContinue.
 		Entry("connectionFailed, same ports",
 			testCaseActionEnsureProvisioned{
+				outRescueSshClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientGetHostName:                sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientCloudInitStatus:            sshclient.Output{},
 				outSSHClientCheckSigterm:               sshclient.Output{},
 				outOldSSHClientCloudInitStatus:         sshclient.Output{},
 				outOldSSHClientCheckSigterm:            sshclient.Output{},
 				expectedActionResult:                   actionContinue{},
-				expectedErrorType:                      infrav1.ErrorTypeConnectionError,
+				expectedErrorType:                      infrav1.ErrorType(""),
 				expectsSSHClientCallCloudInitStatus:    false,
 				expectsSSHClientCallCheckSigterm:       false,
 				expectsSSHClientCallReboot:             false,
 				expectsOldSSHClientCallCloudInitStatus: false,
 				expectsOldSSHClientCallCheckSigterm:    false,
 				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// When ErrorTypeHardwareRebootTriggered is set, Step-1 is skipped and Step-2 runs directly.
+		Entry("hardware reboot triggered, correct hostname, cloud init done",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				outRescueSshClientGetHostName:          sshclient.Output{}, // not called (Step-1 skipped)
+				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
+				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
+				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionComplete{},
+				expectedErrorType:                      infrav1.ErrorType(""),
+				expectsSSHClientCallCloudInitStatus:    true,
+				expectsSSHClientCallCheckSigterm:       true,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// Hardware reboot triggered but hostname not matching yet and timeout not reached, therefore requeue.
+		Entry("hardware reboot triggered, SSH timeout, hardware reboot not timed out",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				outRescueSshClientGetHostName:          sshclient.Output{},
+				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
+				outSSHClientCloudInitStatus:            sshclient.Output{},
+				outSSHClientCheckSigterm:               sshclient.Output{},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionContinue{},
+				expectedErrorType:                      infrav1.ErrorType(""),
+				expectsSSHClientCallCloudInitStatus:    false,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// Hardware reboot triggered, hostname still not matching after hardwareResetTimeout, set permanent error.
+		Entry("hardware reboot triggered, SSH timeout, hardware reboot timed out",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				outRescueSshClientGetHostName:          sshclient.Output{},
+				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
+				outSSHClientCloudInitStatus:            sshclient.Output{},
+				outSSHClientCheckSigterm:               sshclient.Output{},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionFailed{},
+				expectedErrorType:                      infrav1.PermanentError,
+				expectsSSHClientCallCloudInitStatus:    false,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+	)
+
+	It("SSHAfterInstallImage disabled: mark complete immediately without SSH verification", func() {
+		ctx := context.Background()
+		host := helpers.BareMetalHost("test-host", "default",
+			helpers.WithSSHSpecInclPorts(24),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+			// Use ErrorTypeHardwareRebootTriggered so Step-1 is skipped.
+			helpers.WithError(infrav1.ErrorTypeHardwareRebootTriggered, "test", 1),
+		)
+		host.Spec.Status.SSHSpec.NoSSHAfterInstallImage = true
+
+		robotMock := robotmock.Client{}
+		rescueSshMock := &sshmock.Client{}
+		osSshMock := &sshmock.Client{}
+
+		service := newTestService(host, &robotMock,
+			bmmock.NewSSHFactory(rescueSshMock, osSshMock, osSshMock),
+			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+			helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
+
+		actResult := service.actionEnsureProvisioned(ctx)
+		Expect(actResult).Should(BeAssignableToTypeOf(actionComplete{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.ErrorType("")))
+		Expect(osSshMock.AssertNotCalled(GinkgoT(), "GetHostName", mock.Anything)).To(BeTrue())
+	})
+})
+
+var _ = Describe("checkRescueAndTriggerReboot", func() {
+	type testCaseCheckRescueAndTriggerReboot struct {
+		hostErrorType         infrav1.ErrorType
+		hostRebootTriggeredAt *metav1.Time
+		rebootTypes           []infrav1.RebootType
+		rescueSSHHostname     sshclient.Output
+		rescueActive          bool
+		// Expected
+		expectNilResult        bool // true = proceeds to Step-2
+		expectedActionResult   actionResult
+		expectedErrorType      infrav1.ErrorType
+		expectRebootBMServer   bool
+		expectedRebootType     infrav1.RebootType
+		expectDeleteBootRescue bool
+	}
+
+	DescribeTable("checkRescueAndTriggerReboot",
+		func(tc testCaseCheckRescueAndTriggerReboot) {
+			ctx := context.Background()
+
+			hostOpts := []helpers.HostOpts{
+				helpers.WithIPv4(),
+				helpers.WithSSHSpec(),
+				helpers.WithSSHStatus(),
+				helpers.WithRebootTypes(tc.rebootTypes),
+			}
+			if tc.hostErrorType != infrav1.ErrorType("") {
+				hostOpts = append(hostOpts, helpers.WithError(tc.hostErrorType, "test", 1))
+			}
+			if tc.hostRebootTriggeredAt != nil {
+				hostOpts = append(hostOpts, helpers.WithRebootTriggeredAt(*tc.hostRebootTriggeredAt))
+			}
+
+			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
+
+			rescueSshMock := &sshmock.Client{}
+			rescueSshMock.On("GetHostName", mock.Anything).Return(tc.rescueSSHHostname)
+
+			robotMock := robotmock.Client{}
+			robotMock.On("GetBootRescue", mock.Anything).Return(&models.Rescue{Active: tc.rescueActive}, nil)
+			robotMock.On("DeleteBootRescue", mock.Anything).Return(&models.Rescue{Active: false}, nil)
+			robotMock.On("RebootBMServer", mock.Anything, mock.Anything).Return(&models.ResetPost{}, nil)
+
+			service := newTestService(host, &robotMock,
+				bmmock.NewSSHFactory(rescueSshMock, &sshmock.Client{}, &sshmock.Client{}),
+				nil,
+				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
+
+			result := service.checkRescueAndTriggerReboot(ctx)
+
+			if tc.expectNilResult {
+				Expect(result).To(BeNil())
+			} else {
+				Expect(result).Should(BeAssignableToTypeOf(tc.expectedActionResult))
+			}
+
+			if tc.expectedErrorType != infrav1.ErrorType("") {
+				Expect(host.Spec.Status.ErrorType).To(Equal(tc.expectedErrorType))
+			}
+
+			if tc.expectRebootBMServer {
+				Expect(robotMock.AssertCalled(GinkgoT(), "RebootBMServer", mock.Anything, tc.expectedRebootType)).To(BeTrue())
+			} else {
+				Expect(robotMock.AssertNotCalled(GinkgoT(), "RebootBMServer", mock.Anything, mock.Anything)).To(BeTrue())
+			}
+
+			if tc.expectDeleteBootRescue {
+				Expect(robotMock.AssertCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
+			} else {
+				Expect(robotMock.AssertNotCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
+			}
+		},
+		// software reboot timed out: skip SSH, trigger hardware reboot and proceed to Step-2.
+		Entry("software reboot timed out: escalate to hardware reboot without SSH check",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:          infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt:  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				rebootTypes:            []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:      sshclient.Output{}, // not called
+				rescueActive:           false,
+				expectNilResult:        true,
+				expectedErrorType:      infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer:   true,
+				expectedRebootType:     infrav1.RebootTypeHardware,
+				expectDeleteBootRescue: false,
+			},
+		),
+		// active rescue: DeleteBootRescue is called before triggering hardware reboot.
+		Entry("software reboot timed out, rescue active: unset rescue then hardware reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:          infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt:  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				rebootTypes:            []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:      sshclient.Output{},
+				rescueActive:           true,
+				expectNilResult:        true,
+				expectedErrorType:      infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer:   true,
+				expectedRebootType:     infrav1.RebootTypeHardware,
+				expectDeleteBootRescue: true,
+			},
+		),
+		// SSH error accessing rescue mode: host may already be booting OS, pass through to Step-2.
+		Entry("rescue SSH error: pass through to Step-2",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:       []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname: sshclient.Output{Err: syscall.ECONNREFUSED},
+				expectNilResult:   true,
+			},
+		),
+		// non-rescue hostname: host is booting OS or already there, pass through to Step-2.
+		Entry("non-rescue hostname: pass through to Step-2",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:       []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname: sshclient.Output{StdOut: "some-other-hostname"},
+				expectNilResult:   true,
+			},
+		),
+		// Rescue hostname but reboot was triggered recently: give the reboot time to take effect.
+		Entry("rescue hostname, recently rebooted: wait for reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:         infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt: ptr.To(metav1.NewTime(time.Now().Add(-5 * time.Second))),
+				rebootTypes:           []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:     sshclient.Output{StdOut: rescue},
+				expectNilResult:       false,
+				expectedActionResult:  actionContinue{},
+			},
+		),
+		// Rescue hostname, no prior reboot, software reboot available: trigger software reboot and requeue.
+		Entry("rescue hostname, no prior error, software reboot available: trigger software reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:          []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:    sshclient.Output{StdOut: rescue},
+				rescueActive:         false,
+				expectNilResult:      false,
+				expectedActionResult: actionContinue{},
+				expectedErrorType:    infrav1.ErrorTypeSoftwareRebootTriggered,
+				expectRebootBMServer: true,
+				expectedRebootType:   infrav1.RebootTypeSoftware,
+			},
+		),
+		// Rescue hostname, no prior reboot, hardware reboot only: trigger hardware reboot and proceed to Step-2.
+		Entry("rescue hostname, no prior error, hardware reboot only: trigger hardware reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:          []infrav1.RebootType{infrav1.RebootTypeHardware},
+				rescueSSHHostname:    sshclient.Output{StdOut: rescue},
+				rescueActive:         false,
+				expectNilResult:      true,
+				expectedErrorType:    infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer: true,
+				expectedRebootType:   infrav1.RebootTypeHardware,
+			},
+		),
+		// Rescue hostname with software reboot in progress but not timed out: keep waiting.
+		Entry("rescue hostname, software reboot in progress, not timed out: requeue",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:         infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt: ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				rebootTypes:           []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:     sshclient.Output{StdOut: rescue},
+				rescueActive:          false,
+				expectNilResult:       false,
+				expectedActionResult:  actionContinue{},
 			},
 		),
 	)

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1809,11 +1809,19 @@ var _ = Describe("getImageDetails", func() {
 
 var _ = Describe("actionEnsureProvisioned", func() {
 	type testCaseActionEnsureProvisioned struct {
-		outSSHClientGetHostName                sshclient.Output
-		outSSHClientCloudInitStatus            sshclient.Output
-		outSSHClientCheckSigterm               sshclient.Output
-		outOldSSHClientCloudInitStatus         sshclient.Output
-		outOldSSHClientCheckSigterm            sshclient.Output
+		// Initial host state
+		hostErrorType         infrav1.ErrorType
+		hostRebootTriggeredAt *metav1.Time
+		// Rescue SSH client responses (Step-1: checkRescueAndTriggerReboot)
+		// Empty output (default) means non-rescue hostname so Step-1 passes through to Step-2.
+		outRescueSSHClientGetHostName sshclient.Output
+		// OS SSH client responses (Step-2: verifyProvisionedOS)
+		outSSHClientGetHostName        sshclient.Output
+		outSSHClientCloudInitStatus    sshclient.Output
+		outSSHClientCheckSigterm       sshclient.Output
+		outOldSSHClientCloudInitStatus sshclient.Output
+		outOldSSHClientCheckSigterm    sshclient.Output
+		// Expected results
 		expectedActionResult                   actionResult
 		expectedErrorType                      infrav1.ErrorType
 		expectsSSHClientCallCloudInitStatus    bool
@@ -1829,13 +1837,25 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			ctx := context.Background()
 			portAfterInstallImage := 24
 
-			host := helpers.BareMetalHost(
-				"test-host",
-				"default",
+			hostOpts := []helpers.HostOpts{
 				helpers.WithSSHSpecInclPorts(portAfterInstallImage),
 				helpers.WithIPv4(),
 				helpers.WithConsumerRef(),
-			)
+			}
+			if in.hostErrorType != infrav1.ErrorType("") {
+				hostOpts = append(hostOpts, helpers.WithError(in.hostErrorType, "test error", 1))
+			}
+			if in.hostRebootTriggeredAt != nil {
+				hostOpts = append(hostOpts, helpers.WithRebootTriggeredAt(*in.hostRebootTriggeredAt))
+			}
+
+			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
+
+			// rescueSSHMock is used in Step-1 (checkRescueAndTriggerReboot).
+			rescueSSHMock := &sshmock.Client{}
+			rescueSSHMock.On("GetHostName", mock.Anything).Return(in.outRescueSSHClientGetHostName)
+
+			// sshMock is used in Step-2 (verifyProvisionedOS).
 			sshMock := &sshmock.Client{}
 			sshMock.On("GetHostName", mock.Anything).Return(in.outSSHClientGetHostName)
 			sshMock.On("CloudInitStatus", mock.Anything).Return(in.outSSHClientCloudInitStatus)
@@ -1855,7 +1875,10 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			robotMock := robotmock.Client{}
 			robotMock.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
 
-			service := newTestService(host, &robotMock, bmmock.NewSSHFactory(sshMock, oldSSHMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), nil)
+			service := newTestService(host, &robotMock,
+				bmmock.NewSSHFactory(rescueSSHMock, oldSSHMock, sshMock),
+				helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
 
 			actResult := service.actionEnsureProvisioned(ctx)
 			Expect(actResult).Should(BeAssignableToTypeOf(in.expectedActionResult))
@@ -1895,6 +1918,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		},
 		Entry("correct hostname, cloud init running",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: running"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1912,6 +1936,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, no SIGTERM",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
@@ -1929,6 +1954,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init done, SIGTERM",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
 				outSSHClientCheckSigterm:               sshclient.Output{StdOut: "found SIGTERM in cloud init output logs"},
@@ -1946,6 +1972,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init error",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: error"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1963,6 +1990,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 		),
 		Entry("correct hostname, cloud init disabled",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{},
 				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
 				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: disabled"},
 				outSSHClientCheckSigterm:               sshclient.Output{},
@@ -1978,21 +2006,282 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				expectsOldSSHClientCallReboot:          false,
 			},
 		),
+		// connectionFailed: SSH error in Step-1, so passes through to Step-2, which also gets connection
+		// refused; returns actionContinue.
 		Entry("connectionFailed, same ports",
 			testCaseActionEnsureProvisioned{
+				outRescueSSHClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientGetHostName:                sshclient.Output{Err: syscall.ECONNREFUSED},
 				outSSHClientCloudInitStatus:            sshclient.Output{},
 				outSSHClientCheckSigterm:               sshclient.Output{},
 				outOldSSHClientCloudInitStatus:         sshclient.Output{},
 				outOldSSHClientCheckSigterm:            sshclient.Output{},
 				expectedActionResult:                   actionContinue{},
-				expectedErrorType:                      infrav1.ErrorTypeConnectionError,
+				expectedErrorType:                      infrav1.ErrorType(""),
 				expectsSSHClientCallCloudInitStatus:    false,
 				expectsSSHClientCallCheckSigterm:       false,
 				expectsSSHClientCallReboot:             false,
 				expectsOldSSHClientCallCloudInitStatus: false,
 				expectsOldSSHClientCallCheckSigterm:    false,
 				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// When ErrorTypeHardwareRebootTriggered is set, Step-1 is skipped and Step-2 runs directly.
+		Entry("hardware reboot triggered, correct hostname, cloud init done",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				outRescueSSHClientGetHostName:          sshclient.Output{}, // not called (Step-1 skipped)
+				outSSHClientGetHostName:                sshclient.Output{StdOut: infrav1.BareMetalHostNamePrefix + "bm-machine"},
+				outSSHClientCloudInitStatus:            sshclient.Output{StdOut: "status: done"},
+				outSSHClientCheckSigterm:               sshclient.Output{StdOut: ""},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionComplete{},
+				expectedErrorType:                      infrav1.ErrorType(""),
+				expectsSSHClientCallCloudInitStatus:    true,
+				expectsSSHClientCallCheckSigterm:       true,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// Hardware reboot triggered but hostname not matching yet and timeout not reached, therefore requeue.
+		Entry("hardware reboot triggered, SSH timeout, hardware reboot not timed out",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				outRescueSSHClientGetHostName:          sshclient.Output{},
+				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
+				outSSHClientCloudInitStatus:            sshclient.Output{},
+				outSSHClientCheckSigterm:               sshclient.Output{},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionContinue{},
+				expectedErrorType:                      infrav1.ErrorType(""),
+				expectsSSHClientCallCloudInitStatus:    false,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// Hardware reboot triggered, hostname still not matching after hardwareResetTimeout, set permanent error.
+		Entry("hardware reboot triggered, SSH timeout, hardware reboot timed out",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeHardwareRebootTriggered,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				outRescueSSHClientGetHostName:          sshclient.Output{},
+				outSSHClientGetHostName:                sshclient.Output{Err: timeout},
+				outSSHClientCloudInitStatus:            sshclient.Output{},
+				outSSHClientCheckSigterm:               sshclient.Output{},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionFailed{},
+				expectedErrorType:                      infrav1.PermanentError,
+				expectsSSHClientCallCloudInitStatus:    false,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+	)
+
+	It("SSHAfterInstallImage disabled: mark complete immediately without SSH verification", func() {
+		ctx := context.Background()
+		host := helpers.BareMetalHost("test-host", "default",
+			helpers.WithSSHSpecInclPorts(24),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+			// Use ErrorTypeHardwareRebootTriggered so Step-1 is skipped.
+			helpers.WithError(infrav1.ErrorTypeHardwareRebootTriggered, "test", 1),
+		)
+		host.Spec.Status.SSHSpec.NoSSHAfterInstallImage = true
+
+		robotMock := robotmock.Client{}
+		rescueSSHMock := &sshmock.Client{}
+		osSSHMock := &sshmock.Client{}
+
+		service := newTestService(host, &robotMock,
+			bmmock.NewSSHFactory(rescueSSHMock, osSSHMock, osSSHMock),
+			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+			helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
+
+		actResult := service.actionEnsureProvisioned(ctx)
+		Expect(actResult).Should(BeAssignableToTypeOf(actionComplete{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.ErrorType("")))
+		Expect(osSSHMock.AssertNotCalled(GinkgoT(), "GetHostName", mock.Anything)).To(BeTrue())
+	})
+})
+
+var _ = Describe("checkRescueAndTriggerReboot", func() {
+	type testCaseCheckRescueAndTriggerReboot struct {
+		hostErrorType         infrav1.ErrorType
+		hostRebootTriggeredAt *metav1.Time
+		rebootTypes           []infrav1.RebootType
+		rescueSSHHostname     sshclient.Output
+		rescueActive          bool
+		// Expected
+		expectNilResult        bool // true = proceeds to Step-2
+		expectedActionResult   actionResult
+		expectedErrorType      infrav1.ErrorType
+		expectRebootBMServer   bool
+		expectedRebootType     infrav1.RebootType
+		expectDeleteBootRescue bool
+	}
+
+	DescribeTable("checkRescueAndTriggerReboot",
+		func(tc testCaseCheckRescueAndTriggerReboot) {
+			ctx := context.Background()
+
+			hostOpts := []helpers.HostOpts{
+				helpers.WithIPv4(),
+				helpers.WithSSHSpec(),
+				helpers.WithSSHStatus(),
+				helpers.WithRebootTypes(tc.rebootTypes),
+			}
+			if tc.hostErrorType != infrav1.ErrorType("") {
+				hostOpts = append(hostOpts, helpers.WithError(tc.hostErrorType, "test", 1))
+			}
+			if tc.hostRebootTriggeredAt != nil {
+				hostOpts = append(hostOpts, helpers.WithRebootTriggeredAt(*tc.hostRebootTriggeredAt))
+			}
+
+			host := helpers.BareMetalHost("test-host", "default", hostOpts...)
+
+			rescueSSHMock := &sshmock.Client{}
+			rescueSSHMock.On("GetHostName", mock.Anything).Return(tc.rescueSSHHostname)
+
+			robotMock := robotmock.Client{}
+			robotMock.On("GetBootRescue", mock.Anything).Return(&models.Rescue{Active: tc.rescueActive}, nil)
+			robotMock.On("DeleteBootRescue", mock.Anything).Return(&models.Rescue{Active: false}, nil)
+			robotMock.On("RebootBMServer", mock.Anything, mock.Anything).Return(&models.ResetPost{}, nil)
+
+			service := newTestService(host, &robotMock,
+				bmmock.NewSSHFactory(rescueSSHMock, &sshmock.Client{}, &sshmock.Client{}),
+				nil,
+				helpers.GetDefaultSSHSecret("rescue-ssh-secret", "default"))
+
+			result := service.checkRescueAndTriggerReboot(ctx)
+
+			if tc.expectNilResult {
+				Expect(result).To(BeNil())
+			} else {
+				Expect(result).Should(BeAssignableToTypeOf(tc.expectedActionResult))
+			}
+
+			if tc.expectedErrorType != infrav1.ErrorType("") {
+				Expect(host.Spec.Status.ErrorType).To(Equal(tc.expectedErrorType))
+			}
+
+			if tc.expectRebootBMServer {
+				Expect(robotMock.AssertCalled(GinkgoT(), "RebootBMServer", mock.Anything, tc.expectedRebootType)).To(BeTrue())
+			} else {
+				Expect(robotMock.AssertNotCalled(GinkgoT(), "RebootBMServer", mock.Anything, mock.Anything)).To(BeTrue())
+			}
+
+			if tc.expectDeleteBootRescue {
+				Expect(robotMock.AssertCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
+			} else {
+				Expect(robotMock.AssertNotCalled(GinkgoT(), "DeleteBootRescue", mock.Anything)).To(BeTrue())
+			}
+		},
+		// software reboot timed out: skip SSH, trigger hardware reboot and proceed to Step-2.
+		Entry("software reboot timed out: escalate to hardware reboot without SSH check",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:          infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt:  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				rebootTypes:            []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:      sshclient.Output{}, // not called
+				rescueActive:           false,
+				expectNilResult:        true,
+				expectedErrorType:      infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer:   true,
+				expectedRebootType:     infrav1.RebootTypeHardware,
+				expectDeleteBootRescue: false,
+			},
+		),
+		// active rescue: DeleteBootRescue is called before triggering hardware reboot.
+		Entry("software reboot timed out, rescue active: unset rescue then hardware reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:          infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt:  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				rebootTypes:            []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:      sshclient.Output{},
+				rescueActive:           true,
+				expectNilResult:        true,
+				expectedErrorType:      infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer:   true,
+				expectedRebootType:     infrav1.RebootTypeHardware,
+				expectDeleteBootRescue: true,
+			},
+		),
+		// SSH error accessing rescue mode: host may already be booting OS, pass through to Step-2.
+		Entry("rescue SSH error: pass through to Step-2",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:       []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname: sshclient.Output{Err: syscall.ECONNREFUSED},
+				expectNilResult:   true,
+			},
+		),
+		// non-rescue hostname: host is booting OS or already there, pass through to Step-2.
+		Entry("non-rescue hostname: pass through to Step-2",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:       []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname: sshclient.Output{StdOut: "some-other-hostname"},
+				expectNilResult:   true,
+			},
+		),
+		// Rescue hostname but reboot was triggered recently: give the reboot time to take effect.
+		Entry("rescue hostname, recently rebooted: wait for reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:         infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt: ptr.To(metav1.NewTime(time.Now().Add(-5 * time.Second))),
+				rebootTypes:           []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:     sshclient.Output{StdOut: rescue},
+				expectNilResult:       false,
+				expectedActionResult:  actionContinue{},
+			},
+		),
+		// Rescue hostname, no prior reboot, software reboot available: trigger software reboot and requeue.
+		Entry("rescue hostname, no prior error, software reboot available: trigger software reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:          []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:    sshclient.Output{StdOut: rescue},
+				rescueActive:         false,
+				expectNilResult:      false,
+				expectedActionResult: actionContinue{},
+				expectedErrorType:    infrav1.ErrorTypeSoftwareRebootTriggered,
+				expectRebootBMServer: true,
+				expectedRebootType:   infrav1.RebootTypeSoftware,
+			},
+		),
+		// Rescue hostname, no prior reboot, hardware reboot only: trigger hardware reboot and proceed to Step-2.
+		Entry("rescue hostname, no prior error, hardware reboot only: trigger hardware reboot",
+			testCaseCheckRescueAndTriggerReboot{
+				rebootTypes:          []infrav1.RebootType{infrav1.RebootTypeHardware},
+				rescueSSHHostname:    sshclient.Output{StdOut: rescue},
+				rescueActive:         false,
+				expectNilResult:      true,
+				expectedErrorType:    infrav1.ErrorTypeHardwareRebootTriggered,
+				expectRebootBMServer: true,
+				expectedRebootType:   infrav1.RebootTypeHardware,
+			},
+		),
+		// Rescue hostname with software reboot in progress but not timed out: keep waiting.
+		Entry("rescue hostname, software reboot in progress, not timed out: requeue",
+			testCaseCheckRescueAndTriggerReboot{
+				hostErrorType:         infrav1.ErrorTypeSoftwareRebootTriggered,
+				hostRebootTriggeredAt: ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute))),
+				rebootTypes:           []infrav1.RebootType{infrav1.RebootTypeSoftware, infrav1.RebootTypeHardware},
+				rescueSSHHostname:     sshclient.Output{StdOut: rescue},
+				rescueActive:          false,
+				expectNilResult:       false,
+				expectedActionResult:  actionContinue{},
 			},
 		),
 	)

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -2080,7 +2080,7 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				outOldSSHClientCloudInitStatus:         sshclient.Output{},
 				outOldSSHClientCheckSigterm:            sshclient.Output{},
 				expectedActionResult:                   actionFailed{},
-				expectedErrorType:                      infrav1.PermanentError,
+				expectedErrorType:                      infrav1.FatalError,
 				expectsSSHClientCallCloudInitStatus:    false,
 				expectsSSHClientCallCheckSigterm:       false,
 				expectsSSHClientCallReboot:             false,
@@ -2312,7 +2312,7 @@ var _ = Describe("checkRescueAndTriggerReboot", func() {
 		robotMock := robotmock.Client{}
 		robotMock.On("SetBMServerName", mock.Anything, infrav1.BareMetalHostNamePrefix+host.Spec.ConsumerRef.Name).Return(nil, nil)
 
-		service := newTestService(host, &robotMock, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), nil)
+		service := newTestService(host, &robotMock, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 
 		// the error is still returned, and the cloud-init output is recorded in an event
 		Expect(service.actionEnsureProvisioned(ctx)).To(BeAssignableToTypeOf(actionError{}))

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -2007,7 +2007,8 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			},
 		),
 		// connectionFailed: SSH error in Step-1, so passes through to Step-2, which also gets connection
-		// refused; returns actionContinue.
+		// refused; returns actionContinue and starts tracking ErrorTypeConnectionError so a host
+		// that is unreachable via SSH everywhere eventually escalates instead of retrying forever.
 		Entry("connectionFailed, same ports",
 			testCaseActionEnsureProvisioned{
 				outRescueSSHClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
@@ -2017,7 +2018,29 @@ var _ = Describe("actionEnsureProvisioned", func() {
 				outOldSSHClientCloudInitStatus:         sshclient.Output{},
 				outOldSSHClientCheckSigterm:            sshclient.Output{},
 				expectedActionResult:                   actionContinue{},
-				expectedErrorType:                      infrav1.ErrorType(""),
+				expectedErrorType:                      infrav1.ErrorTypeConnectionError,
+				expectsSSHClientCallCloudInitStatus:    false,
+				expectsSSHClientCallCheckSigterm:       false,
+				expectsSSHClientCallReboot:             false,
+				expectsOldSSHClientCallCloudInitStatus: false,
+				expectsOldSSHClientCallCheckSigterm:    false,
+				expectsOldSSHClientCallReboot:          false,
+			},
+		),
+		// connectionFailed, still unreachable after connectionRefusedTimeout: give up instead of
+		// retrying forever.
+		Entry("connectionFailed, same ports, timed out",
+			testCaseActionEnsureProvisioned{
+				hostErrorType:                          infrav1.ErrorTypeConnectionError,
+				hostRebootTriggeredAt:                  ptr.To(metav1.NewTime(time.Now().Add(-15 * time.Minute))),
+				outRescueSSHClientGetHostName:          sshclient.Output{Err: syscall.ECONNREFUSED},
+				outSSHClientGetHostName:                sshclient.Output{Err: syscall.ECONNREFUSED},
+				outSSHClientCloudInitStatus:            sshclient.Output{},
+				outSSHClientCheckSigterm:               sshclient.Output{},
+				outOldSSHClientCloudInitStatus:         sshclient.Output{},
+				outOldSSHClientCheckSigterm:            sshclient.Output{},
+				expectedActionResult:                   actionFailed{},
+				expectedErrorType:                      infrav1.FatalError,
 				expectsSSHClientCallCloudInitStatus:    false,
 				expectsSSHClientCallCheckSigterm:       false,
 				expectsSSHClientCallReboot:             false,


### PR DESCRIPTION

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Refactor `actionEnsureProvisioned` to reliably detect failed rescue mode reboot.

actionEnsureProvisioned is refactored into 2 steps:
 **Step-1**: Check if the host is still in rescue mode SSH on port 22 and check `hostname`.

If hostname is `rescue`:
- Check if the host was just rebooted (within 15s period)
  - If yes, reque with delay.
- Ensure rescue is not set for the next reboot.
  - If rescue is set for next boot, unset it via robot API.
- Based on the current `ErrorType`, decide what to do:
  - *Empty*: This means no prior reboot triggered. Use trigger software reboot (if the host supports it) otherwise hardware reboot.
  - *`ErrorTypeSoftwareRebootTriggered` and not timed out yet (within `softwareResetTimeout` of 10 min)*: The software reboot is still in progress, so reque with delay.
  - *`ErrorTypeSoftwareRebootTriggered` and timed out*: Software reboot failed to bring the host out of rescue. Escalate to hardware reboot. Trigger hardware reboot via Robot API, set `ErrorTypeHardwareRebootTriggered` and move to Step-2.

If SSH error or hostname is not rescue, then also move to step-2

**Step-2**:
If `SSHAfterInstallImage` is disabled, mark the action as completed, clear the `ErrorType` and move to the next phase `Provisioned`. Otherwise, SSH via configured OS port and check hostname.
- If hostname matches the desired hostname: mark the action as completed, clear the errorType and move to the next phase.
- If the hostname doesn't match:
  - If `ErrorTypeHardwareRebootTriggered` and not yet timed out (within `hardwareResetTimeout` of 10 min): requeue with delay as the hardware reboot is still in progress.
  - Otherwise set a fatal error.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2073 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

