### PR TITLE
:seedling: Relax imageURLCommand regex to allow syself-provisioner naming

### DIFF
--- a/pkg/utils/image_url_command.go
+++ b/pkg/utils/image_url_command.go
@@ -27,10 +27,10 @@ import (
 	"strings"
 )
 
-var imageURLCommandNameRegex = regexp.MustCompile(`^image-url-command-[a-z0-9][a-z0-9._-]*$`)
+var imageURLCommandNameRegex = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
 
 // ValidateImageURLCommandName validates the user-provided command name. The name must be a
-// basename, must not contain "..", and must start with image-url-command-.
+// basename, must not contain "..", and must match the pattern ^[a-z][a-z0-9._-]*$.
 func ValidateImageURLCommandName(name string) error {
 	if name != filepath.Base(name) {
 		return fmt.Errorf("must be a basename without slashes")

--- a/pkg/webhook/v1beta1/hcloudmachine_validation_test.go
+++ b/pkg/webhook/v1beta1/hcloudmachine_validation_test.go
@@ -215,9 +215,9 @@ func TestValidateHCloudMachineSpec(t *testing.T) {
 
 	allErrs = validateHCloudMachineSpec(infrav1.HCloudMachineSpec{
 		ImageURL:        "oci://ghcr.io/example/foo:v1",
-		ImageURLCommand: "my-command.sh",
+		ImageURLCommand: "1bad-command",
 	})
-	require.Equal(t, `spec.imageURLCommand: Invalid value: "my-command.sh": must match the regex ^image-url-command-[a-z0-9][a-z0-9._-]*$`, errorsToString(allErrs))
+	require.Equal(t, `spec.imageURLCommand: Invalid value: "1bad-command": must match the regex ^[a-z][a-z0-9._-]*$`, errorsToString(allErrs))
 
 	allErrs = validateHCloudMachineSpec(infrav1.HCloudMachineSpec{
 		ImageURL:        "oci://ghcr.io/example/foo:v1",

--- a/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation_test.go
+++ b/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation_test.go
@@ -150,14 +150,14 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 			args: args{
 				spec: infrav1.HetznerBareMetalMachineSpec{
 					InstallImage: infrav1.InstallImage{
-						ImageURLCommand: "my-command.sh",
+						ImageURLCommand: "1bad-command",
 						Image: infrav1.Image{
 							URL: "oci://ghcr.io/example/ubuntu:v1",
 						},
 					},
 				},
 			},
-			want: field.Invalid(field.NewPath("spec", "installImage", "imageURLCommand"), "my-command.sh", "must match the regex ^image-url-command-[a-z0-9][a-z0-9._-]*$"),
+			want: field.Invalid(field.NewPath("spec", "installImage", "imageURLCommand"), "1bad-command", "must match the regex ^[a-z][a-z0-9._-]*$"),
 		},
 		{
 			name: "Invalid Image URL Command With Dot Dot",

--- a/pkg/webhook/v1beta2/hcloudmachine_validation_test.go
+++ b/pkg/webhook/v1beta2/hcloudmachine_validation_test.go
@@ -215,9 +215,9 @@ func TestValidateHCloudMachineSpec(t *testing.T) {
 
 	allErrs = validateHCloudMachineSpec(infrav2.HCloudMachineSpec{
 		ImageURL:        "oci://ghcr.io/example/foo:v1",
-		ImageURLCommand: "my-command.sh",
+		ImageURLCommand: "1bad-command",
 	})
-	require.Equal(t, `spec.imageURLCommand: Invalid value: "my-command.sh": must match the regex ^image-url-command-[a-z0-9][a-z0-9._-]*$`, errorsToString(allErrs))
+	require.Equal(t, `spec.imageURLCommand: Invalid value: "1bad-command": must match the regex ^[a-z][a-z0-9._-]*$`, errorsToString(allErrs))
 
 	allErrs = validateHCloudMachineSpec(infrav2.HCloudMachineSpec{
 		ImageURL:        "oci://ghcr.io/example/foo:v1",

--- a/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation_test.go
+++ b/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation_test.go
@@ -150,14 +150,14 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 			args: args{
 				spec: infrav2.HetznerBareMetalMachineSpec{
 					InstallImage: infrav2.InstallImage{
-						ImageURLCommand: "my-command.sh",
+						ImageURLCommand: "1bad-command",
 						Image: infrav2.Image{
 							URL: "oci://ghcr.io/example/ubuntu:v1",
 						},
 					},
 				},
 			},
-			want: field.Invalid(field.NewPath("spec", "installImage", "imageURLCommand"), "my-command.sh", "must match the regex ^image-url-command-[a-z0-9][a-z0-9._-]*$"),
+			want: field.Invalid(field.NewPath("spec", "installImage", "imageURLCommand"), "1bad-command", "must match the regex ^[a-z][a-z0-9._-]*$"),
 		},
 		{
 			name: "Invalid Image URL Command With Dot Dot",


### PR DESCRIPTION
## Summary

- Change `imageURLCommandNameRegex` from `^image-url-command-[a-z0-9][a-z0-9._-]*$` to `^[a-z][a-z0-9._-]*$`
- The new cluster-stack format names the command `syself-provisioner-amd64-v0.0.1` (arch + version), which does not match the old `image-url-command-` prefix requirement
- Security: path traversal is already prevented by the existing `filepath.Base` and `..` checks
