### PR TITLE
:seedling: backport: Enable proxy protocol for control plane load balancer (#2113)

### DIFF
--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -44,6 +44,11 @@ const (
 	// format to use for baremetal nodes. If "true" "hrobot://" will be used. If not set or empty,
 	// then the old format ("hcloud://bm-") gets used.
 	UseHrobotProviderIDForBaremetalAnnotation = "capi.syself.com/use-hrobot-provider-id-for-baremetal"
+
+	// ProxyProtocolForControlPlaneLoadBalancerAnnotation is set on control-plane nodes by an external
+	// service (e.g. a node-configuration daemonset) to signal that the node is ready to receive
+	// PROXY-protocol headers. CAPH reads this annotation but never writes it.
+	ProxyProtocolForControlPlaneLoadBalancerAnnotation = "capi.syself.com/proxy-protocol-for-controlplane-loadbalancer"
 )
 
 // HetznerClusterSpec defines the desired state of HetznerCluster.

--- a/api/v1beta1/hetznercluster_types.go
+++ b/api/v1beta1/hetznercluster_types.go
@@ -45,9 +45,15 @@ const (
 	// then the old format ("hcloud://bm-") gets used.
 	UseHrobotProviderIDForBaremetalAnnotation = "capi.syself.com/use-hrobot-provider-id-for-baremetal"
 
-	// ProxyProtocolForControlPlaneLoadBalancerAnnotation is set on control-plane nodes by an external
-	// service (e.g. a node-configuration daemonset) to signal that the node is ready to receive
-	// PROXY-protocol headers. CAPH reads this annotation but never writes it.
+	// ProxyProtocolForControlPlaneLoadBalancerAnnotation is used only when enabling proxy protocol
+	// on an EXISTING cluster (migration path). It must be present with value "true" on ALL
+	// control-plane nodes before CAPH recreates the LB service with proxy protocol enabled.
+	// The annotation is set by an external service (e.g. a node-configuration daemonset) once the
+	// node is ready to receive PROXY-protocol connections. CAPH reads this annotation — it never
+	// writes it.
+	//
+	// For NEW clusters created with EnableProxyProtocol: true, this annotation is never read:
+	// the LB service is created with proxy protocol from the start, so no migration is needed.
 	ProxyProtocolForControlPlaneLoadBalancerAnnotation = "capi.syself.com/proxy-protocol-for-controlplane-loadbalancer"
 )
 

--- a/api/v1beta1/hetznercluster_webhook.go
+++ b/api/v1beta1/hetznercluster_webhook.go
@@ -197,6 +197,13 @@ func (*hetznerClusterWebhook) ValidateUpdate(_ context.Context, oldC, r *Hetzner
 		)
 	}
 
+	if oldC.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol && !r.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "controlPlaneLoadBalancer", "enableProxyProtocol"),
+				r.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol, "proxy protocol cannot be disabled once enabled"),
+		)
+	}
+
 	if err := r.validateHetznerSecretKey(); err != nil {
 		allErrs = append(allErrs, err)
 	}

--- a/api/v1beta1/hetznercluster_webhook_test.go
+++ b/api/v1beta1/hetznercluster_webhook_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validHetznerCluster(lb LoadBalancerSpec) *HetznerCluster {
+	return &HetznerCluster{
+		Spec: HetznerClusterSpec{
+			ControlPlaneLoadBalancer: lb,
+			HetznerSecret: HetznerSecretRef{
+				Key: HetznerSecretKeyRef{
+					HCloudToken: "token",
+				},
+			},
+		},
+	}
+}
+
+func TestValidateUpdateProxyProtocol(t *testing.T) {
+	webhook := &hetznerClusterWebhook{}
+
+	tests := []struct {
+		name        string
+		oldLB       LoadBalancerSpec
+		newLB       LoadBalancerSpec
+		expectError bool
+	}{
+		{
+			name:        "disabling proxy protocol is not allowed",
+			oldLB:       LoadBalancerSpec{EnableProxyProtocol: true},
+			newLB:       LoadBalancerSpec{EnableProxyProtocol: false},
+			expectError: true,
+		},
+		{
+			name:        "enabling proxy protocol is allowed",
+			oldLB:       LoadBalancerSpec{EnableProxyProtocol: false},
+			newLB:       LoadBalancerSpec{EnableProxyProtocol: true},
+			expectError: false,
+		},
+		{
+			name:        "keeping proxy protocol enabled is allowed",
+			oldLB:       LoadBalancerSpec{EnableProxyProtocol: true},
+			newLB:       LoadBalancerSpec{EnableProxyProtocol: true},
+			expectError: false,
+		},
+		{
+			name:        "keeping proxy protocol disabled is allowed",
+			oldLB:       LoadBalancerSpec{EnableProxyProtocol: false},
+			newLB:       LoadBalancerSpec{EnableProxyProtocol: false},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := webhook.ValidateUpdate(context.Background(), validHetznerCluster(tt.oldLB), validHetznerCluster(tt.newLB))
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "proxy protocol cannot be disabled once enabled")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -213,6 +213,23 @@ type LoadBalancerSpec struct {
 
 	// Region contains the name of the HCloud location where the load balancer is running.
 	Region Region `json:"region,omitempty"`
+
+	// EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
+	// Only the kube-apiserver service is affected; extra services are never given proxy protocol.
+	//
+	// For new clusters the LB service is created with proxy protocol enabled immediately — no
+	// annotation check is performed because there are no existing backends that could receive
+	// unexpected PROXY-protocol headers.
+	//
+	// For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
+	// every control-plane node carries the annotation
+	// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
+	// service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
+	// nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+	//
+	// Enabling proxy protocol is a one-way operation — it is never turned back off.
+	// +optional
+	EnableProxyProtocol bool `json:"enableProxyProtocol,omitempty"`
 }
 
 // LoadBalancerServiceSpec defines a load balancer Target.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -101,6 +101,23 @@ spec:
                       It could be round_robin or least_connection. The default value
                       is "round_robin".
                     type: string
+                  enableProxyProtocol:
+                    description: |-
+                      EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
+                      Only the kube-apiserver service is affected; extra services are never given proxy protocol.
+
+                      For new clusters the LB service is created with proxy protocol enabled immediately — no
+                      annotation check is performed because there are no existing backends that could receive
+                      unexpected PROXY-protocol headers.
+
+                      For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
+                      every control-plane node carries the annotation
+                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
+                      service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
+                      nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+
+                      Enabling proxy protocol is a one-way operation — it is never turned back off.
+                    type: boolean
                   enabled:
                     default: true
                     description: Enabled specifies if a load balancer should be created.
@@ -146,23 +163,6 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
-                  enableProxyProtocol:
-                    description: |-
-                      EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
-                      Only the kube-apiserver service is affected; extra services are never given proxy protocol.
-
-                      For new clusters the LB service is created with proxy protocol enabled immediately — no
-                      annotation check is performed because there are no existing backends that could receive
-                      unexpected PROXY-protocol headers.
-
-                      For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                      every control-plane node carries the annotation
-                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                      service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                      nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
-
-                      Enabling proxy protocol is a one-way operation — it is never turned back off.
-                    type: boolean
                   region:
                     description: Region contains the name of the HCloud location where
                       the load balancer is running.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -146,6 +146,23 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  enableProxyProtocol:
+                    description: |-
+                      EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
+                      Only the kube-apiserver service is affected; extra services are never given proxy protocol.
+
+                      For new clusters the LB service is created with proxy protocol enabled immediately — no
+                      annotation check is performed because there are no existing backends that could receive
+                      unexpected PROXY-protocol headers.
+
+                      For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
+                      every control-plane node carries the annotation
+                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
+                      service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
+                      nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+
+                      Enabling proxy protocol is a one-way operation — it is never turned back off.
+                    type: boolean
                   region:
                     description: Region contains the name of the HCloud location where
                       the load balancer is running.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -125,6 +125,23 @@ spec:
                               algorithm. It could be round_robin or least_connection.
                               The default value is "round_robin".
                             type: string
+                          enableProxyProtocol:
+                            description: |-
+                              EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
+                              Only the kube-apiserver service is affected; extra services are never given proxy protocol.
+
+                              For new clusters the LB service is created with proxy protocol enabled immediately — no
+                              annotation check is performed because there are no existing backends that could receive
+                              unexpected PROXY-protocol headers.
+
+                              For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
+                              every control-plane node carries the annotation
+                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
+                              service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
+                              nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+
+                              Enabling proxy protocol is a one-way operation — it is never turned back off.
+                            type: boolean
                           enabled:
                             default: true
                             description: Enabled specifies if a load balancer should
@@ -174,23 +191,6 @@ spec:
                             maximum: 65535
                             minimum: 1
                             type: integer
-                          enableProxyProtocol:
-                            description: |-
-                              EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
-                              Only the kube-apiserver service is affected; extra services are never given proxy protocol.
-
-                              For new clusters the LB service is created with proxy protocol enabled immediately — no
-                              annotation check is performed because there are no existing backends that could receive
-                              unexpected PROXY-protocol headers.
-
-                              For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                              every control-plane node carries the annotation
-                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                              service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                              nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
-
-                              Enabling proxy protocol is a one-way operation — it is never turned back off.
-                            type: boolean
                           region:
                             description: Region contains the name of the HCloud location
                               where the load balancer is running.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -174,6 +174,23 @@ spec:
                             maximum: 65535
                             minimum: 1
                             type: integer
+                          enableProxyProtocol:
+                            description: |-
+                              EnableProxyProtocol enables proxy protocol on the kube-apiserver load balancer service.
+                              Only the kube-apiserver service is affected; extra services are never given proxy protocol.
+
+                              For new clusters the LB service is created with proxy protocol enabled immediately — no
+                              annotation check is performed because there are no existing backends that could receive
+                              unexpected PROXY-protocol headers.
+
+                              For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
+                              every control-plane node carries the annotation
+                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
+                              service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
+                              nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+
+                              Enabling proxy protocol is a one-way operation — it is never turned back off.
+                            type: boolean
                           region:
                             description: Region contains the name of the HCloud location
                               where the load balancer is running.

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -268,4 +269,50 @@ func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 
 	_, err = clientSet.Discovery().RESTClient().Get().AbsPath("/readyz").DoRaw(ctx)
 	return err
+}
+
+// AllControlPlaneNodesReadyForProxyProtocol returns true when every control-plane node
+// in the workload cluster carries the annotation
+// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true".
+// Returns false (no error) when the workload cluster has no control-plane nodes yet.
+func (s *ClusterScope) AllControlPlaneNodesReadyForProxyProtocol(ctx context.Context) (bool, error) {
+	wlClientConfig, err := s.ClientConfig(ctx)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.V(1).Info("proxy protocol: kubeconfig secret not found, cluster not yet provisioned")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get workload cluster client config: %w", err)
+	}
+	if err := IsControlPlaneReady(ctx, wlClientConfig); err != nil {
+		return false, fmt.Errorf("workload cluster control plane not ready: %w", err)
+	}
+
+	restConfig, err := wlClientConfig.ClientConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to get workload cluster rest config: %w", err)
+	}
+	wlClient, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create workload cluster client: %w", err)
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := wlClient.List(ctx, nodeList, client.MatchingLabels{clusterv1.NodeRoleLabelPrefix + "/control-plane": ""}); err != nil {
+		return false, fmt.Errorf("failed to list control-plane nodes in workload cluster: %w", err)
+	}
+
+	if len(nodeList.Items) == 0 {
+		s.V(1).Info("proxy protocol: no control-plane nodes found")
+		return false, nil
+	}
+	for _, node := range nodeList.Items {
+		if node.Annotations[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: node missing annotation",
+				"node", node.Name,
+				"annotation", infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation)
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -292,22 +292,23 @@ func (s *Service) reconcileLBProperties(ctx context.Context, lb *hcloud.LoadBala
 func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer) (reconcile.Result, error) {
 	extraServicesSpec := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.ExtraServices
 
+	wantServiceListenPorts := make([]int, 0, len(extraServicesSpec)+1)
+	wantServiceListenPortsMap := make(map[int]infrav1.LoadBalancerServiceSpec, len(extraServicesSpec)+1)
+
 	existingServicesByPort := make(map[int]hcloud.LoadBalancerService, len(lb.Services))
 	for _, service := range lb.Services {
 		existingServicesByPort[service.ListenPort] = service
 	}
 
-	wantServiceListenPorts := make([]int, 0, len(extraServicesSpec)+1)
-	wantServiceListenPortsMap := make(map[int]infrav1.LoadBalancerServiceSpec, len(extraServicesSpec)+1)
+	// ControlPlaneEndpoint is a pointer in v1beta1; zero-value port means unknown.
+	var kubeAPIServicePort int
+	if s.scope.HetznerCluster.Spec.ControlPlaneEndpoint != nil {
+		kubeAPIServicePort = int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port)
+	}
 
 	for _, serviceInSpec := range extraServicesSpec {
 		wantServiceListenPorts = append(wantServiceListenPorts, serviceInSpec.ListenPort)
 		wantServiceListenPortsMap[serviceInSpec.ListenPort] = serviceInSpec
-	}
-
-	var kubeAPIServicePort int
-	if s.scope.HetznerCluster.Spec.ControlPlaneEndpoint != nil {
-		kubeAPIServicePort = int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port)
 	}
 
 	// add kubeAPI service if the endpoint port is known

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -142,7 +144,7 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile network attachment: %w", err)
 	}
 
-	if err := s.reconcileServices(ctx, lb); err != nil {
+	if res, err := s.reconcileServices(ctx, lb); err != nil {
 		v1beta1conditions.MarkFalse(
 			s.scope.HetznerCluster,
 			infrav1.LoadBalancerReadyCondition,
@@ -160,6 +162,8 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 		})
 
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile services: %w", err)
+	} else if res != (reconcile.Result{}) {
+		return res, nil
 	}
 
 	v1beta1conditions.MarkTrue(s.scope.HetznerCluster, infrav1.LoadBalancerReadyCondition)
@@ -285,27 +289,29 @@ func (s *Service) reconcileLBProperties(ctx context.Context, lb *hcloud.LoadBala
 	return multierr
 }
 
-func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer) error {
+func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer) (reconcile.Result, error) {
 	extraServicesSpec := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.ExtraServices
 
-	// build slices and maps to make diffs
-	haveServiceListenPorts := make([]int, 0, len(lb.Services))
+	existingServicesByPort := make(map[int]hcloud.LoadBalancerService, len(lb.Services))
+	for _, service := range lb.Services {
+		existingServicesByPort[service.ListenPort] = service
+	}
+
 	wantServiceListenPorts := make([]int, 0, len(extraServicesSpec)+1)
 	wantServiceListenPortsMap := make(map[int]infrav1.LoadBalancerServiceSpec, len(extraServicesSpec)+1)
-
-	// filter kubeAPI service out
-	for _, service := range lb.Services {
-		haveServiceListenPorts = append(haveServiceListenPorts, service.ListenPort)
-	}
 
 	for _, serviceInSpec := range extraServicesSpec {
 		wantServiceListenPorts = append(wantServiceListenPorts, serviceInSpec.ListenPort)
 		wantServiceListenPortsMap[serviceInSpec.ListenPort] = serviceInSpec
 	}
 
-	// add kubeAPI service if exists
-	if s.scope.HetznerCluster.Spec.ControlPlaneEndpoint != nil && s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port != 0 {
-		kubeAPIServicePort := int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port)
+	var kubeAPIServicePort int
+	if s.scope.HetznerCluster.Spec.ControlPlaneEndpoint != nil {
+		kubeAPIServicePort = int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port)
+	}
+
+	// add kubeAPI service if the endpoint port is known
+	if kubeAPIServicePort != 0 {
 		wantServiceListenPorts = append(wantServiceListenPorts, kubeAPIServicePort)
 		wantServiceListenPortsMap[kubeAPIServicePort] = infrav1.LoadBalancerServiceSpec{
 			Protocol:        "tcp",
@@ -314,27 +320,68 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 		}
 	}
 
-	toCreate, toDelete := utils.DifferenceOfIntSlices(wantServiceListenPorts, haveServiceListenPorts)
+	toCreate, toDelete := utils.DifferenceOfIntSlices(wantServiceListenPorts, slices.Collect(maps.Keys(existingServicesByPort)))
 
-	// delete services which are registered for lb but are not in specs
+	// kubeAPIServiceExists: whether the kube-API service already exists on the LB.
+	// New cluster: service absent → create immediately with EnableProxyProtocol from spec (no annotation check).
+	// Existing cluster migration: service present without proxy protocol → wait for all CP nodes to carry the
+	// annotation before recreating, to avoid sending malformed PROXY-protocol headers to unprepared backends.
+	existingKubeAPIService, kubeAPIServiceExists := existingServicesByPort[kubeAPIServicePort]
+	proxyProtocolAlreadyActive := kubeAPIServiceExists && existingKubeAPIService.Proxyprotocol
+
+	// proxyProtocolShouldGetEnabled: whether proxy protocol should get enabled now.
+	// The workload cluster is only contacted when the spec wants proxy protocol but the LB
+	// service doesn't have it yet. For new clusters or when already active, no call is made.
+	var proxyProtocolShouldGetEnabled bool
+	var requeueForProxyProtocol bool
+	if s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol && kubeAPIServiceExists && !proxyProtocolAlreadyActive {
+		var err error
+		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneNodesReadyForProxyProtocol(ctx)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if !proxyProtocolShouldGetEnabled {
+			s.scope.V(1).Info("proxy protocol: not all CP nodes ready yet, requeueing")
+			requeueForProxyProtocol = true
+		}
+	}
+	// Enabling proxy protocol is a one-way operation: delete the existing service and
+	// recreate it with proxy protocol on once all CP nodes signal readiness.
+	if proxyProtocolShouldGetEnabled && !proxyProtocolAlreadyActive {
+		toDelete = append(toDelete, kubeAPIServicePort)
+		toCreate = append(toCreate, kubeAPIServicePort)
+	}
+
+	// kubeAPIProxyProtocol: the proxy protocol value to use when creating the kube-API service.
+	// For existing clusters, wait for CP nodes to signal readiness before enabling.
+	// For new clusters, use the spec value directly.
+	kubeAPIProxyProtocol := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol
+	if kubeAPIServiceExists {
+		kubeAPIProxyProtocol = proxyProtocolShouldGetEnabled
+	}
+
+	// delete services that are no longer in the spec, or the kube-API service being recreated
+	// to enable proxy protocol
 	var multierr error
 
 	for _, listenPort := range toDelete {
-		if _, ok := wantServiceListenPortsMap[listenPort]; !ok {
-			if err := s.scope.HCloudClient.DeleteServiceFromLoadBalancer(ctx, lb, listenPort); err != nil {
-				// return immediately on rate limit
-				hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "DeleteServiceFromLoadBalancer")
-				multierr = errors.Join(multierr, fmt.Errorf("failed to delete service from load balancer: %w", err))
-				if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
-					return multierr
-				}
+		if err := s.scope.HCloudClient.DeleteServiceFromLoadBalancer(ctx, lb, listenPort); err != nil {
+			// return immediately on rate limit
+			hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "DeleteServiceFromLoadBalancer")
+			multierr = errors.Join(multierr, fmt.Errorf("failed to delete service from load balancer: %w", err))
+			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+				return reconcile.Result{}, multierr
 			}
 		}
 	}
 
-	// create services which are in specs and not yet in API
+	// create services that are in the spec but not yet on the LB
 	for i, listenPort := range toCreate {
 		proxyProtocol := false
+		if listenPort == kubeAPIServicePort {
+			// Proxy protocol is only relevant for the kube-apiserver port (default 6443).
+			proxyProtocol = kubeAPIProxyProtocol
+		}
 		destinationPort := wantServiceListenPortsMap[listenPort].DestinationPort
 		serviceOpts := hcloud.LoadBalancerAddServiceOpts{
 			Protocol:        hcloud.LoadBalancerServiceProtocol(wantServiceListenPortsMap[listenPort].Protocol),
@@ -347,11 +394,15 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "AddServiceToLoadBalancer")
 			multierr = errors.Join(multierr, fmt.Errorf("failed to add service to load balancer: %w", err))
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
-				return multierr
+				return reconcile.Result{}, multierr
 			}
 		}
 	}
-	return multierr
+
+	if requeueForProxyProtocol {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, multierr
+	}
+	return reconcile.Result{}, multierr
 }
 
 func (s *Service) createLoadBalancer(ctx context.Context) (*hcloud.LoadBalancer, error) {


### PR DESCRIPTION
## Summary

Back-port of #2113 to `release-1.1`.

Since `release-1.1` has no `v1beta2` API and webhooks live in `api/v1beta1/` (not `pkg/webhook/`), the changes were adapted manually:

- `ProxyProtocolForControlPlaneLoadBalancerAnnotation` constant added to `api/v1beta1/hetznercluster_types.go`
- `EnableProxyProtocol bool` field added to `LoadBalancerSpec` in `api/v1beta1/types.go`
- `AllControlPlaneNodesReadyForProxyProtocol` added to `ClusterScope` using `infrav1` (no `infrav2` in this branch)
- `reconcileServices` updated with proxy protocol enable/migration logic (returns `reconcile.Result` now)
- Webhook validation added to `api/v1beta1/hetznercluster_webhook.go` to prevent disabling proxy protocol once enabled
- CRD manifests updated for both `hetznerclusters` and `hetznerclustertemplates`
- Webhook test added to `api/v1beta1/hetznercluster_webhook_test.go`
