### PR TITLE
:seedling: Increate timeout to 20 minutes (image-url-command)

### DIFF
--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -128,8 +128,7 @@ give information from the node and to publish it as event. It's not about succes
 
 CAPH reads only the `message` field from this file to update the provisioning condition on the
 machine (HCloudMachine or HetznerBareMetalHost). The `message` field is forwarded verbatim into the
-condition message. It is read again and again to keep the condition in the Kubernetes object up to
-date.
+condition message. CAPH reads the file, and updates the condition (if needed) every ten seconds.
 
 ## Outcome summary
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1365,8 +1365,8 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.
-		s.scope.Info("ImageURLCommandOutput", "logFile", logFile)
-		record.Event(s.scope.HetznerBareMetalHost, "ImageURLCommandOutput", logFile)
+		s.scope.Info("CustomProvisionerOutput", "logFile", logFile)
+		record.Event(s.scope.HetznerBareMetalHost, "CustomProvisionerOutput", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1351,7 +1351,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		// has terminated.
 		msg := output.Message
 		if msg == "" {
-			msg = "imageURLCommand running"
+			msg = "custom provisioner running"
 		}
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
 			infrav1.HetznerBareMetalHostProvisioningV1Beta2Reason, clusterv1beta1.ConditionSeverityInfo, "%s", msg)

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1308,8 +1308,8 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		duration = time.Since(host.Spec.Status.RebootTriggeredAt.Time)
 	}
 
-	// Please keep the number (7) in sync with the docstring of ImageURL.
-	if duration > 7*time.Minute {
+	// Please keep the number (20) in sync with the docstring of ImageURL.
+	if duration > 20*time.Minute {
 		// timeout. Something has failed.
 		msg := fmt.Sprintf("ImageURLCommand timed out after %s. Deleting machine",
 			duration.Round(time.Second).String())

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1347,7 +1347,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 			return actionContinue{delay: 10 * time.Second}
 		}
 
-		// imageURLCommand is still running. CAPH wait until the Linux process in the rescue system
+		// imageURLCommand is still running. CAPH waits until the Linux process in the rescue system
 		// has terminated.
 		msg := output.Message
 		if msg == "" {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -939,12 +939,12 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"HCloudImageURLCommandRunning", clusterv1beta1.ConditionSeverityInfo,
-		"imageURLCommand running")
+		"custom provisioner running")
 	v1beta2conditions.Set(hm, metav1.Condition{
 		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 		Status:  metav1.ConditionFalse,
 		Reason:  infrav1.HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason,
-		Message: "imageURLCommand running",
+		Message: "custom provisioner running",
 	})
 	hm.SetBootState(infrav1.HCloudBootStateRunningImageCommand)
 	return reconcile.Result{RequeueAfter: 55 * time.Second}, nil
@@ -1031,7 +1031,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		// has terminated.
 		msg := output.Message
 		if msg == "" {
-			msg = "imageURLCommand running"
+			msg = "custom provisioner running"
 		}
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"HCloudImageURLCommandRunning", clusterv1beta1.ConditionSeverityInfo, "%s", msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1027,7 +1027,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		// imageURLCommand is still running. CAPH wait until the Linux process in the rescue system
+		// imageURLCommand is still running. CAPH waits until the Linux process in the rescue system
 		// has terminated.
 		msg := output.Message
 		if msg == "" {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -966,8 +966,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 	}
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
-	// Please keep the number (7) in sync with the docstring of ImageURL.
-	if durationOfState > 7*time.Minute {
+	// Please keep the number (20) in sync with the docstring of ImageURL.
+	if durationOfState > 20*time.Minute {
 		// timeout. Something has failed.
 		timeoutMsg := fmt.Sprintf("image URL command timed out, in this state since %s", durationOfState.Round(time.Second).String())
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1045,8 +1045,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.
-		s.scope.Info("ImageURLCommandOutput", "logFile", logFile)
-		record.Event(hm, "ImageURLCommandOutput", logFile)
+		s.scope.Info("CustomProvisionerOutput", "logFile", logFile)
+		record.Event(hm, "CustomProvisionerOutput", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {


### PR DESCRIPTION
Increates timeout of image-url-command to 20 minutes.

Follow-up to [:seedling: image-url-command: read output.json (if it exists) by guettli · Pull Request #2025 · syself/cluster-api-provider-hetzner](https://github.com/syself/cluster-api-provider-hetzner/pull/2025)