### PR TITLE
:seedling: Increase provisioning timeout to 20 minutes (backport #2136)

### DIFF
--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -72,7 +72,7 @@ type HCloudMachineSpec struct {
 	// the process is considered to have failed.
 	//
 	// A Kubernetes event will be created in both (success, failure) cases containing the output
-	// (stdout and stderr) of the script. If the script takes longer than 7 minutes, the
+	// (stdout and stderr) of the script. If the script takes longer than 20 minutes, the
 	// controller cancels the provisioning.
 	//
 	// Docs: https://syself.com/docs/caph/developers/image-url-command

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -86,7 +86,7 @@ spec:
                   the process is considered to have failed.
 
                   A Kubernetes event will be created in both (success, failure) cases containing the output
-                  (stdout and stderr) of the script. If the script takes longer than 7 minutes, the
+                  (stdout and stderr) of the script. If the script takes longer than 20 minutes, the
                   controller cancels the provisioning.
 
                   Docs: https://syself.com/docs/caph/developers/image-url-command

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachinetemplates.yaml
@@ -113,7 +113,7 @@ spec:
                           the process is considered to have failed.
 
                           A Kubernetes event will be created in both (success, failure) cases containing the output
-                          (stdout and stderr) of the script. If the script takes longer than 7 minutes, the
+                          (stdout and stderr) of the script. If the script takes longer than 20 minutes, the
                           controller cancels the provisioning.
 
                           Docs: https://syself.com/docs/caph/developers/image-url-command

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -102,7 +102,7 @@ process is still running.
 The controller uses url.ParseRequestURI (Go function) to validate the imageURL.
 
 A Kubernetes event will be created in both (success, failure) cases containing the output (stdout
-and stderr) of the script. If the script takes longer than 7 minutes, the controller cancels the
+and stderr) of the script. If the script takes longer than 20 minutes, the controller cancels the
 provisioning.
 
 ## Steps

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1308,8 +1308,8 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		duration = time.Since(host.Spec.Status.RebootTriggeredAt.Time)
 	}
 
-	// Please keep the number (7) in sync with the docstring of ImageURL.
-	if duration > 7*time.Minute {
+	// Please keep the number (20) in sync with the docstring of ImageURL.
+	if duration > 20*time.Minute {
 		// timeout. Something has failed.
 		msg := fmt.Sprintf("ImageURLCommand timed out after %s. Deleting machine",
 			duration.Round(time.Second).String())

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -325,10 +325,10 @@ var _ = Describe("actionImageInstalling (image-url-command)", func() {
 		Expect(c.Message).To(ContainSubstring("StartImageURLCommand failed with non-zero exit status. Deleting machine"))
 	})
 
-	It("times out after 7 minutes", func() {
+	It("times out after 20 minutes", func() {
 		host := newBaseHost()
-		sevenPlus := metav1.NewTime(time.Now().Add(-8 * time.Minute))
-		host.Spec.Status.RebootTriggeredAt = &sevenPlus
+		timeout := metav1.NewTime(time.Now().Add(-21 * time.Minute))
+		host.Spec.Status.RebootTriggeredAt = &timeout
 
 		sshMock := &sshmock.Client{}
 		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{StdOut: "rescue"})

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -966,8 +966,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 	}
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
-	// Please keep the number (7) in sync with the docstring of ImageURL.
-	if durationOfState > 7*time.Minute {
+	// Please keep the number (20) in sync with the docstring of ImageURL.
+	if durationOfState > 20*time.Minute {
 		// timeout. Something has failed.
 		timeoutMsg := fmt.Sprintf("image URL command timed out, in this state since %s", durationOfState.Round(time.Second).String())
 


### PR DESCRIPTION
Backport of #2136 (main commit 5fb187f5d) to release-1.1. The v1beta2-only parts are dropped because release-1.1 has no v1beta2.