### PR TITLE
:seedling: disable bm-e2e-1716772 again (rescue-mode reboot timeout)

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -16,7 +16,7 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# 2026-06-23: Re-enabled after rescue-mode reboot timeout investigation.
+# 2026-07-08: Disabled again. Hardware reboot into rescue mode timed out (CI run 28847985206).
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -28,7 +28,7 @@ spec:
   serverID: 1716772 # ip: 136.243.69.24
   rootDeviceHints:
     wwn: "0x5002538d41d70a46"
-  maintenanceMode: false
+  maintenanceMode: true
   description: Test Machine 1716772
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Server bm-e2e-1716772 fails to reboot into rescue mode again, breaking the baremetal e2e (CI run 28847985206). Set maintenanceMode: true so the pool skips it.