### PR TITLE
✨ DeviceStringType field for ImageURLCommand (sda vs WWN)

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -47,11 +47,15 @@ var errUnknownSuffix = errors.New("unknown suffix")
 type ImageType string
 
 // DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
-// The zero value ("") passes the short device name (e.g. "sda"). Set to "wwn" to pass the WWN instead.
+// Allowed values are "" (same as "short"), "short", and "wwn".
 type DeviceStringType string
 
-// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
-const DeviceStringTypeWWN DeviceStringType = "wwn"
+const (
+	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
+	DeviceStringTypeShort DeviceStringType = "short"
+	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+	DeviceStringTypeWWN DeviceStringType = "wwn"
+)
 
 const (
 	// ImageTypeTar defines the image type for tar files.
@@ -187,11 +191,11 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-	// calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-	// used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-	// or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'wwn'",message="DeviceStringType must be empty or 'wwn'"
+	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -47,15 +47,11 @@ var errUnknownSuffix = errors.New("unknown suffix")
 type ImageType string
 
 // DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
-// Allowed values are "" (same as "short"), "short", and "wwn".
+// The zero value ("") passes the short device name (e.g. "sda"). Set to "wwn" to pass the WWN instead.
 type DeviceStringType string
 
-const (
-	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
-	DeviceStringTypeShort DeviceStringType = "short"
-	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
-	DeviceStringTypeWWN DeviceStringType = "wwn"
-)
+// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+const DeviceStringTypeWWN DeviceStringType = "wwn"
 
 const (
 	// ImageTypeTar defines the image type for tar files.
@@ -191,11 +187,11 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
+	// DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+	// calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+	// used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+	// or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'wwn'",message="DeviceStringType must be empty or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -192,9 +192,9 @@ type InstallImage struct {
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
 	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
 	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -191,7 +191,7 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
 	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
 	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
 	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -192,10 +192,9 @@ type InstallImage struct {
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
 	// DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+	// the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+	// +kubebuilder:validation:Enum="";short;wwn
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -46,6 +46,17 @@ var errUnknownSuffix = errors.New("unknown suffix")
 // ImageType defines the accepted image types.
 type ImageType string
 
+// DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
+// Allowed values are "" (same as "short"), "short", and "wwn".
+type DeviceStringType string
+
+const (
+	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
+	DeviceStringTypeShort DeviceStringType = "short"
+	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+	DeviceStringTypeWWN DeviceStringType = "wwn"
+)
+
 const (
 	// ImageTypeTar defines the image type for tar files.
 	ImageTypeTar ImageType = "tar"
@@ -179,6 +190,13 @@ type InstallImage struct {
 	// +kubebuilder:validation:Optional
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
+
+	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// +optional
+	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 
 	// PostInstallScript (Bash) is used for configuring commands that should be executed after installimage.
 	// It is passed along with the installimage command.

--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -195,6 +195,7 @@ type InstallImage struct {
 	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
 	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
 	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2477,6 +2477,7 @@ func autoConvert_v1beta1_InstallImage_To_v1beta2_InstallImage(in *InstallImage, 
 		return err
 	}
 	out.ImageURLCommand = in.ImageURLCommand
+	out.DeviceStringType = v1beta2.DeviceStringType(in.DeviceStringType)
 	out.PostInstallScript = in.PostInstallScript
 	out.Partitions = *(*[]v1beta2.Partition)(unsafe.Pointer(&in.Partitions))
 	out.LVMDefinitions = *(*[]v1beta2.LVMDefinition)(unsafe.Pointer(&in.LVMDefinitions))
@@ -2496,6 +2497,7 @@ func autoConvert_v1beta2_InstallImage_To_v1beta1_InstallImage(in *v1beta2.Instal
 		return err
 	}
 	out.ImageURLCommand = in.ImageURLCommand
+	out.DeviceStringType = DeviceStringType(in.DeviceStringType)
 	out.PostInstallScript = in.PostInstallScript
 	out.Partitions = *(*[]Partition)(unsafe.Pointer(&in.Partitions))
 	out.LVMDefinitions = *(*[]LVMDefinition)(unsafe.Pointer(&in.LVMDefinitions))

--- a/api/v1beta2/hcloudmachine_types.go
+++ b/api/v1beta2/hcloudmachine_types.go
@@ -93,13 +93,6 @@ type HCloudMachineSpec struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceString instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used, when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, then ImageURLCommand will receive a string like
-	// "sda", when "wwn" is used, it will be a string like "eui.00253885910c8cec" or
-	// "0x500a07511bb48b25".
-	DeviceString string `json:"deviceString,omitempty"`
-
 	// SSHKeys define machine-specific SSH keys and override cluster-wide SSH keys.
 	// +optional
 	// +listType=map

--- a/api/v1beta2/hcloudmachine_types.go
+++ b/api/v1beta2/hcloudmachine_types.go
@@ -93,6 +93,13 @@ type HCloudMachineSpec struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
+	// DeviceString instructs caph to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used, when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, then ImageURLCommand will receive a string like
+	// "sda", when "wwn" is used, it will be a string like "eui.00253885910c8cec" or
+	// "0x500a07511bb48b25".
+	DeviceString string `json:"deviceString,omitempty"`
+
 	// SSHKeys define machine-specific SSH keys and override cluster-wide SSH keys.
 	// +optional
 	// +listType=map

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -46,11 +46,15 @@ var errUnknownSuffix = errors.New("unknown suffix")
 type ImageType string
 
 // DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
-// The zero value ("") passes the short device name (e.g. "sda"). Set to "wwn" to pass the WWN instead.
+// Allowed values are "" (same as "short"), "short", and "wwn".
 type DeviceStringType string
 
-// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
-const DeviceStringTypeWWN DeviceStringType = "wwn"
+const (
+	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
+	DeviceStringTypeShort DeviceStringType = "short"
+	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+	DeviceStringTypeWWN DeviceStringType = "wwn"
+)
 
 const (
 	// ImageTypeTar defines the image type for tar files.
@@ -188,11 +192,11 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-	// calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-	// used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-	// or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'wwn'",message="DeviceStringType must be empty or 'wwn'"
+	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -45,6 +45,17 @@ var errUnknownSuffix = errors.New("unknown suffix")
 // ImageType defines the accepted image types.
 type ImageType string
 
+// DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
+// Allowed values are "" (same as "short"), "short", and "wwn".
+type DeviceStringType string
+
+const (
+	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
+	DeviceStringTypeShort DeviceStringType = "short"
+	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+	DeviceStringTypeWWN DeviceStringType = "wwn"
+)
+
 const (
 	// ImageTypeTar defines the image type for tar files.
 	ImageTypeTar ImageType = "tar"
@@ -181,12 +192,13 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceString instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used, when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, then ImageURLCommand will receive a string like
-	// "sda", when "wwn" is used, it will be a string like "eui.00253885910c8cec" or
-	// "0x500a07511bb48b25".
-	DeviceString string `json:"deviceString,omitempty"`
+	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
+	// +optional
+	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 
 	// PostInstallScript (Bash) is used for configuring commands that should be executed after installimage.
 	// It is passed along with the installimage command.

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -181,6 +181,13 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
+	// DeviceString instructs caph to either use the short device name, or the WWN  when calling
+	// ImageURLCommand. It is not used, when ImageURLCommand is not set. Allowed values are "short"
+	// or "wwn". Example: When "short" is used, then ImageURLCommand will receive a string like
+	// "sda", when "wwn" is used, it will be a string like "eui.00253885910c8cec" or
+	// "0x500a07511bb48b25".
+	DeviceString string `json:"deviceString,omitempty"`
+
 	// PostInstallScript (Bash) is used for configuring commands that should be executed after installimage.
 	// It is passed along with the installimage command.
 	PostInstallScript string `json:"postInstallScript,omitempty"`

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -192,7 +192,7 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+	// DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
 	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
 	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
 	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -193,9 +193,9 @@ type InstallImage struct {
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
 	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
 	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -181,7 +181,7 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceString instructs caph to either use the short device name, or the WWN  when calling
+	// DeviceString instructs caph to either use the short device name, or the WWN when calling
 	// ImageURLCommand. It is not used, when ImageURLCommand is not set. Allowed values are "short"
 	// or "wwn". Example: When "short" is used, then ImageURLCommand will receive a string like
 	// "sda", when "wwn" is used, it will be a string like "eui.00253885910c8cec" or

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -193,10 +193,9 @@ type InstallImage struct {
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
 	// DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-	// "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-	// receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+	// the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+	// +kubebuilder:validation:Enum="";short;wwn
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/api/v1beta2/hetznerbaremetalmachine_types.go
+++ b/api/v1beta2/hetznerbaremetalmachine_types.go
@@ -46,15 +46,11 @@ var errUnknownSuffix = errors.New("unknown suffix")
 type ImageType string
 
 // DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
-// Allowed values are "" (same as "short"), "short", and "wwn".
+// The zero value ("") passes the short device name (e.g. "sda"). Set to "wwn" to pass the WWN instead.
 type DeviceStringType string
 
-const (
-	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
-	DeviceStringTypeShort DeviceStringType = "short"
-	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
-	DeviceStringTypeWWN DeviceStringType = "wwn"
-)
+// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+const DeviceStringTypeWWN DeviceStringType = "wwn"
 
 const (
 	// ImageTypeTar defines the image type for tar files.
@@ -192,11 +188,11 @@ type InstallImage struct {
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
 
-	// DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-	// ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-	// or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-	// used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
-	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'short' || self == 'wwn'",message="DeviceStringType must be empty, 'short', or 'wwn'"
+	// DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+	// calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+	// used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+	// or "0x500a07511bb48b25".
+	// +kubebuilder:validation:XValidation:rule="self == '' || self == 'wwn'",message="DeviceStringType must be empty or 'wwn'"
 	// +optional
 	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -371,7 +371,7 @@ spec:
                         type: array
                       deviceStringType:
                         description: |-
-                          DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                          DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
                           ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
                           "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
                           receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -372,13 +372,13 @@ spec:
                       deviceStringType:
                         description: |-
                           DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-                          ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-                          "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-                          receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                          ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                          the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                        enum:
+                        - ""
+                        - short
+                        - wwn
                         type: string
-                        x-kubernetes-validations:
-                        - message: DeviceStringType must be empty, 'short', or 'wwn'
-                          rule: self == '' || self == 'short' || self == 'wwn'
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -377,8 +377,8 @@ spec:
                           or "0x500a07511bb48b25".
                         type: string
                         x-kubernetes-validations:
-                        - message: DeviceStringType must be empty or 'wwn'
-                          rule: self == '' || self == 'wwn'
+                        - message: DeviceStringType must be empty, 'short', or 'wwn'
+                          rule: self == '' || self == 'short' || self == 'wwn'
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -377,8 +377,8 @@ spec:
                           used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                         type: string
                         x-kubernetes-validations:
-                        - message: DeviceStringType must be empty, 'short', or 'wwn'
-                          rule: self == '' || self == 'short' || self == 'wwn'
+                        - message: DeviceStringType must be empty or 'wwn'
+                          rule: self == '' || self == 'wwn'
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -371,10 +371,10 @@ spec:
                         type: array
                       deviceStringType:
                         description: |-
-                          DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-                          calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-                          used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-                          or "0x500a07511bb48b25".
+                          DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                          ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+                          "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+                          receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                         type: string
                         x-kubernetes-validations:
                         - message: DeviceStringType must be empty, 'short', or 'wwn'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -371,10 +371,10 @@ spec:
                         type: array
                       deviceStringType:
                         description: |-
-                          DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-                          ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-                          or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-                          used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                          DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+                          calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+                          used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+                          or "0x500a07511bb48b25".
                         type: string
                         x-kubernetes-validations:
                         - message: DeviceStringType must be empty or 'wwn'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -369,6 +369,13 @@ spec:
                           - volume
                           type: object
                         type: array
+                      deviceStringType:
+                        description: |-
+                          DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                          ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+                          or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+                          used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                        type: string
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -376,6 +376,9 @@ spec:
                           or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
                           used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                         type: string
+                        x-kubernetes-validations:
+                        - message: DeviceStringType must be empty, 'short', or 'wwn'
+                          rule: self == '' || self == 'short' || self == 'wwn'
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -141,7 +141,7 @@ spec:
                     type: array
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
                       ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
                       "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
                       receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
@@ -668,7 +668,7 @@ spec:
                     x-kubernetes-list-type: atomic
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
                       ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
                       "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
                       receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -147,8 +147,8 @@ spec:
                       or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
-                    - message: DeviceStringType must be empty or 'wwn'
-                      rule: self == '' || self == 'wwn'
+                    - message: DeviceStringType must be empty, 'short', or 'wwn'
+                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.
@@ -674,8 +674,8 @@ spec:
                       or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
-                    - message: DeviceStringType must be empty or 'wwn'
-                      rule: self == '' || self == 'wwn'
+                    - message: DeviceStringType must be empty, 'short', or 'wwn'
+                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -139,6 +139,13 @@ spec:
                       - volume
                       type: object
                     type: array
+                  deviceStringType:
+                    description: |-
+                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+                      or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+                      used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                    type: string
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.
@@ -656,6 +663,16 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  deviceStringType:
+                    description: |-
+                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+                      or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+                      used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                    type: string
+                    x-kubernetes-validations:
+                    - message: DeviceStringType must be empty, 'short', or 'wwn'
+                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -141,10 +141,10 @@ spec:
                     type: array
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-                      or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-                      used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                      DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+                      calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+                      used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+                      or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
                     - message: DeviceStringType must be empty or 'wwn'
@@ -668,10 +668,10 @@ spec:
                     x-kubernetes-list-type: atomic
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-                      or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-                      used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                      DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+                      calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+                      used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+                      or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
                     - message: DeviceStringType must be empty or 'wwn'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -142,13 +142,13 @@ spec:
                   deviceStringType:
                     description: |-
                       DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-                      "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-                      receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                      the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                    enum:
+                    - ""
+                    - short
+                    - wwn
                     type: string
-                    x-kubernetes-validations:
-                    - message: DeviceStringType must be empty, 'short', or 'wwn'
-                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.
@@ -669,13 +669,13 @@ spec:
                   deviceStringType:
                     description: |-
                       DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-                      "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-                      receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                      the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                    enum:
+                    - ""
+                    - short
+                    - wwn
                     type: string
-                    x-kubernetes-validations:
-                    - message: DeviceStringType must be empty, 'short', or 'wwn'
-                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -146,6 +146,9 @@ spec:
                       or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
                       used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                     type: string
+                    x-kubernetes-validations:
+                    - message: DeviceStringType must be empty, 'short', or 'wwn'
+                      rule: self == '' || self == 'short' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -147,8 +147,8 @@ spec:
                       used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
-                    - message: DeviceStringType must be empty, 'short', or 'wwn'
-                      rule: self == '' || self == 'short' || self == 'wwn'
+                    - message: DeviceStringType must be empty or 'wwn'
+                      rule: self == '' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.
@@ -674,8 +674,8 @@ spec:
                       used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
-                    - message: DeviceStringType must be empty, 'short', or 'wwn'
-                      rule: self == '' || self == 'short' || self == 'wwn'
+                    - message: DeviceStringType must be empty or 'wwn'
+                      rule: self == '' || self == 'wwn'
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -141,10 +141,10 @@ spec:
                     type: array
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-                      calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-                      used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-                      or "0x500a07511bb48b25".
+                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+                      "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+                      receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
                     - message: DeviceStringType must be empty, 'short', or 'wwn'
@@ -668,10 +668,10 @@ spec:
                     x-kubernetes-list-type: atomic
                   deviceStringType:
                     description: |-
-                      DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-                      calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-                      used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-                      or "0x500a07511bb48b25".
+                      DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+                      "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+                      receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                     type: string
                     x-kubernetes-validations:
                     - message: DeviceStringType must be empty, 'short', or 'wwn'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -125,6 +125,13 @@ spec:
                               - volume
                               type: object
                             type: array
+                          deviceStringType:
+                            description: |-
+                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+                              or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+                              used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                            type: string
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.
@@ -438,6 +445,17 @@ spec:
                               type: object
                             type: array
                             x-kubernetes-list-type: atomic
+                          deviceStringType:
+                            description: |-
+                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
+                              or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
+                              used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                            type: string
+                            x-kubernetes-validations:
+                            - message: DeviceStringType must be empty, 'short', or
+                                'wwn'
+                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -133,8 +133,9 @@ spec:
                               or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
-                            - message: DeviceStringType must be empty or 'wwn'
-                              rule: self == '' || self == 'wwn'
+                            - message: DeviceStringType must be empty, 'short', or
+                                'wwn'
+                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.
@@ -456,8 +457,9 @@ spec:
                               or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
-                            - message: DeviceStringType must be empty or 'wwn'
-                              rule: self == '' || self == 'wwn'
+                            - message: DeviceStringType must be empty, 'short', or
+                                'wwn'
+                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -128,14 +128,13 @@ spec:
                           deviceStringType:
                             description: |-
                               DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-                              "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-                              receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                              the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                            enum:
+                            - ""
+                            - short
+                            - wwn
                             type: string
-                            x-kubernetes-validations:
-                            - message: DeviceStringType must be empty, 'short', or
-                                'wwn'
-                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.
@@ -452,14 +451,13 @@ spec:
                           deviceStringType:
                             description: |-
                               DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
-                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
-                              "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
-                              receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                              the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                            enum:
+                            - ""
+                            - short
+                            - wwn
                             type: string
-                            x-kubernetes-validations:
-                            - message: DeviceStringType must be empty, 'short', or
-                                'wwn'
-                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -127,10 +127,10 @@ spec:
                             type: array
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-                              calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-                              used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-                              or "0x500a07511bb48b25".
+                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+                              "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+                              receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
                             - message: DeviceStringType must be empty, 'short', or
@@ -451,10 +451,10 @@ spec:
                             x-kubernetes-list-type: atomic
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
-                              calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
-                              used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
-                              or "0x500a07511bb48b25".
+                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
+                              "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
+                              receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
                             - message: DeviceStringType must be empty, 'short', or

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -127,7 +127,7 @@ spec:
                             type: array
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
                               ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
                               "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
                               receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
@@ -451,7 +451,7 @@ spec:
                             x-kubernetes-list-type: atomic
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
+                              DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
                               ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "",
                               "short" (same as ""), and "wwn". Example: When "" or "short" is used, ImageURLCommand
                               receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -127,10 +127,10 @@ spec:
                             type: array
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-                              or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-                              used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                              DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+                              calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+                              used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+                              or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
                             - message: DeviceStringType must be empty or 'wwn'
@@ -450,10 +450,10 @@ spec:
                             x-kubernetes-list-type: atomic
                           deviceStringType:
                             description: |-
-                              DeviceStringType instructs caph to either use the short device name, or the WWN when calling
-                              ImageURLCommand. It is not used when ImageURLCommand is not set. Allowed values are "short"
-                              or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
-                              used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
+                              DeviceStringType instructs caph to pass the short device name (default, "") or the WWN when
+                              calling ImageURLCommand. It is not used when ImageURLCommand is not set. Example: when "" is
+                              used, ImageURLCommand receives "sda"; when "wwn" is used, it receives "eui.00253885910c8cec"
+                              or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
                             - message: DeviceStringType must be empty or 'wwn'

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -133,9 +133,8 @@ spec:
                               used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
-                            - message: DeviceStringType must be empty, 'short', or
-                                'wwn'
-                              rule: self == '' || self == 'short' || self == 'wwn'
+                            - message: DeviceStringType must be empty or 'wwn'
+                              rule: self == '' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.
@@ -457,9 +456,8 @@ spec:
                               used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                             type: string
                             x-kubernetes-validations:
-                            - message: DeviceStringType must be empty, 'short', or
-                                'wwn'
-                              rule: self == '' || self == 'short' || self == 'wwn'
+                            - message: DeviceStringType must be empty or 'wwn'
+                              rule: self == '' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -132,6 +132,10 @@ spec:
                               or "wwn". Example: When "short" is used, ImageURLCommand receives "sda"; when "wwn" is
                               used, it receives "eui.00253885910c8cec" or "0x500a07511bb48b25".
                             type: string
+                            x-kubernetes-validations:
+                            - message: DeviceStringType must be empty, 'short', or
+                                'wwn'
+                              rule: self == '' || self == 'short' || self == 'wwn'
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -84,11 +84,7 @@ can change across reboots while WWNs are stable identifiers. The `deviceStringTy
 used for hcloud machines (hcloud VMs always boot from `sda` and disks have no WWN).
 
 When multiple devices are configured (e.g. RAID via `rootDeviceHints.raid.wwn`), all device
-strings are passed as a single space-separated `$4` argument. Scripts should split on whitespace:
-
-```bash
-read -ra DEVICES <<< "$4"
-```
+strings are passed as a single space-separated `$4` argument. Scripts should split on whitespace.
 
 The command must end with the last line containing IMAGE_URL_DONE. Otherwise the execution is
 considered to have failed.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -65,7 +65,7 @@ The env var OCI_REGISTRY_AUTH_TOKEN from the caph process will be set for the co
 By default, CAPH passes short device names (e.g. `sda`) as the last argument to the command.
 For bare metal machines you can set `spec.installImage.deviceStringType` to control this:
 
-* `""` or `"short"` (default): passes the short device name, e.g. `sda`
+* `""` (default): passes the short device name, e.g. `sda`
 * `"wwn"`: passes the WWN from the `rootDeviceHints`, e.g. `eui.00253885910c8cec`
 
 Example:
@@ -82,6 +82,13 @@ spec:
 Using `deviceStringType: wwn` avoids fragile device-name lookups, because device names like `sda`
 can change across reboots while WWNs are stable identifiers. The `deviceStringType` field is not
 used for hcloud machines (hcloud VMs always boot from `sda` and disks have no WWN).
+
+When multiple devices are configured (e.g. RAID via `rootDeviceHints.raid.wwn`), all device
+strings are passed as a single space-separated `$4` argument. Scripts should split on whitespace:
+
+```bash
+read -ra DEVICES <<< "$4"
+```
 
 The command must end with the last line containing IMAGE_URL_DONE. Otherwise the execution is
 considered to have failed.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -65,7 +65,7 @@ The env var OCI_REGISTRY_AUTH_TOKEN from the caph process will be set for the co
 By default, CAPH passes short device names (e.g. `sda`) as the last argument to the command.
 For bare metal machines you can set `spec.installImage.deviceStringType` to control this:
 
-* `""` (default): passes the short device name, e.g. `sda`
+* `"short"` (or empty): passes the short device name, e.g. `sda`
 * `"wwn"`: passes the WWN from the `rootDeviceHints`, e.g. `eui.00253885910c8cec`
 
 Example:

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -62,8 +62,26 @@ and must start with `image-url-command-`.
 
 The env var OCI_REGISTRY_AUTH_TOKEN from the caph process will be set for the command, too.
 
-If you want caph to send WWNs instead of short device names like `sda`, you can configure
-DeviceString to "wwn" in the infra machine spec.
+By default, CAPH passes short device names (e.g. `sda`) as the last argument to the command.
+For bare metal machines you can set `spec.installImage.deviceStringType` to control this:
+
+* `""` or `"short"` (default): passes the short device name, e.g. `sda`
+* `"wwn"`: passes the WWN from the `rootDeviceHints`, e.g. `eui.00253885910c8cec`
+
+Example:
+
+```yaml
+spec:
+  installImage:
+    imageURLCommand: image-url-command-install-foo.sh
+    deviceStringType: wwn
+    image:
+      url: oci://example.com/yourimage:v1
+```
+
+Using `deviceStringType: wwn` avoids fragile device-name lookups, because device names like `sda`
+can change across reboots while WWNs are stable identifiers. The `deviceStringType` field is not
+used for hcloud machines (hcloud VMs always boot from `sda` and disks have no WWN).
 
 The command must end with the last line containing IMAGE_URL_DONE. Otherwise the execution is
 considered to have failed.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -62,6 +62,9 @@ and must start with `image-url-command-`.
 
 The env var OCI_REGISTRY_AUTH_TOKEN from the caph process will be set for the command, too.
 
+If you want caph to send WWNs instead of short device names like `sda`, you can configure
+DeviceString to "wwn" in the infra machine spec.
+
 The command must end with the last line containing IMAGE_URL_DONE. Otherwise the execution is
 considered to have failed.
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1418,19 +1418,21 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 			return actionStop{}
 		}
 
-		// get the information about storage devices again to have the latest names.
-		// Device names can change during restart.
-		storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
-		if err != nil {
-			return actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
-		}
-
 		// get device names from storage device
 		var deviceNames []string
 		switch s.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType {
 		case infrav1.DeviceStringTypeWWN:
 			deviceNames = s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN()
-		default: // "short" or ""
+			if len(deviceNames) == 0 {
+				return actionError{err: fmt.Errorf("DeviceStringType is %q but no WWN is configured in rootDeviceHints", infrav1.DeviceStringTypeWWN)}
+			}
+		default:
+			// Get the information about storage devices again to have the latest names.
+			// Device names can change during restart.
+			storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
+			if err != nil {
+				return actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
+			}
 			deviceNames = getDeviceNames(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN(), storage)
 		}
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1422,12 +1422,14 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		var deviceNames []string
 		switch s.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType {
 		case infrav1.DeviceStringTypeWWN:
+			// WWN examples: "eui.00253885910c8cec" or "0x500a07511bb48b25"
 			deviceNames = s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN()
 			if len(deviceNames) == 0 {
 				// this is not expected, because it is already validated.
 				return actionError{err: fmt.Errorf("DeviceStringType is %q but no WWN is configured in rootDeviceHints", infrav1.DeviceStringTypeWWN)}
 			}
 		default:
+			// Short device name examples: "sda", "sdb"
 			// Get the information about storage devices again to have the latest names.
 			// Device names can change during restart.
 			storage, err := obtainHardwareDetailsStorage(ctx, sshClient)

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1426,7 +1426,13 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		}
 
 		// get device names from storage device
-		deviceNames := getDeviceNames(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN(), storage)
+		var deviceNames []string
+		switch s.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType {
+		case infrav1.DeviceStringTypeWWN:
+			deviceNames = s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN()
+		default: // "short" or ""
+			deviceNames = getDeviceNames(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN(), storage)
+		}
 
 		exitStatus, stdoutStderr, err := sshClient.StartImageURLCommand(ctx, commandPath, s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.Image.URL, data, s.scope.Hostname(), deviceNames)
 		if err != nil {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1424,6 +1424,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		case infrav1.DeviceStringTypeWWN:
 			deviceNames = s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN()
 			if len(deviceNames) == 0 {
+				// this is not expected, because it is already validated.
 				return actionError{err: fmt.Errorf("DeviceStringType is %q but no WWN is configured in rootDeviceHints", infrav1.DeviceStringTypeWWN)}
 			}
 		default:

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -226,6 +226,9 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 
 		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
 		svc.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType = infrav1.DeviceStringTypeWWN
+		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
+			WWN: "eui.0025388801b4dff2",
+		}
 
 		commandPath := filepath.Join(baremetalImageURLCommandDir, host.Spec.Status.InstallImage.ImageURLCommand)
 		sshMock.On("StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"}).Return(0, "", nil)
@@ -233,16 +236,35 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
 		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
 
-		sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
-		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
-			WWN: "eui.0025388801b4dff2",
-		}
-
 		res := svc.actionImageInstalling(ctx)
 		Expect(res).To(BeAssignableToTypeOf(actionContinue{}))
 		Expect(sshMock.AssertCalled(GinkgoT(), "StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"})).To(BeTrue())
 		c := v1beta1conditions.Get(host, infrav1.ProvisionSucceededCondition)
 		Expect(c.Message).To(ContainSubstring(`imageURLCommand started`))
+	})
+
+	It("returns error when DeviceStringType is wwn but no WWN is configured in rootDeviceHints", func() {
+		host := newBaseHost()
+		host.Spec.Status.UserData = &corev1.SecretReference{
+			Name:      "bootstrap-secret",
+			Namespace: host.Namespace,
+		}
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+
+		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+		svc.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType = infrav1.DeviceStringTypeWWN
+		// RootDeviceHints has no WWN set — empty list
+		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{}
+
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
+		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
+
+		res := svc.actionImageInstalling(ctx)
+		Expect(res).To(BeAssignableToTypeOf(actionError{}))
+		Expect(res.(actionError).err.Error()).To(ContainSubstring("no WWN is configured in rootDeviceHints"))
 	})
 
 	It("records failure when StartImageURLCommand returns non-zero exit", func() {

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -213,6 +213,38 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		Expect(c.Message).To(ContainSubstring(`imageURLCommand started`))
 	})
 
+	It("passes WWN to StartImageURLCommand when DeviceStringType is wwn", func() {
+		host := newBaseHost()
+		host.Spec.Status.UserData = &corev1.SecretReference{
+			Name:      "bootstrap-secret",
+			Namespace: host.Namespace,
+		}
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+
+		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+		svc.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType = infrav1.DeviceStringTypeWWN
+
+		commandPath := filepath.Join(baremetalImageURLCommandDir, host.Spec.Status.InstallImage.ImageURLCommand)
+		sshMock.On("StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"}).Return(0, "", nil)
+
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
+		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
+
+		sshMock.On("GetHardwareDetailsStorage", mock.Anything).Return(sshclient.Output{StdOut: `NAME="nvme1n1" TYPE="disk" HCTL="" MODEL="SAMSUNG MZVLB512HAJQ-00000" VENDOR="" SERIAL="S3W8NX0N811178" SIZE="512110190592" WWN="eui.0025388801b4dff2" ROTA="0"`})
+		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
+			WWN: "eui.0025388801b4dff2",
+		}
+
+		res := svc.actionImageInstalling(ctx)
+		Expect(res).To(BeAssignableToTypeOf(actionContinue{}))
+		Expect(sshMock.AssertCalled(GinkgoT(), "StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"})).To(BeTrue())
+		c := v1beta1conditions.Get(host, infrav1.ProvisionSucceededCondition)
+		Expect(c.Message).To(ContainSubstring(`imageURLCommand started`))
+	})
+
 	It("records failure when StartImageURLCommand returns non-zero exit", func() {
 		host := newBaseHost()
 		host.Spec.Status.UserData = &corev1.SecretReference{Name: "bootstrap-secret", Namespace: host.Namespace}

--- a/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation.go
+++ b/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation.go
@@ -68,6 +68,13 @@ func validateHetznerBareMetalMachineSpecCreate(spec infrav1.HetznerBareMetalMach
 			)
 		}
 	} else {
+		if installImage.DeviceStringType != "" {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), installImage.DeviceStringType,
+					"deviceStringType is only valid when imageURLCommand is set"),
+			)
+		}
+
 		if (image.Name == "" || image.URL == "") && image.Path == "" {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "installImage", "image"), image,

--- a/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation_test.go
+++ b/pkg/webhook/v1beta1/hetznerbaremetalmachine_validation_test.go
@@ -80,6 +80,36 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "Valid Image URL Command with DeviceStringType wwn",
+			args: args{
+				spec: infrav1.HetznerBareMetalMachineSpec{
+					InstallImage: infrav1.InstallImage{
+						ImageURLCommand:  "image-url-command-bm-test.sh",
+						DeviceStringType: infrav1.DeviceStringTypeWWN,
+						Image: infrav1.Image{
+							URL: "oci://ghcr.io/example/ubuntu:v1",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Invalid DeviceStringType wwn without imageURLCommand",
+			args: args{
+				spec: infrav1.HetznerBareMetalMachineSpec{
+					InstallImage: infrav1.InstallImage{
+						DeviceStringType: infrav1.DeviceStringTypeWWN,
+						Image: infrav1.Image{
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
+						},
+					},
+				},
+			},
+			want: field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), infrav1.DeviceStringTypeWWN, "deviceStringType is only valid when imageURLCommand is set"),
+		},
+		{
 			name: "Invalid Image",
 			args: args{
 				spec: infrav1.HetznerBareMetalMachineSpec{

--- a/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation.go
+++ b/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation.go
@@ -68,6 +68,13 @@ func validateHetznerBareMetalMachineSpecCreate(spec infrav2.HetznerBareMetalMach
 			)
 		}
 	} else {
+		if installImage.DeviceStringType != "" {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), installImage.DeviceStringType,
+					"deviceStringType is only valid when imageURLCommand is set"),
+			)
+		}
+
 		if (image.Name == "" || image.URL == "") && image.Path == "" {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "installImage", "image"), image,

--- a/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation_test.go
+++ b/pkg/webhook/v1beta2/hetznerbaremetalmachine_validation_test.go
@@ -80,6 +80,36 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "Valid Image URL Command with DeviceStringType wwn",
+			args: args{
+				spec: infrav2.HetznerBareMetalMachineSpec{
+					InstallImage: infrav2.InstallImage{
+						ImageURLCommand:  "image-url-command-bm-test.sh",
+						DeviceStringType: infrav2.DeviceStringTypeWWN,
+						Image: infrav2.Image{
+							URL: "oci://ghcr.io/example/ubuntu:v1",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Invalid DeviceStringType wwn without imageURLCommand",
+			args: args{
+				spec: infrav2.HetznerBareMetalMachineSpec{
+					InstallImage: infrav2.InstallImage{
+						DeviceStringType: infrav2.DeviceStringTypeWWN,
+						Image: infrav2.Image{
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
+						},
+					},
+				},
+			},
+			want: field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), infrav2.DeviceStringTypeWWN, "deviceStringType is only valid when imageURLCommand is set"),
+		},
+		{
 			name: "Invalid Image",
 			args: args{
 				spec: infrav2.HetznerBareMetalMachineSpec{


### PR DESCRIPTION
Closes #2127

## Summary

* Adds `DeviceStringType` Go type (named string) with constants `DeviceStringTypeShort` and `DeviceStringTypeWWN` to both `api/v1beta1` and `api/v1beta2`
* Adds `DeviceStringType DeviceStringType` (JSON: `deviceStringType`) with a CEL validation rule restricting values to `""`, `"short"`, and `"wwn"`
* Implements the switch in `actionImageInstallingImageURLCommand`: when `DeviceStringType == "wwn"`, passes WWNs directly from `RootDeviceHints` to `StartImageURLCommand` instead of resolving to short device names
* Regenerates CRDs and conversion code via `make generate`
* Adds a test for the `"wwn"` path verifying the correct WWN is passed to `StartImageURLCommand`
* Updates docs explaining `deviceStringType` and why WWNs are more stable than short device names
