### PR TITLE
:seedling: re-enable bm-e2e-1716772

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -16,7 +16,7 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# 2026-06-23: Disabled after hardware reboot into rescue mode timed out (CI run 27964284038).
+# 2026-06-23: Re-enabled after rescue-mode reboot timeout investigation.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -28,7 +28,7 @@ spec:
   serverID: 1716772 # ip: 136.243.69.24
   rootDeviceHints:
     wwn: "0x5002538d41d70a46"
-  maintenanceMode: true
+  maintenanceMode: false
   description: Test Machine 1716772
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
## Summary

- Re-enables server 1716772 (136.243.69.24) which was disabled in #2118 after a rescue-mode reboot timed out during CI run 27964284038.
- Sets `maintenanceMode: false` so the server can be picked up by CI again.

## Test plan

- [ ] Verify CI picks up the server and completes a test run successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)