### PR TITLE
:bug: Fix stale HetznerCluster.Status causing cp targets to be skipped on LB attach

### DIFF
--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -1005,6 +1005,16 @@ func (r *HetznerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			handler.EnqueueRequestsFromMapFunc(r.clusterToHetznerCluster),
 			builder.WithPredicates(IgnoreInsignificantClusterStatusUpdates(log)),
 		).
+		Watches(
+			&infrav1.HetznerBareMetalMachine{},
+			handler.EnqueueRequestsFromMapFunc(r.baremetalMachineToHetznerCluster),
+			builder.WithPredicates(controlPlaneMachineToHetznerClusterPredicate()),
+		).
+		Watches(
+			&infrav1.HCloudMachine{},
+			handler.EnqueueRequestsFromMapFunc(r.hcloudMachineToHetznerCluster),
+			builder.WithPredicates(controlPlaneMachineToHetznerClusterPredicate()),
+		).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)
@@ -1158,5 +1168,81 @@ func IgnoreInsignificantHetznerClusterStatusUpdates(logger logr.Logger) predicat
 		CreateFunc:  func(_ event.CreateEvent) bool { return true },
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return true },
+	}
+}
+
+// bareMetalMachineToHetznerCluster maps an HetznerBareMetalMachine to the owning HetznerCluster.
+func (r *HetznerClusterReconciler) baremetalMachineToHetznerCluster(ctx context.Context, o client.Object) []reconcile.Request {
+	bm, ok := o.(*infrav1.HetznerBareMetalMachine)
+	if !ok {
+		return nil
+	}
+
+	clusterName := bm.Labels[clusterv1.ClusterNameLabel]
+	if clusterName == "" {
+		return nil
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: bm.Namespace, Name: clusterName}, cluster); err != nil {
+		return nil
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "HetznerCluster" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: bm.Namespace, Name: cluster.Spec.InfrastructureRef.Name},
+	}}
+}
+
+// hcloudMachineToHetznerCluster maps an HCloudMachine to the owning HetznerCluster.
+func (r *HetznerClusterReconciler) hcloudMachineToHetznerCluster(ctx context.Context, o client.Object) []reconcile.Request {
+	hm, ok := o.(*infrav1.HCloudMachine)
+	if !ok {
+		return nil
+	}
+
+	clusterName := hm.Labels[clusterv1.ClusterNameLabel]
+	if clusterName == "" {
+		return nil
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: hm.Namespace, Name: clusterName}, cluster); err != nil {
+		return nil
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "HetznerCluster" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: hm.Namespace, Name: cluster.Spec.InfrastructureRef.Name},
+	}}
+}
+
+// controlPlaneMachineToHetznerClusterPredicate returns a predicate that fires only when:
+//   - a machine is deleted (so the HetznerCluster can update its LB target status), or
+//   - ServerAvailableCondition transitions to True.
+func controlPlaneMachineToHetznerClusterPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldGetter, ok := e.ObjectOld.(v1beta1conditions.Getter)
+			if !ok {
+				return false
+			}
+			newGetter, ok := e.ObjectNew.(v1beta1conditions.Getter)
+			if !ok {
+				return false
+			}
+			wasTrue := v1beta1conditions.IsTrue(oldGetter, infrav1.ServerAvailableCondition)
+			isTrue := v1beta1conditions.IsTrue(newGetter, infrav1.ServerAvailableCondition)
+			return !wasTrue && isTrue
+		},
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -620,13 +620,61 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, host *inf
 		return nil
 	}
 
-	// check whether IPs of host have been added as load balancer targets already
+	// check whether IPs of host have been added as load balancer targets already.
 	var foundIPv4 bool
 	var foundIPv6 bool
 
-	for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
-		if target.Type == infrav1.LoadBalancerTargetTypeIP {
-			switch target.IP {
+	if v1beta1conditions.IsTrue(s.scope.BareMetalMachine, infrav1.ServerAvailableCondition) {
+		// If ServerAvailableCondition is set to true, then it means that this machine's ip was
+		// already successfully added as a target in the load balancer during a prior reconcile, this condition
+		// is only set to True after reconcileLoadBalancerAttachment returns nil.
+		// It is safe to use HetznerCluster.Status as a cache here because the HetznerCluster controller
+		// watches HetznerBareMetalMachine objects and triggers a reconcile on every ServerAvailableCondition
+		// marked as true transition and on machine deletion, keeping the target list up to date.
+		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
+			if target.Type == infrav1.LoadBalancerTargetTypeIP {
+				switch target.IP {
+				case host.Spec.Status.IPv4:
+					foundIPv4 = true
+				case host.Spec.Status.IPv6:
+					foundIPv6 = true
+				}
+			}
+		}
+	} else {
+		// use the HCloud API.
+		clusterTagKey := s.scope.HetznerCluster.ClusterTagKey()
+		opts := hcloud.LoadBalancerListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: utils.LabelsToLabelSelector(map[string]string{
+					clusterTagKey: string(infrav1.ResourceLifecycleOwned),
+				}),
+			},
+		}
+
+		loadBalancers, err := s.scope.HCloudClient.ListLoadBalancers(ctx, opts)
+		if err != nil {
+			hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "ListLoadBalancers")
+			return fmt.Errorf("failed to list load balancers: %w", err)
+		}
+
+		if len(loadBalancers) != 1 {
+			return fmt.Errorf("found %v loadbalancers in HCloud", len(loadBalancers))
+		}
+
+		lb := loadBalancers[0]
+
+		// This should never be the case: the label selector is cluster-scoped,
+		// so the only LB it can return is the one we own.
+		if lb.ID != s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID {
+			return fmt.Errorf("mismatch between the owned loadbalancer ID (%d) and the one specified in HetznerCluster.Status.ControlPlaneLoadBalancer.ID (%d)", lb.ID, s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID)
+		}
+
+		for _, target := range lb.Targets {
+			if target.Type != hcloud.LoadBalancerTargetTypeIP || target.IP == nil {
+				continue
+			}
+			switch target.IP.IP {
 			case host.Spec.Status.IPv4:
 				foundIPv4 = true
 			case host.Spec.Status.IPv6:

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -625,12 +625,10 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, host *inf
 	var foundIPv6 bool
 
 	if v1beta1conditions.IsTrue(s.scope.BareMetalMachine, infrav1.ServerAvailableCondition) {
-		// If ServerAvailableCondition is set to true, then it means that this machine's ip was
-		// already successfully added as a target in the load balancer during a prior reconcile, this condition
-		// is only set to True after reconcileLoadBalancerAttachment returns nil.
-		// It is safe to use HetznerCluster.Status as a cache here because the HetznerCluster controller
-		// watches HetznerBareMetalMachine objects and triggers a reconcile on every ServerAvailableCondition
-		// marked as true transition and on machine deletion, keeping the target list up to date.
+		// The status may be slightly outdated but that is acceptable as this check
+		// is only a safeguard against unexpected changes (e.g. a user manually removing a target).
+		// In the vast majority of reconciles there is nothing to do, so we skip the extra API call
+		// to fetch the live load-balancer targets.
 		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
 			if target.Type == infrav1.LoadBalancerTargetTypeIP {
 				switch target.IP {

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -1003,7 +1003,7 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 			},
 		}
 
-		// It should fallback to adding the load balancer target via Hetzner API.
+		// It should add the load balancer target via Hetzner API.
 		// But it should not call the Hetzner API to list load balancers, instead it should utilize
 		// the HetznerCluster.Status to find out which targets should be added to the load balancer.
 		hcloudClient.On(

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -1003,7 +1003,9 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 			},
 		}
 
-		// It should fallback to adding the load balancer target based on HetznerCluster status.
+		// It should fallback to adding the load balancer target via Hetzner API.
+		// But it should not call the Hetzner API to list load balancers, instead it should utilize
+		// the HetznerCluster.Status to find out which targets should be added to the load balancer.
 		hcloudClient.On(
 			"AddIPTargetToLoadBalancer",
 			mock.Anything,

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -917,6 +917,18 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 			},
 		}
 
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{
+				ID: 123,
+				Targets: []hcloud.LoadBalancerTarget{
+					{
+						Type: hcloud.LoadBalancerTargetTypeIP,
+						IP:   &hcloud.LoadBalancerTargetIP{IP: "192.0.2.9"},
+					},
+				},
+			},
+		}, nil).Once()
+
 		service := newServiceForLoadBalancerAttachment(machine, bareMetalMachine, newControlPlaneCluster(), hetznerCluster, hcloudClient)
 
 		err := service.reconcileLoadBalancerAttachment(context.Background(), newHost("192.0.2.10"))
@@ -947,6 +959,12 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 			},
 		}
 
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{
+				ID: 123,
+			},
+		}, nil).Once()
+
 		hcloudClient.On(
 			"AddIPTargetToLoadBalancer",
 			mock.Anything,
@@ -963,6 +981,46 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 		Expect(service.reconcileLoadBalancerAttachment(context.Background(), newHost("192.0.2.10"))).To(Succeed())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
+
+	It("does not list LoadBalancers via Hetzner API, when ServerAvailable condition is marked true", func() {
+		hcloudClient := mocks.NewClient(GinkgoT())
+		machine := &clusterv1.Machine{}
+		conditions.Set(machine, metav1.Condition{
+			Type:    controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  "PodNotHealthy",
+			Message: "kube-apiserver is still starting",
+		})
+
+		bareMetalMachine := &infrav1.HetznerBareMetalMachine{}
+		v1beta1conditions.MarkTrue(bareMetalMachine, infrav1.ServerAvailableCondition)
+
+		hetznerCluster := &infrav1.HetznerCluster{
+			Status: infrav1.HetznerClusterStatus{
+				ControlPlaneLoadBalancer: &infrav1.LoadBalancerStatus{
+					ID: 123,
+				},
+			},
+		}
+
+		// It should fallback to adding the load balancer target based on HetznerCluster status.
+		hcloudClient.On(
+			"AddIPTargetToLoadBalancer",
+			mock.Anything,
+			mock.MatchedBy(func(opts hcloud.LoadBalancerAddIPTargetOpts) bool {
+				return opts.IP.String() == "192.0.2.10"
+			}),
+			mock.MatchedBy(func(lb *hcloud.LoadBalancer) bool {
+				return lb.ID == 123
+			}),
+		).Return(nil).Once()
+
+		service := newServiceForLoadBalancerAttachment(machine, bareMetalMachine, newControlPlaneCluster(), hetznerCluster, hcloudClient)
+
+		Expect(service.reconcileLoadBalancerAttachment(context.Background(), newHost("192.0.2.10"))).To(Succeed())
+		Expect(hcloudClient.AssertNotCalled(GinkgoT(), "ListLoadBalancers", mock.Anything, mock.Anything)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
 })
 
 var _ = Describe("Reconcile with control-plane load balancer attachment", func() {
@@ -974,7 +1032,7 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 	)
 
 	buildService := func(lbTargets []infrav1.LoadBalancerTarget, apiServerHealthy, isControlPlane bool) (
-		*Service, *infrav1.HetznerBareMetalMachine,
+		*Service, *infrav1.HetznerBareMetalMachine, *mocks.Client,
 	) {
 		scheme := runtime.NewScheme()
 		utilruntime.Must(infrav1.AddToScheme(scheme))
@@ -1056,6 +1114,8 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 			WithObjects(host, bareMetalMachine, machine).
 			Build()
 
+		hcloudClient := mocks.NewClient(GinkgoT())
+
 		service := &Service{
 			scope: &scope.BareMetalMachineScope{
 				Logger:           log,
@@ -1064,11 +1124,11 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 				Machine:          machine,
 				BareMetalMachine: bareMetalMachine,
 				HetznerCluster:   hetznerCluster,
-				HCloudClient:     mocks.NewClient(GinkgoT()),
+				HCloudClient:     hcloudClient,
 			},
 		}
 
-		return service, bareMetalMachine
+		return service, bareMetalMachine, hcloudClient
 	}
 
 	It("keeps ProviderID and Ready set when reconcileLoadBalancerAttachment requeues for WaitingForAPIServer", func() {
@@ -1078,13 +1138,25 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 		// still set Ready=true and ProviderID so CAPI can copy ProviderID onto
 		// the core Machine - otherwise MachineAPIServerPodHealthy never flips
 		// true and the attachment requeues forever (bootstrap deadlock).
-		service, bareMetalMachine := buildService(
+		service, bareMetalMachine, hcloudClient := buildService(
 			[]infrav1.LoadBalancerTarget{
 				{Type: infrav1.LoadBalancerTargetTypeIP, IP: "192.0.2.9"},
 			},
 			false,
 			true,
 		)
+
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{
+				ID: 123,
+				Targets: []hcloud.LoadBalancerTarget{
+					{
+						Type: hcloud.LoadBalancerTargetTypeIP,
+						IP:   &hcloud.LoadBalancerTargetIP{IP: "192.0.2.9"},
+					},
+				},
+			},
+		}, nil).Once()
 
 		res, err := service.Reconcile(context.Background())
 		Expect(err).To(BeNil())
@@ -1100,13 +1172,25 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 		// LB target list already contains this host's IPv4, so
 		// reconcileLoadBalancerAttachment returns no requeue and Reconcile
 		// marks the condition true.
-		service, bareMetalMachine := buildService(
+		service, bareMetalMachine, hcloudClient := buildService(
 			[]infrav1.LoadBalancerTarget{
 				{Type: infrav1.LoadBalancerTargetTypeIP, IP: "192.0.2.10"},
 			},
 			true,
 			true,
 		)
+
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{
+				ID: 123,
+				Targets: []hcloud.LoadBalancerTarget{
+					{
+						Type: hcloud.LoadBalancerTargetTypeIP,
+						IP:   &hcloud.LoadBalancerTargetIP{IP: "192.0.2.10"},
+					},
+				},
+			},
+		}, nil).Once()
 
 		res, err := service.Reconcile(context.Background())
 		Expect(err).To(BeNil())
@@ -1121,7 +1205,7 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 		// Worker nodes never hit reconcileLoadBalancerAttachment, but Reconcile
 		// must still mark the condition true so the condition is meaningful on
 		// non-control-plane HetznerBareMetalMachines too.
-		service, bareMetalMachine := buildService(nil, true, false)
+		service, bareMetalMachine, _ := buildService(nil, true, false)
 
 		res, err := service.Reconcile(context.Background())
 		Expect(err).To(BeNil())

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1395,12 +1395,10 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 	}
 
 	if v1beta1conditions.IsTrue(hm, infrav1.ServerAvailableCondition) {
-		// If ServerAvailableCondition is set to true, then it means that this server was
-		// already successfully added as a target in the load balancer during a prior reconcile, this condition
-		// is only set to True after reconcileLoadBalancerAttachment returns without an error.
-		// It is safe to use HetznerCluster.Status as a cache here because the HetznerCluster controller
-		// watches HCloudMachine objects and triggers a reconcile on every ServerAvailableCondition marked
-		// as true transition and on machine deletion, keeping the target list up to date.
+		// The status may be slightly outdated but that is acceptable as this check
+		// is only a safeguard against unexpected changes (e.g. a user manually removing a target).
+		// In the vast majority of reconciles there is nothing to do, so we skip the extra API call
+		// to fetch the live load-balancer targets.
 		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
 			if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {
 				return reconcile.Result{}, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1394,6 +1394,55 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 		return reconcile.Result{}, nil
 	}
 
+	if v1beta1conditions.IsTrue(hm, infrav1.ServerAvailableCondition) {
+		// If ServerAvailableCondition is set to true, then it means that this server was
+		// already successfully added as a target in the load balancer during a prior reconcile, this condition
+		// is only set to True after reconcileLoadBalancerAttachment returns without an error.
+		// It is safe to use HetznerCluster.Status as a cache here because the HetznerCluster controller
+		// watches HCloudMachine objects and triggers a reconcile on every ServerAvailableCondition marked
+		// as true transition and on machine deletion, keeping the target list up to date.
+		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
+			if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {
+				return reconcile.Result{}, nil
+			}
+		}
+	} else {
+		clusterTagKey := s.scope.HetznerCluster.ClusterTagKey()
+		opts := hcloud.LoadBalancerListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: utils.LabelsToLabelSelector(map[string]string{
+					clusterTagKey: string(infrav1.ResourceLifecycleOwned),
+				}),
+			},
+		}
+
+		loadBalancers, err := s.scope.HCloudClient.ListLoadBalancers(ctx, opts)
+		if err != nil {
+			hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "ListLoadBalancers")
+			return reconcile.Result{}, fmt.Errorf("failed to list load balancers: %w", err)
+		}
+
+		if len(loadBalancers) != 1 {
+			return reconcile.Result{}, fmt.Errorf("found %v loadbalancers in HCloud", len(loadBalancers))
+		}
+
+		lb := loadBalancers[0]
+
+		// This should never be the case: the label selector is cluster-scoped,
+		// so the only LB it can return is the one we own.
+		if lb.ID != s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID {
+			return reconcile.Result{}, fmt.Errorf("mismatch between the owned loadbalancer ID (%d) and the one specified in HetznerCluster.Status.ControlPlaneLoadBalancer.ID (%d)", lb.ID, s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID)
+		}
+
+		for _, target := range lb.Targets {
+			if target.Type == hcloud.LoadBalancerTargetTypeServer &&
+				target.Server != nil && target.Server.Server != nil &&
+				target.Server.Server.ID == server.ID {
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
 	// if already attached do nothing
 	for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
 		if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1565,6 +1565,20 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 		// handleOperatingSystemRunning, that condition would be overwritten to True.
 		// Ready must still flip to true so CAPI can propagate ProviderID and
 		// downstream controllers can observe the apiserver pod health.
+
+		// ServerAvailableCondition is not True yet, so reconcileLoadBalancerAttachment
+		// fetches live LB state. Seed the fake client with an LB so ListLoadBalancers
+		// returns it. The LB has no target for this server, so the health gate fires.
+		algo := hcloud.LoadBalancerAlgorithm{Type: hcloud.LoadBalancerAlgorithmTypeRoundRobin}
+		_, err := service.scope.HCloudClient.CreateLoadBalancer(context.Background(), hcloud.LoadBalancerCreateOpts{
+			Name:      "test-lb",
+			Algorithm: &algo,
+			Labels: map[string]string{
+				service.scope.HetznerCluster.ClusterTagKey(): string(infrav1.ResourceLifecycleOwned),
+			},
+		})
+		Expect(err).To(BeNil())
+
 		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
 			ID: 1,
 			Target: []infrav1.LoadBalancerTarget{
@@ -1591,6 +1605,29 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 
 		Expect(hcloudMachine.Status.Ready).To(BeTrue())
 		Expect(v1beta1conditions.IsTrue(hcloudMachine, infrav1.ServerAvailableCondition)).To(BeTrue())
+	})
+
+	It("does not call ListLoadBalancers when ServerAvailableCondition is already True", func() {
+		// Replace the fake client with a mock so we can assert the call is never made.
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service.scope.HCloudClient = hcloudClient
+
+		v1beta1conditions.MarkTrue(hcloudMachine, infrav1.ServerAvailableCondition)
+
+		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
+			ID: 1,
+			Target: []infrav1.LoadBalancerTarget{
+				{Type: infrav1.LoadBalancerTargetTypeServer, ServerID: server.ID},
+			},
+		}
+
+		res, err := service.handleOperatingSystemRunning(context.Background(), server)
+		Expect(err).To(Succeed())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(hcloudMachine.Status.Ready).To(BeTrue())
+		Expect(v1beta1conditions.IsTrue(hcloudMachine, infrav1.ServerAvailableCondition)).To(BeTrue())
+		Expect(hcloudClient.AssertNotCalled(GinkgoT(), "ListLoadBalancers", mock.Anything, mock.Anything)).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
reconcileLoadBalancerAttachment in both HCloudMachine and HetznerBareMetalMachine services checks HetznerCluster.Status to decide whether a machine is already a load-balancer target. That status is only updated when the HetznerCluster controller reconciles, independently of the machine controllers. During a rollout this can produce a false positive: a target is removed from the LB and then re-added with the same IP/server-ID, but the stale status still shows it as present, so the attachment step is skipped and the control-plane node is never actually added back to the LB.

fixes done:

In both `reconcileLoadBalancerAttachment` implementations, check whether `ServerAvailableCondition` is already `True` on the machine:

- False/absent (first time): fetch the live LB state directly from the Hetzner API. This guarantees correctness regardless of stale status. Add the target if missing. When the function returns nil, `ServerAvailableCondition` gets set to `True` which signals that the target was confirmed in the real LB at least once.
- True (steady state): use `HetznerCluster.Status.ControlPlaneLoadBalancer.Target` as the cache. No extra API call is needed. If the target has been removed, `HetznerCluster.Status` will eventually reflect this (see below), and the add logic will re-run.

This ensures exactly one Hetzner API call for lb per machine lifecycle.

Also, add watches on `HetznerBareMetalMachine` and `HCloudMachine` in the `HetznerCluster` controller's `SetupWithManager`. Each watch triggers a `HetznerCluster` reconcile when:
- `ServerAvailableCondition` transitions to `True` (machine provisioned, target just added)
- The machine is deleted (target needs to be reflected as removed in status)

This ensures that the `HetznerCluster.Status` is not stale.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2094 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

