### PR TITLE
✨ DeviceStringType field for ImageURLCommand (sda vs WWN) (backport #2130)

### DIFF
--- a/api/v1beta1/hetznerbaremetalmachine_types.go
+++ b/api/v1beta1/hetznerbaremetalmachine_types.go
@@ -46,6 +46,17 @@ var errUnknownSuffix = errors.New("unknown suffix")
 // ImageType defines the accepted image types.
 type ImageType string
 
+// DeviceStringType controls what CAPH passes as the device argument to ImageURLCommand.
+// Allowed values are "" (same as "short"), "short", and "wwn".
+type DeviceStringType string
+
+const (
+	// DeviceStringTypeShort passes the short device name (e.g. "sda") to ImageURLCommand.
+	DeviceStringTypeShort DeviceStringType = "short"
+	// DeviceStringTypeWWN passes the WWN (e.g. "eui.00253885910c8cec") to ImageURLCommand.
+	DeviceStringTypeWWN DeviceStringType = "wwn"
+)
+
 const (
 	// ImageTypeTar defines the image type for tar files.
 	ImageTypeTar ImageType = "tar"
@@ -179,6 +190,13 @@ type InstallImage struct {
 	// +kubebuilder:validation:Optional
 	// +optional
 	ImageURLCommand string `json:"imageURLCommand,omitempty"`
+
+	// DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
+	// ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+	// the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+	// +kubebuilder:validation:Enum="";short;wwn
+	// +optional
+	DeviceStringType DeviceStringType `json:"deviceStringType,omitempty"`
 
 	// PostInstallScript (Bash) is used for configuring commands that should be executed after installimage.
 	// It is passed along with the installimage command.

--- a/api/v1beta1/hetznerbaremetalmachine_validation.go
+++ b/api/v1beta1/hetznerbaremetalmachine_validation.go
@@ -67,6 +67,13 @@ func validateHetznerBareMetalMachineSpecCreate(spec HetznerBareMetalMachineSpec)
 			)
 		}
 	} else {
+		if installImage.DeviceStringType != "" {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), installImage.DeviceStringType,
+					"deviceStringType is only valid when imageURLCommand is set"),
+			)
+		}
+
 		if (image.Name == "" || image.URL == "") && image.Path == "" {
 			allErrs = append(allErrs,
 				field.Invalid(field.NewPath("spec", "installImage", "image"), image,

--- a/api/v1beta1/hetznerbaremetalmachine_validation_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_validation_test.go
@@ -78,6 +78,36 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "Valid Image URL Command with DeviceStringType wwn",
+			args: args{
+				spec: infrav1.HetznerBareMetalMachineSpec{
+					InstallImage: infrav1.InstallImage{
+						ImageURLCommand:  "image-url-command-bm-test.sh",
+						DeviceStringType: infrav1.DeviceStringTypeWWN,
+						Image: infrav1.Image{
+							URL: "oci://ghcr.io/example/ubuntu:v1",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Invalid DeviceStringType wwn without imageURLCommand",
+			args: args{
+				spec: infrav1.HetznerBareMetalMachineSpec{
+					InstallImage: infrav1.InstallImage{
+						DeviceStringType: infrav1.DeviceStringTypeWWN,
+						Image: infrav1.Image{
+							Name: "ubuntu-24.04",
+							URL:  "https://example.com/ubuntu-24.04.tar.gz",
+						},
+					},
+				},
+			},
+			want: field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), infrav1.DeviceStringTypeWWN, "deviceStringType is only valid when imageURLCommand is set"),
+		},
+		{
 			name: "Invalid Image",
 			args: args{
 				spec: HetznerBareMetalMachineSpec{

--- a/api/v1beta1/hetznerbaremetalmachine_validation_test.go
+++ b/api/v1beta1/hetznerbaremetalmachine_validation_test.go
@@ -80,11 +80,11 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 		{
 			name: "Valid Image URL Command with DeviceStringType wwn",
 			args: args{
-				spec: infrav1.HetznerBareMetalMachineSpec{
-					InstallImage: infrav1.InstallImage{
+				spec: HetznerBareMetalMachineSpec{
+					InstallImage: InstallImage{
 						ImageURLCommand:  "image-url-command-bm-test.sh",
-						DeviceStringType: infrav1.DeviceStringTypeWWN,
-						Image: infrav1.Image{
+						DeviceStringType: DeviceStringTypeWWN,
+						Image: Image{
 							URL: "oci://ghcr.io/example/ubuntu:v1",
 						},
 					},
@@ -95,17 +95,17 @@ func TestValidateHetznerBareMetalMachineSpecCreate(t *testing.T) {
 		{
 			name: "Invalid DeviceStringType wwn without imageURLCommand",
 			args: args{
-				spec: infrav1.HetznerBareMetalMachineSpec{
-					InstallImage: infrav1.InstallImage{
-						DeviceStringType: infrav1.DeviceStringTypeWWN,
-						Image: infrav1.Image{
+				spec: HetznerBareMetalMachineSpec{
+					InstallImage: InstallImage{
+						DeviceStringType: DeviceStringTypeWWN,
+						Image: Image{
 							Name: "ubuntu-24.04",
 							URL:  "https://example.com/ubuntu-24.04.tar.gz",
 						},
 					},
 				},
 			},
-			want: field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), infrav1.DeviceStringTypeWWN, "deviceStringType is only valid when imageURLCommand is set"),
+			want: field.Invalid(field.NewPath("spec", "installImage", "deviceStringType"), DeviceStringTypeWWN, "deviceStringType is only valid when imageURLCommand is set"),
 		},
 		{
 			name: "Invalid Image",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -369,6 +369,16 @@ spec:
                           - volume
                           type: object
                         type: array
+                      deviceStringType:
+                        description: |-
+                          DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
+                          ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                          the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                        enum:
+                        - ""
+                        - short
+                        - wwn
+                        type: string
                       image:
                         description: Image is the image to be provisioned. It defines
                           the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachines.yaml
@@ -139,6 +139,16 @@ spec:
                       - volume
                       type: object
                     type: array
+                  deviceStringType:
+                    description: |-
+                      DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
+                      ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                      the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                    enum:
+                    - ""
+                    - short
+                    - wwn
+                    type: string
                   image:
                     description: Image is the image to be provisioned. It defines
                       the image for baremetal machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalmachinetemplates.yaml
@@ -125,6 +125,16 @@ spec:
                               - volume
                               type: object
                             type: array
+                          deviceStringType:
+                            description: |-
+                              DeviceStringType instructs CAPH to either use the short device name, or the WWN when calling
+                              ImageURLCommand. It is not used when ImageURLCommand is not set. "" and "short" both pass
+                              the short device name (e.g. "sda"); "wwn" passes the WWN (e.g. "eui.00253885910c8cec").
+                            enum:
+                            - ""
+                            - short
+                            - wwn
+                            type: string
                           image:
                             description: Image is the image to be provisioned. It
                               defines the image for baremetal machine.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -62,6 +62,30 @@ and must start with `image-url-command-`.
 
 The env var OCI_REGISTRY_AUTH_TOKEN from the caph process will be set for the command, too.
 
+By default, CAPH passes short device names (e.g. `sda`) as the last argument to the command.
+For bare metal machines you can set `spec.installImage.deviceStringType` to control this:
+
+* `"short"` (or empty): passes the short device name, e.g. `sda`
+* `"wwn"`: passes the WWN from the `rootDeviceHints`, e.g. `eui.00253885910c8cec`
+
+Example:
+
+```yaml
+spec:
+  installImage:
+    imageURLCommand: image-url-command-install-foo.sh
+    deviceStringType: wwn
+    image:
+      url: oci://example.com/yourimage:v1
+```
+
+Using `deviceStringType: wwn` avoids fragile device-name lookups, because device names like `sda`
+can change across reboots while WWNs are stable identifiers. The `deviceStringType` field is not
+used for hcloud machines (hcloud VMs always boot from `sda` and disks have no WWN).
+
+When multiple devices are configured (e.g. RAID via `rootDeviceHints.raid.wwn`), all device
+strings are passed as a single space-separated `$4` argument. Scripts should split on whitespace.
+
 The command must end with the last line containing IMAGE_URL_DONE. Otherwise the execution is
 considered to have failed.
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1417,15 +1417,26 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 			return actionStop{}
 		}
 
-		// get the information about storage devices again to have the latest names.
-		// Device names can change during restart.
-		storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
-		if err != nil {
-			return actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
-		}
-
 		// get device names from storage device
-		deviceNames := getDeviceNames(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN(), storage)
+		var deviceNames []string
+		switch s.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType {
+		case infrav1.DeviceStringTypeWWN:
+			// WWN examples: "eui.00253885910c8cec" or "0x500a07511bb48b25"
+			deviceNames = s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN()
+			if len(deviceNames) == 0 {
+				// this is not expected, because it is already validated.
+				return actionError{err: fmt.Errorf("DeviceStringType is %q but no WWN is configured in rootDeviceHints", infrav1.DeviceStringTypeWWN)}
+			}
+		default:
+			// Short device name examples: "sda", "sdb"
+			// Get the information about storage devices again to have the latest names.
+			// Device names can change during restart.
+			storage, err := obtainHardwareDetailsStorage(ctx, sshClient)
+			if err != nil {
+				return actionError{err: fmt.Errorf("failed to obtain hardware details storage: %w", err)}
+			}
+			deviceNames = getDeviceNames(s.scope.HetznerBareMetalHost.Spec.RootDeviceHints.ListOfWWN(), storage)
+		}
 
 		exitStatus, stdoutStderr, err := sshClient.StartImageURLCommand(ctx, commandPath, s.scope.HetznerBareMetalHost.Spec.Status.InstallImage.Image.URL, data, s.scope.Hostname(), deviceNames)
 		if err != nil {

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -213,6 +213,60 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		Expect(c.Message).To(ContainSubstring(`imageURLCommand started`))
 	})
 
+	It("passes WWN to StartImageURLCommand when DeviceStringType is wwn", func() {
+		host := newBaseHost()
+		host.Spec.Status.UserData = &corev1.SecretReference{
+			Name:      "bootstrap-secret",
+			Namespace: host.Namespace,
+		}
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+
+		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+		svc.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType = infrav1.DeviceStringTypeWWN
+		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{
+			WWN: "eui.0025388801b4dff2",
+		}
+
+		commandPath := filepath.Join(baremetalImageURLCommandDir, host.Spec.Status.InstallImage.ImageURLCommand)
+		sshMock.On("StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"}).Return(0, "", nil)
+
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
+		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
+
+		res := svc.actionImageInstalling(ctx)
+		Expect(res).To(BeAssignableToTypeOf(actionContinue{}))
+		Expect(sshMock.AssertCalled(GinkgoT(), "StartImageURLCommand", mock.Anything, commandPath, host.Spec.Status.InstallImage.Image.URL, mock.Anything, svc.scope.Hostname(), []string{"eui.0025388801b4dff2"})).To(BeTrue())
+		c := v1beta1conditions.Get(host, infrav1.ProvisionSucceededCondition)
+		Expect(c.Message).To(ContainSubstring(`imageURLCommand started`))
+	})
+
+	It("returns error when DeviceStringType is wwn but no WWN is configured in rootDeviceHints", func() {
+		host := newBaseHost()
+		host.Spec.Status.UserData = &corev1.SecretReference{
+			Name:      "bootstrap-secret",
+			Namespace: host.Namespace,
+		}
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})
+		sshMock.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateNotStarted, "", nil)
+
+		svc := newTestService(host, nil, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+		svc.scope.HetznerBareMetalMachine.Spec.InstallImage.DeviceStringType = infrav1.DeviceStringTypeWWN
+		// RootDeviceHints has no WWN set — empty list
+		svc.scope.HetznerBareMetalHost.Spec.RootDeviceHints = &infrav1.RootDeviceHints{}
+
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: host.Spec.Status.UserData.Name, Namespace: host.Spec.Status.UserData.Namespace}, Data: map[string][]byte{"value": []byte("#cloud-config")}}
+		Expect(svc.scope.Client.Create(ctx, secret)).To(Succeed())
+
+		res := svc.actionImageInstalling(ctx)
+		Expect(res).To(BeAssignableToTypeOf(actionError{}))
+		Expect(res.(actionError).err.Error()).To(ContainSubstring("no WWN is configured in rootDeviceHints"))
+	})
+
 	It("records failure when StartImageURLCommand returns non-zero exit", func() {
 		host := newBaseHost()
 		host.Spec.Status.UserData = &corev1.SecretReference{Name: "bootstrap-secret", Namespace: host.Namespace}


### PR DESCRIPTION
Backport of #2130 to `release-1.1`.

## Changes

Cherry-picked commit `f5178f9` with v1beta2 files excluded (release-1.1 does not have v1beta2):
- Adds `DeviceStringType` Go type with constants `DeviceStringTypeShort` and `DeviceStringTypeWWN` to `api/v1beta1`
- Adds `deviceStringType` field with CEL validation restricting values to `""`, `"short"`, and `"wwn"`
- Implements the switch in `actionImageInstallingImageURLCommand`: when `DeviceStringType == "wwn"`, passes WWNs directly from `RootDeviceHints` instead of resolving to short device names
- Updates CRDs (v1beta1 only)
- Adds tests for the `"wwn"` path
- Updates docs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)