### PR TITLE
:seedling: disable bm-e2e-1716772 after rescue-mode reboot timeout

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -12,7 +12,7 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# Feb 2026: worked.
+# 2026-06-23: Disabled after hardware reboot into rescue mode timed out (CI run 27964284038).
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -24,7 +24,7 @@ spec:
   serverID: 1716772 # ip: 136.243.69.24
   rootDeviceHints:
     wwn: "0x5002538d41d70a46"
-  maintenanceMode: false
+  maintenanceMode: true
   description: Test Machine 1716772
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -1,3 +1,7 @@
+## CI always uses this file from the main branch, so disabling a server here takes effect for all
+## PRs immediately — no rebase required. See the `Use hbmh list from main branch` step in
+## .github/workflows/pr-e2e.yaml and .github/workflows/e2e-basic-baremetal.yaml.
+##
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:


### PR DESCRIPTION
## Summary

Server `bm-e2e-1716772` (ID 1716772, IP 136.243.69.24) caused CI run [27964284038](https://github.com/syself/cluster-api-provider-hetzner/actions/runs/27964284038/job/82904734813) to fail with a hardware reboot into rescue mode timing out after 10 minutes. The server was the only one attempted during the test.

This server was recently added to the CI pool in #2088 to restore baremetal CI. It appears to have hardware issues already.

- Sets `maintenanceMode: true` on `bm-e2e-1716772`
- Adds a dated comment explaining why

## Test plan

- [ ] Merge to main — the CI workflows always check out `hetznerbaremetalhosts.yaml` from main before running, so this takes effect for all subsequent runs immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)