### PR TITLE
:seedling: test/e2e: cancel spec context on fast-fail to unblock waits

### DIFF
--- a/test/e2e/caph.go
+++ b/test/e2e/caph.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -30,6 +31,29 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
 )
+
+// specCancelMu protects specCancelFn, which is set per-spec so that the
+// logStatusContinuously goroutine can cancel the active spec's context when a
+// permanent error or no-available-host condition is detected.
+var (
+	specCancelMu sync.Mutex
+	specCancelFn context.CancelFunc = func() {}
+)
+
+// setSpecCancel registers cancel as the function to call when a fast-fail
+// condition is detected in the current spec.
+func setSpecCancel(cancel context.CancelFunc) {
+	specCancelMu.Lock()
+	defer specCancelMu.Unlock()
+	specCancelFn = cancel
+}
+
+// clearSpecCancel resets the per-spec cancel to a no-op after the spec exits.
+func clearSpecCancel() {
+	specCancelMu.Lock()
+	defer specCancelMu.Unlock()
+	specCancelFn = func() {}
+}
 
 // CaphClusterDeploymentSpecInput is the input for CaphClusterDeploymentSpec.
 type CaphClusterDeploymentSpecInput struct {
@@ -73,7 +97,15 @@ func CaphClusterDeploymentSpec(ctx context.Context, inputGetter func() CaphClust
 
 	ginkgo.It("Should successfully create a cluster with three control planes", func() {
 		ginkgo.By("Creating a workload cluster")
-		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+		// Use a cancellable child so the fail-fast goroutine (logStatusContinuously)
+		// can abort this wait when a permanent bare-metal error is detected.
+		specCtx, cancel := context.WithCancel(ctx)
+		setSpecCancel(cancel)
+		defer func() {
+			clearSpecCancel()
+			cancel()
+		}()
+		clusterctl.ApplyClusterTemplateAndWait(specCtx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
 				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -363,6 +363,12 @@ func logStatusContinuously(ctx context.Context, restConfig *restclient.Config, c
 			err := logStatus(ctx, restConfig, c, ccmLogs)
 			if err != nil {
 				if errors.Is(err, errPermanentHBMH) || errors.Is(err, errNoAvailableHost) {
+					// Cancel the active spec's context so that WaitForControlPlaneToBeReady
+					// and similar blockers abort immediately instead of running to timeout.
+					specCancelMu.Lock()
+					fn := specCancelFn
+					specCancelMu.Unlock()
+					fn()
 					Fail(err.Error())
 				}
 				log(fmt.Sprintf("Error logging status: %v", err))

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -366,9 +366,8 @@ func logStatusContinuously(ctx context.Context, restConfig *restclient.Config, c
 					// Cancel the active spec's context so that WaitForControlPlaneToBeReady
 					// and similar blockers abort immediately instead of running to timeout.
 					specCancelMu.Lock()
-					fn := specCancelFn
+					specCancelFn()
 					specCancelMu.Unlock()
-					fn()
 					Fail(err.Error())
 				}
 				log(fmt.Sprintf("Error logging status: %v", err))


### PR DESCRIPTION
## Summary

The CI failure on [#2113 CI Run](https://github.com/syself/cluster-api-provider-hetzner/actions/runs/27964284038/job/82904734813) was caused by a physical bare metal server failing to boot into rescue mode — completely unrelated to that PR's changes.

However, the failure revealed that the existing **fail-fast mechanism** in `logStatusContinuously` isn't actually fast. When it detects a `PermanentError` on a `HetznerBareMetalHost`, it calls `Fail()` from the goroutine. That records the Ginkgo failure and exits the goroutine, but the main `It` goroutine keeps blocking on `WaitForControlPlaneToBeReady` until the full **1200-second timeout** — wasting ~10 minutes of CI time per occurrence.

### Fix

- Add a `specCancelFn` (protected by `specCancelMu`) in `caph.go`, updated per-spec via `setSpecCancel`/`clearSpecCancel`.
- In `CaphClusterDeploymentSpec`'s `It` block, create a cancellable child context (`specCtx`) and register its cancel. Pass `specCtx` to `ApplyClusterTemplateAndWait`.
- In `logStatusContinuously`, call `fn()` (cancel the spec context) **before** `Fail()` so `WaitForControlPlaneToBeReady` aborts immediately.
- `AfterEach` still uses the original `ctx`, so cleanup is unaffected.

### Result

When hardware reboots fail (PermanentError after ~10 min), the test now aborts within ~30 seconds of detection instead of waiting the full 1200-second timeout.

## Test plan

- [ ] CI baremetal test passes on healthy hardware (context cancellation is a no-op in the happy path)
- [ ] On hardware failure, test fails fast (~30s after PermanentError is set) instead of waiting 20 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)