### PR TITLE
✨ Add skipCheckDisk field to HetznerBareMetalMachine spec

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -87,6 +87,11 @@ type HetznerBareMetalMachineSpec struct {
 
 	// SSHSpec gives a reference on the secret where SSH details are specified as well as ports for SSH.
 	SSHSpec SSHSpec `json:"sshSpec,omitempty"`
+
+	// IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+	// This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+	// +optional
+	IgnoreCheckDisk bool `json:"ignoreCheckDisk,omitempty"`
 }
 
 // HostSelector specifies matching criteria for labels on BareMetalHosts.

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -88,10 +88,10 @@ type HetznerBareMetalMachineSpec struct {
 	// SSHSpec gives a reference on the secret where SSH details are specified as well as ports for SSH.
 	SSHSpec SSHSpec `json:"sshSpec,omitempty"`
 
-	// IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+	// SkipCheckDisk skips the CheckDisk step during provisioning.
 	// This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
 	// +optional
-	IgnoreCheckDisk bool `json:"ignoreCheckDisk,omitempty"`
+	SkipCheckDisk bool `json:"skipCheckDisk,omitempty"`
 }
 
 // HostSelector specifies matching criteria for labels on BareMetalHosts.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1791,6 +1791,7 @@ func autoConvert_v1beta1_HetznerBareMetalMachineSpec_To_v1beta2_HetznerBareMetal
 	if err := Convert_v1beta1_SSHSpec_To_v1beta2_SSHSpec(&in.SSHSpec, &out.SSHSpec, s); err != nil {
 		return err
 	}
+	out.IgnoreCheckDisk = in.IgnoreCheckDisk
 	return nil
 }
 
@@ -1810,6 +1811,7 @@ func autoConvert_v1beta2_HetznerBareMetalMachineSpec_To_v1beta1_HetznerBareMetal
 	if err := Convert_v1beta2_SSHSpec_To_v1beta1_SSHSpec(&in.SSHSpec, &out.SSHSpec, s); err != nil {
 		return err
 	}
+	out.IgnoreCheckDisk = in.IgnoreCheckDisk
 	return nil
 }
 

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1791,7 +1791,7 @@ func autoConvert_v1beta1_HetznerBareMetalMachineSpec_To_v1beta2_HetznerBareMetal
 	if err := Convert_v1beta1_SSHSpec_To_v1beta2_SSHSpec(&in.SSHSpec, &out.SSHSpec, s); err != nil {
 		return err
 	}
-	out.IgnoreCheckDisk = in.IgnoreCheckDisk
+	out.SkipCheckDisk = in.SkipCheckDisk
 	return nil
 }
 
@@ -1811,7 +1811,7 @@ func autoConvert_v1beta2_HetznerBareMetalMachineSpec_To_v1beta1_HetznerBareMetal
 	if err := Convert_v1beta2_SSHSpec_To_v1beta1_SSHSpec(&in.SSHSpec, &out.SSHSpec, s); err != nil {
 		return err
 	}
-	out.IgnoreCheckDisk = in.IgnoreCheckDisk
+	out.SkipCheckDisk = in.SkipCheckDisk
 	return nil
 }
 

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -87,10 +87,10 @@ type HetznerBareMetalMachineSpec struct {
 	// SSHSpec gives a reference on the secret where SSH details are specified as well as ports for SSH.
 	SSHSpec SSHSpec `json:"sshSpec,omitempty"`
 
-	// IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+	// SkipCheckDisk skips the CheckDisk step during provisioning.
 	// This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
 	// +optional
-	IgnoreCheckDisk bool `json:"ignoreCheckDisk,omitempty"`
+	SkipCheckDisk bool `json:"skipCheckDisk,omitempty"`
 }
 
 // HostSelector specifies matching criteria for labels on BareMetalHosts.

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -86,6 +86,11 @@ type HetznerBareMetalMachineSpec struct {
 
 	// SSHSpec gives a reference on the secret where SSH details are specified as well as ports for SSH.
 	SSHSpec SSHSpec `json:"sshSpec,omitempty"`
+
+	// IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+	// This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+	// +optional
+	IgnoreCheckDisk bool `json:"ignoreCheckDisk,omitempty"`
 }
 
 // HostSelector specifies matching criteria for labels on BareMetalHosts.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -113,6 +113,11 @@ spec:
                       that must exist on a chosen BareMetalHost.
                     type: object
                 type: object
+              ignoreCheckDisk:
+                description: |-
+                  IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                type: boolean
               installImage:
                 description: InstallImage is the configuration that is used for the
                   autosetup configuration for installing an OS via InstallImage.
@@ -624,6 +629,11 @@ spec:
                       that must exist on a chosen BareMetalHost.
                     type: object
                 type: object
+              ignoreCheckDisk:
+                description: |-
+                  IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                type: boolean
               installImage:
                 description: InstallImage is the configuration that is used for the
                   autosetup configuration for installing an OS via InstallImage.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -113,11 +113,6 @@ spec:
                       that must exist on a chosen BareMetalHost.
                     type: object
                 type: object
-              ignoreCheckDisk:
-                description: |-
-                  IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
-                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
-                type: boolean
               installImage:
                 description: InstallImage is the configuration that is used for the
                   autosetup configuration for installing an OS via InstallImage.
@@ -272,6 +267,11 @@ spec:
                   `capi.syself.com/use-hrobot-provider-id-for-baremetal` on the hetznerCluster is set to
                   `"true"`.
                 type: string
+              skipCheckDisk:
+                description: |-
+                  SkipCheckDisk skips the CheckDisk step during provisioning.
+                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                type: boolean
               sshSpec:
                 description: SSHSpec gives a reference on the secret where SSH details
                   are specified as well as ports for SSH.
@@ -629,11 +629,6 @@ spec:
                       that must exist on a chosen BareMetalHost.
                     type: object
                 type: object
-              ignoreCheckDisk:
-                description: |-
-                  IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
-                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
-                type: boolean
               installImage:
                 description: InstallImage is the configuration that is used for the
                   autosetup configuration for installing an OS via InstallImage.
@@ -791,6 +786,11 @@ spec:
                   `capi.syself.com/use-hrobot-provider-id-for-baremetal` on the hetznerCluster is set to
                   `"true"`.
                 type: string
+              skipCheckDisk:
+                description: |-
+                  SkipCheckDisk skips the CheckDisk step during provisioning.
+                  This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                type: boolean
               sshSpec:
                 description: SSHSpec gives a reference on the secret where SSH details
                   are specified as well as ports for SSH.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -98,11 +98,6 @@ spec:
                               labels that must exist on a chosen BareMetalHost.
                             type: object
                         type: object
-                      ignoreCheckDisk:
-                        description: |-
-                          IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
-                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
-                        type: boolean
                       installImage:
                         description: InstallImage is the configuration that is used
                           for the autosetup configuration for installing an OS via
@@ -259,6 +254,11 @@ spec:
                           `capi.syself.com/use-hrobot-provider-id-for-baremetal` on the hetznerCluster is set to
                           `"true"`.
                         type: string
+                      skipCheckDisk:
+                        description: |-
+                          SkipCheckDisk skips the CheckDisk step during provisioning.
+                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                        type: boolean
                       sshSpec:
                         description: SSHSpec gives a reference on the secret where
                           SSH details are specified as well as ports for SSH.
@@ -410,11 +410,6 @@ spec:
                               labels that must exist on a chosen BareMetalHost.
                             type: object
                         type: object
-                      ignoreCheckDisk:
-                        description: |-
-                          IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
-                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
-                        type: boolean
                       installImage:
                         description: InstallImage is the configuration that is used
                           for the autosetup configuration for installing an OS via
@@ -574,6 +569,11 @@ spec:
                           `capi.syself.com/use-hrobot-provider-id-for-baremetal` on the hetznerCluster is set to
                           `"true"`.
                         type: string
+                      skipCheckDisk:
+                        description: |-
+                          SkipCheckDisk skips the CheckDisk step during provisioning.
+                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                        type: boolean
                       sshSpec:
                         description: SSHSpec gives a reference on the secret where
                           SSH details are specified as well as ports for SSH.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -98,6 +98,11 @@ spec:
                               labels that must exist on a chosen BareMetalHost.
                             type: object
                         type: object
+                      ignoreCheckDisk:
+                        description: |-
+                          IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                        type: boolean
                       installImage:
                         description: InstallImage is the configuration that is used
                           for the autosetup configuration for installing an OS via
@@ -405,6 +410,11 @@ spec:
                               labels that must exist on a chosen BareMetalHost.
                             type: object
                         type: object
+                      ignoreCheckDisk:
+                        description: |-
+                          IgnoreCheckDisk allows provisioning to continue even if CheckDisk fails.
+                          This is equivalent to setting the annotation capi.syself.com/ignore-check-disk on the HetznerBareMetalHost.
+                        type: boolean
                       installImage:
                         description: InstallImage is the configuration that is used
                           for the autosetup configuration for installing an OS via

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1494,11 +1494,12 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 	// CheckDisk before accessing the disk
 	info, err := sshClient.CheckDisk(ctx, s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN())
 	if err != nil {
-		_, ok := s.scope.HetznerBareMetalHost.Annotations[infrav1.IgnoreCheckDiskAnnotation]
-		if !ok {
-			// The annotation is not set. This is a permanent error.
+		_, annotationOk := s.scope.HetznerBareMetalHost.Annotations[infrav1.IgnoreCheckDiskAnnotation]
+		machineIgnoresCheckDisk := s.scope.HetznerBareMetalMachine != nil && s.scope.HetznerBareMetalMachine.Spec.IgnoreCheckDisk
+		if !annotationOk && !machineIgnoresCheckDisk {
+			// Neither the annotation nor the machine spec field is set. This is a permanent error.
 			msg := fmt.Sprintf(
-				"CheckDisk failed (permanent error): %s (set annotation %q on hbmh to continue anyway)",
+				"CheckDisk failed (permanent error): %s (set annotation %q on hbmh or ignoreCheckDisk on HetznerBareMetalMachine to continue anyway)",
 				err.Error(), infrav1.IgnoreCheckDiskAnnotation)
 			v1beta1conditions.MarkFalse(
 				s.scope.HetznerBareMetalHost,
@@ -1518,9 +1519,9 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 			s.scope.HetznerBareMetalHost.SetError(infrav1.PermanentError, msg)
 			return actionStop{}
 		}
-		// The annotation was set. Just create a warning and move on.
+		// The annotation or machine spec field was set. Just create a warning and move on.
 		record.Warnf(s.scope.HetznerBareMetalHost, infrav1.CheckDiskFailedReason,
-			"CheckDisk failed. Continue anyway because %q is set: %s",
+			"CheckDisk failed. Continue anyway because %q is set or ignoreCheckDisk is true on HetznerBareMetalMachine: %s",
 			infrav1.IgnoreCheckDiskAnnotation,
 			err.Error())
 	} else {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1495,11 +1495,11 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 	info, err := sshClient.CheckDisk(ctx, s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN())
 	if err != nil {
 		_, annotationOk := s.scope.HetznerBareMetalHost.Annotations[infrav1.IgnoreCheckDiskAnnotation]
-		machineIgnoresCheckDisk := s.scope.HetznerBareMetalMachine != nil && s.scope.HetznerBareMetalMachine.Spec.IgnoreCheckDisk
-		if !annotationOk && !machineIgnoresCheckDisk {
+		machineSkipsCheckDisk := s.scope.HetznerBareMetalMachine != nil && s.scope.HetznerBareMetalMachine.Spec.SkipCheckDisk
+		if !annotationOk && !machineSkipsCheckDisk {
 			// Neither the annotation nor the machine spec field is set. This is a permanent error.
 			msg := fmt.Sprintf(
-				"CheckDisk failed (permanent error): %s (set annotation %q on hbmh or ignoreCheckDisk on HetznerBareMetalMachine to continue anyway)",
+				"CheckDisk failed (permanent error): %s (set annotation %q on hbmh or skipCheckDisk on HetznerBareMetalMachine to skip)",
 				err.Error(), infrav1.IgnoreCheckDiskAnnotation)
 			v1beta1conditions.MarkFalse(
 				s.scope.HetznerBareMetalHost,
@@ -1521,7 +1521,7 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 		}
 		// The annotation or machine spec field was set. Just create a warning and move on.
 		record.Warnf(s.scope.HetznerBareMetalHost, infrav1.CheckDiskFailedReason,
-			"CheckDisk failed. Continue anyway because %q is set or ignoreCheckDisk is true on HetznerBareMetalMachine: %s",
+			"CheckDisk failed. Skipping because %q is set or skipCheckDisk is true on HetznerBareMetalMachine: %s",
 			infrav1.IgnoreCheckDiskAnnotation,
 			err.Error())
 	} else {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1495,7 +1495,7 @@ func (s *Service) actionImageInstallingStartBackgroundProcess(ctx context.Contex
 	info, err := sshClient.CheckDisk(ctx, s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN())
 	if err != nil {
 		_, annotationOk := s.scope.HetznerBareMetalHost.Annotations[infrav1.IgnoreCheckDiskAnnotation]
-		machineSkipsCheckDisk := s.scope.HetznerBareMetalMachine != nil && s.scope.HetznerBareMetalMachine.Spec.SkipCheckDisk
+		machineSkipsCheckDisk := s.scope.HetznerBareMetalMachine.Spec.SkipCheckDisk
 		if !annotationOk && !machineSkipsCheckDisk {
 			// Neither the annotation nor the machine spec field is set. This is a permanent error.
 			msg := fmt.Sprintf(


### PR DESCRIPTION
## Summary

- Adds `skipCheckDisk bool` field to `HetznerBareMetalMachineSpec` (both v1beta1 and v1beta2)
- When `true`, the CheckDisk step is skipped entirely during provisioning — equivalent to setting the `capi.syself.com/ignore-check-disk` annotation on the `HetznerBareMetalHost`
- The check-disk logic in the host service now checks both the host annotation and the new machine spec field
- Conversion between v1beta1 and v1beta2 is handled by the regenerated `zz_generated.conversion.go`

## Background

When a caph admin configures a custom image-url-command, which checks disks, then the caph built-in check-disk might not be needed. For this case the caph admin can set skipCheckDisk=True, and do custom checks in the custom image-url-command.


## Test plan

- [ ] Set `skipCheckDisk: true` on a `HetznerBareMetalMachine` and verify provisioning proceeds without running CheckDisk
- [ ] Verify default (`skipCheckDisk` omitted / `false`) still blocks provisioning on CheckDisk failure
- [ ] Verify the existing host annotation (`capi.syself.com/ignore-check-disk`) still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)