### PR TITLE
fix: Do not set RebootTriggeredAt to nil too early

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -434,7 +434,6 @@ func (s *Service) handleIncompleteBoot(ctx context.Context, isRebootIntoRescue, 
 	// ssh gave no connection refused error but it is still saved in host status - we can remove it
 	if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeConnectionError {
 		s.scope.HetznerBareMetalHost.ClearError()
-		s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
 	}
 
 	// Check whether there has been an error message already, meaning that the reboot did not finish in time.
@@ -447,9 +446,6 @@ func (s *Service) handleIncompleteBoot(ctx context.Context, isRebootIntoRescue, 
 			// A timeout error from SSH indicates that the server did not yet finish rebooting.
 			// As the server has no error set yet, set error message and return.
 			s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeSSHRebootTriggered, "ssh timeout error - server has not restarted yet")
-			if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt == nil {
-				s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
-			}
 			return false, nil
 		}
 
@@ -687,7 +683,7 @@ func (s *Service) actionRegistering(ctx context.Context) actionResult {
 		return actionContinue{delay: 10 * time.Second}
 	}
 
-	// we are in resuce mode i.e. reboot was successful, now clear the RebootTriggeredAt timestamp.
+	// we are in rescue mode i.e. reboot was successful, now clear the RebootTriggeredAt timestamp.
 	s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
 
 	output := sshClient.GetHardwareDetailsDebug(ctx)

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2639,9 +2639,12 @@ func (s *Service) handleRobotRateLimitExceeded(err error, functionName string) {
 // Imagine the controller triggers a reboot, and reconciles immediately. This would
 // mean the controller would do the same reboot immediately again.
 func (s *Service) hasJustRebooted() bool {
-	// If RebootTriggeredAt is nil, we cannot know when the reboot happened, so we treat it as not just rebooted.
-	// Without this guard, hasTimedOut(nil, ...) returns false, making this function return true indefinitely.
+	// Safe guard: RebootTriggeredAt should not be nil, when hasJustRebooted() gets called. If
+	// RebootTriggeredAt is nil, we cannot know when the reboot happened, so we treat it as not just
+	// rebooted. Without this guard, hasTimedOut(nil, ...) returns false, making this function
+	// return true indefinitely.
 	if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt == nil {
+		s.scope.Logger.Info("hasJustRebooted: s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt is nil. That is not expected")
 		return false
 	}
 	return (s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSSHRebootTriggered ||

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2644,7 +2644,7 @@ func (s *Service) hasJustRebooted() bool {
 	// rebooted. Without this guard, hasTimedOut(nil, ...) returns false, making this function
 	// return true indefinitely.
 	if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt == nil {
-		s.scope.Logger.Info("hasJustRebooted: s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt is nil. That is not expected")
+		s.scope.Info("hasJustRebooted: s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt is nil. That is not expected")
 		return false
 	}
 	return (s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSSHRebootTriggered ||

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -447,6 +447,9 @@ func (s *Service) handleIncompleteBoot(ctx context.Context, isRebootIntoRescue, 
 			// A timeout error from SSH indicates that the server did not yet finish rebooting.
 			// As the server has no error set yet, set error message and return.
 			s.scope.HetznerBareMetalHost.SetError(infrav1.ErrorTypeSSHRebootTriggered, "ssh timeout error - server has not restarted yet")
+			if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt == nil {
+				s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = ptr.To(metav1.Now())
+			}
 			return false, nil
 		}
 
@@ -2640,6 +2643,11 @@ func (s *Service) handleRobotRateLimitExceeded(err error, functionName string) {
 // Imagine the controller triggers a reboot, and reconciles immediately. This would
 // mean the controller would do the same reboot immediately again.
 func (s *Service) hasJustRebooted() bool {
+	// If RebootTriggeredAt is nil, we cannot know when the reboot happened, so we treat it as not just rebooted.
+	// Without this guard, hasTimedOut(nil, ...) returns false, making this function return true indefinitely.
+	if s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt == nil {
+		return false
+	}
 	return (s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSSHRebootTriggered ||
 		s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeSoftwareRebootTriggered ||
 		s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeHardwareRebootTriggered) &&

--- a/pkg/services/baremetal/host/utils_test.go
+++ b/pkg/services/baremetal/host/utils_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	"github.com/syself/cluster-api-provider-hetzner/test/helpers"
 )
 
 var _ = Describe("buildAutoSetup", func() {
@@ -254,5 +255,18 @@ var _ = Describe("Test splitHostKey", func() {
 		namespace, name := splitHostKey("namespace/name")
 		Expect(namespace).To(Equal("namespace"))
 		Expect(name).To(Equal("name"))
+	})
+})
+
+var _ = Describe("hasJustRebooted", func() {
+	It("returns false when RebootTriggeredAt is nil even if ErrorType is a reboot type", func() {
+		host := helpers.BareMetalHost("test-host", "default",
+			helpers.WithError(infrav1.ErrorTypeSSHRebootTriggered, "", 0),
+		)
+		// RebootTriggeredAt is intentionally nil here.
+		// Without the nil guard, hasTimedOut(nil, ...) returns false, so hasJustRebooted()
+		// would return true indefinitely.
+		svc := newTestService(host, nil, nil, nil, nil)
+		Expect(svc.hasJustRebooted()).To(BeFalse())
 	})
 })


### PR DESCRIPTION
## Summary

`RebootTriggeredAt` was set to nil to early.

Then `hasJustRebooted()` returned `true` forever when `RebootTriggeredAt` is nil but `ErrorType` is `SSHRebootTriggered`. 

This was introduced in 4f9d7c6bfeefd90059615beaf71699bfe852b723 in April this year:

```diff 
        if s.scope.HetznerBareMetalHost.Spec.Status.ErrorType == infrav1.ErrorTypeConnectionError {
                s.scope.HetznerBareMetalHost.ClearError()
+               s.scope.HetznerBareMetalHost.Spec.Status.RebootTriggeredAt = nil
        }
```

## How this state is reached

The exact path that produces `ErrorType=SSHRebootTriggered` with `RebootTriggeredAt=nil`:

1. During a reboot, the server becomes temporarily unreachable → `handleIncompleteBoot` sets `ErrorType=ConnectionError`, `RebootTriggeredAt=<time>`.
2. On the next reconcile the server is reachable again → lines 435–437 clear the connection error **and set `RebootTriggeredAt=nil`**.
3. SSH still times out (server hasn't fully rebooted yet) → the `emptyErrorType` case sets `ErrorType=SSHRebootTriggered` but (before this fix) never re-sets `RebootTriggeredAt`.
4. `hasJustRebooted()` sees `SSHRebootTriggered` + nil timestamp → `hasTimedOut(nil, …)` returns `false` → `!false == true` → stuck forever.

