### PR TITLE
✨ Boot HCloud imageURL machines directly into rescue system

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -373,13 +373,21 @@ const (
 	HCloudMachineBootStateInitializingTimedOutV1Beta2Reason = "BootStateInitializingTimedOut"
 	// HCloudMachineProvisioningServerV1Beta2Reason indicates the server is being provisioned.
 	HCloudMachineProvisioningServerV1Beta2Reason = "Provisioning"
-	// HCloudMachineServerNotRunningYetV1Beta2Reason indicates the server is not running yet.
-	HCloudMachineServerNotRunningYetV1Beta2Reason = "ServerNotRunningYet"
 	// HCloudMachineServerStatusUnknownV1Beta2Reason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownV1Beta2Reason = "ServerStatusUnknown"
+	// HCloudMachineActionIDCreateNotSetV1Beta2Reason indicates the action ID of the server create action is not set.
+	HCloudMachineActionIDCreateNotSetV1Beta2Reason = "ActionIDCreateNotSet"
+	// HCloudMachineWaitingForCreateActionV1Beta2Reason indicates waiting for the server create action to finish.
+	HCloudMachineWaitingForCreateActionV1Beta2Reason = "WaitingForCreateAction"
+	// HCloudMachineGettingCreateActionFailedV1Beta2Reason indicates getting the server create action failed.
+	HCloudMachineGettingCreateActionFailedV1Beta2Reason = "GettingCreateActionFailed"
+	// HCloudMachineCreateActionFailedV1Beta2Reason indicates the server create action failed.
+	HCloudMachineCreateActionFailedV1Beta2Reason = "CreateActionFailed"
 
 	// HCloudMachineWaitingForRescueSystemV1Beta2Reason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemV1Beta2Reason = "WaitingForRescueSystem"
+	// HCloudMachineEnablingRescueSystemFailedV1Beta2Reason indicates enabling the rescue system failed.
+	HCloudMachineEnablingRescueSystemFailedV1Beta2Reason = "EnablingRescueSystemFailed"
 	// HCloudMachineEnablingRescueTimedOutV1Beta2Reason indicates enabling rescue system timed out.
 	HCloudMachineEnablingRescueTimedOutV1Beta2Reason = "EnablingRescueTimedOut"
 	// HCloudMachineActionIDForEnablingRescueSystemNotSetV1Beta2Reason indicates the action ID for enabling rescue is not set.
@@ -397,12 +405,8 @@ const (
 
 	// HCloudMachineGettingSSHPrivateKeyFailedV1Beta2Reason indicates getting the SSH private key failed.
 	HCloudMachineGettingSSHPrivateKeyFailedV1Beta2Reason = "GettingSSHPrivateKeyFailed"
-	// HCloudMachineGettingSSHClientFailedV1Beta2Reason indicates getting the SSH client failed.
-	HCloudMachineGettingSSHClientFailedV1Beta2Reason = "GettingSSHClientFailed"
 	// HCloudMachineRetryingSSHConnectionV1Beta2Reason indicates the SSH connection is being retried.
 	HCloudMachineRetryingSSHConnectionV1Beta2Reason = "RetryingSSHConnection"
-	// HCloudMachineRebootViaSSHFailedV1Beta2Reason indicates rebooting via SSH failed.
-	HCloudMachineRebootViaSSHFailedV1Beta2Reason = "RebootViaSSHFailed"
 	// HCloudMachineGettingHostnameFailedV1Beta2Reason indicates getting the hostname failed.
 	HCloudMachineGettingHostnameFailedV1Beta2Reason = "GettingHostnameFailed"
 	// HCloudMachineUnexpectedHostnameV1Beta2Reason indicates the remote hostname was unexpected.

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -355,7 +355,8 @@ const (
 	HCloudMachineServerSSHKeyNotFoundV1Beta2Reason = "SSHKeyNotFound"
 	// HCloudMachineServerPlacementGroupNotFoundV1Beta2Reason surfaces when the specified placement group does not exist.
 	HCloudMachineServerPlacementGroupNotFoundV1Beta2Reason = "PlacementGroupNotFound"
-	// HCloudMachineServerCreationFailedV1Beta2Reason surfaces when the HCloud API CreateServer call fails.
+	// HCloudMachineServerCreationFailedV1Beta2Reason surfaces when creating the hcloud server fails,
+	// either because the CreateServer call fails or because the create action fails afterwards.
 	HCloudMachineServerCreationFailedV1Beta2Reason = "CreationFailed"
 )
 
@@ -375,14 +376,12 @@ const (
 	HCloudMachineProvisioningServerV1Beta2Reason = "Provisioning"
 	// HCloudMachineServerStatusUnknownV1Beta2Reason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownV1Beta2Reason = "ServerStatusUnknown"
-	// HCloudMachineActionIDCreateServerNotSetV1Beta2Reason indicates the action ID of the server create action is not set.
+	// HCloudMachineActionIDCreateServerNotSetV1Beta2Reason indicates the ActionIDCreateServer status field is not set.
 	HCloudMachineActionIDCreateServerNotSetV1Beta2Reason = "ActionIDCreateServerNotSet"
 	// HCloudMachineCreatingServerV1Beta2Reason indicates the hcloud server is being created.
 	HCloudMachineCreatingServerV1Beta2Reason = "CreatingServer"
-	// HCloudMachineGettingCreateServerActionFailedV1Beta2Reason indicates getting the server create action failed.
-	HCloudMachineGettingCreateServerActionFailedV1Beta2Reason = "GettingCreateServerActionFailed"
-	// HCloudMachineCreateServerActionFailedV1Beta2Reason indicates the server create action failed.
-	HCloudMachineCreateServerActionFailedV1Beta2Reason = "CreateServerActionFailed"
+	// HCloudMachineGettingServerCreationStatusFailedV1Beta2Reason indicates checking the server creation progress failed.
+	HCloudMachineGettingServerCreationStatusFailedV1Beta2Reason = "GettingServerCreationStatusFailed"
 
 	// HCloudMachineWaitingForRescueSystemV1Beta2Reason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemV1Beta2Reason = "WaitingForRescueSystem"

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -375,14 +375,14 @@ const (
 	HCloudMachineProvisioningServerV1Beta2Reason = "Provisioning"
 	// HCloudMachineServerStatusUnknownV1Beta2Reason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownV1Beta2Reason = "ServerStatusUnknown"
-	// HCloudMachineActionIDCreateNotSetV1Beta2Reason indicates the action ID of the server create action is not set.
-	HCloudMachineActionIDCreateNotSetV1Beta2Reason = "ActionIDCreateNotSet"
-	// HCloudMachineWaitingForCreateActionV1Beta2Reason indicates waiting for the server create action to finish.
-	HCloudMachineWaitingForCreateActionV1Beta2Reason = "WaitingForCreateAction"
-	// HCloudMachineGettingCreateActionFailedV1Beta2Reason indicates getting the server create action failed.
-	HCloudMachineGettingCreateActionFailedV1Beta2Reason = "GettingCreateActionFailed"
-	// HCloudMachineCreateActionFailedV1Beta2Reason indicates the server create action failed.
-	HCloudMachineCreateActionFailedV1Beta2Reason = "CreateActionFailed"
+	// HCloudMachineActionIDCreateServerNotSetV1Beta2Reason indicates the action ID of the server create action is not set.
+	HCloudMachineActionIDCreateServerNotSetV1Beta2Reason = "ActionIDCreateServerNotSet"
+	// HCloudMachineCreatingServerV1Beta2Reason indicates the hcloud server is being created.
+	HCloudMachineCreatingServerV1Beta2Reason = "CreatingServer"
+	// HCloudMachineGettingCreateServerActionFailedV1Beta2Reason indicates getting the server create action failed.
+	HCloudMachineGettingCreateServerActionFailedV1Beta2Reason = "GettingCreateServerActionFailed"
+	// HCloudMachineCreateServerActionFailedV1Beta2Reason indicates the server create action failed.
+	HCloudMachineCreateServerActionFailedV1Beta2Reason = "CreateServerActionFailed"
 
 	// HCloudMachineWaitingForRescueSystemV1Beta2Reason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemV1Beta2Reason = "WaitingForRescueSystem"

--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -208,9 +208,9 @@ type HCloudMachineStatusExternalIDs struct {
 	// +optional
 	ActionIDEnableRescueSystem int64 `json:"actionIdEnableRescueSystem,omitzero"`
 
-	// ActionIDCreate is the hcloud API Action result of CreateServer.
+	// ActionIDCreateServer is the hcloud API Action result of CreateServer.
 	// +optional
-	ActionIDCreate int64 `json:"actionIdCreate,omitzero"`
+	ActionIDCreateServer int64 `json:"actionIdCreateServer,omitzero"`
 }
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -207,6 +207,10 @@ type HCloudMachineStatusExternalIDs struct {
 	// ActionIDEnableRescueSystem is the hcloud API Action result of EnableRescueSystem.
 	// +optional
 	ActionIDEnableRescueSystem int64 `json:"actionIdEnableRescueSystem,omitzero"`
+
+	// ActionIDCreate is the hcloud API Action result of CreateServer.
+	// +optional
+	ActionIDCreate int64 `json:"actionIdCreate,omitzero"`
 }
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -322,8 +322,8 @@ const (
 	// HCloudBootStateUnset is the initial state when the boot state has not been set yet.
 	HCloudBootStateUnset HCloudBootState = ""
 
-	// HCloudBootStateInitializing indicates that the controller waits for PreRescueOS.
-	// When it is available, then the rescue system gets enabled.
+	// HCloudBootStateInitializing indicates the controller waits for the server create action to
+	// finish. The server stays powered off; once it is provisioned, the rescue system gets enabled.
 	HCloudBootStateInitializing HCloudBootState = "Initializing"
 
 	// HCloudBootStateEnablingRescue indicates that the controller waits for the rescue system to be enabled. Then the server gets booted into the rescue system.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1041,6 +1041,7 @@ func Convert_v1beta2_HCloudMachineSpec_To_v1beta1_HCloudMachineSpec(in *v1beta2.
 
 func autoConvert_v1beta1_HCloudMachineStatusExternalIDs_To_v1beta2_HCloudMachineStatusExternalIDs(in *HCloudMachineStatusExternalIDs, out *v1beta2.HCloudMachineStatusExternalIDs, s conversion.Scope) error {
 	out.ActionIDEnableRescueSystem = in.ActionIDEnableRescueSystem
+	out.ActionIDCreate = in.ActionIDCreate
 	return nil
 }
 
@@ -1051,6 +1052,7 @@ func Convert_v1beta1_HCloudMachineStatusExternalIDs_To_v1beta2_HCloudMachineStat
 
 func autoConvert_v1beta2_HCloudMachineStatusExternalIDs_To_v1beta1_HCloudMachineStatusExternalIDs(in *v1beta2.HCloudMachineStatusExternalIDs, out *HCloudMachineStatusExternalIDs, s conversion.Scope) error {
 	out.ActionIDEnableRescueSystem = in.ActionIDEnableRescueSystem
+	out.ActionIDCreate = in.ActionIDCreate
 	return nil
 }
 

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -1041,7 +1041,7 @@ func Convert_v1beta2_HCloudMachineSpec_To_v1beta1_HCloudMachineSpec(in *v1beta2.
 
 func autoConvert_v1beta1_HCloudMachineStatusExternalIDs_To_v1beta2_HCloudMachineStatusExternalIDs(in *HCloudMachineStatusExternalIDs, out *v1beta2.HCloudMachineStatusExternalIDs, s conversion.Scope) error {
 	out.ActionIDEnableRescueSystem = in.ActionIDEnableRescueSystem
-	out.ActionIDCreate = in.ActionIDCreate
+	out.ActionIDCreateServer = in.ActionIDCreateServer
 	return nil
 }
 
@@ -1052,7 +1052,7 @@ func Convert_v1beta1_HCloudMachineStatusExternalIDs_To_v1beta2_HCloudMachineStat
 
 func autoConvert_v1beta2_HCloudMachineStatusExternalIDs_To_v1beta1_HCloudMachineStatusExternalIDs(in *v1beta2.HCloudMachineStatusExternalIDs, out *HCloudMachineStatusExternalIDs, s conversion.Scope) error {
 	out.ActionIDEnableRescueSystem = in.ActionIDEnableRescueSystem
-	out.ActionIDCreate = in.ActionIDCreate
+	out.ActionIDCreateServer = in.ActionIDCreateServer
 	return nil
 }
 

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -411,7 +411,8 @@ const (
 	HCloudMachineServerSSHKeyNotFoundReason = "SSHKeyNotFound"
 	// HCloudMachineServerPlacementGroupNotFoundReason surfaces when the specified placement group does not exist.
 	HCloudMachineServerPlacementGroupNotFoundReason = "PlacementGroupNotFound"
-	// HCloudMachineServerCreationFailedReason surfaces when the HCloud API CreateServer call fails.
+	// HCloudMachineServerCreationFailedReason surfaces when creating the hcloud server fails,
+	// either because the CreateServer call fails or because the create action fails afterwards.
 	HCloudMachineServerCreationFailedReason = "CreationFailed"
 )
 
@@ -431,14 +432,12 @@ const (
 	HCloudMachineProvisioningServerReason = "Provisioning"
 	// HCloudMachineServerStatusUnknownReason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownReason = "ServerStatusUnknown"
-	// HCloudMachineActionIDCreateServerNotSetReason indicates the action ID of the server create action is not set.
+	// HCloudMachineActionIDCreateServerNotSetReason indicates the ActionIDCreateServer status field is not set.
 	HCloudMachineActionIDCreateServerNotSetReason = "ActionIDCreateServerNotSet"
 	// HCloudMachineCreatingServerReason indicates the hcloud server is being created.
 	HCloudMachineCreatingServerReason = "CreatingServer"
-	// HCloudMachineGettingCreateServerActionFailedReason indicates getting the server create action failed.
-	HCloudMachineGettingCreateServerActionFailedReason = "GettingCreateServerActionFailed"
-	// HCloudMachineCreateServerActionFailedReason indicates the server create action failed.
-	HCloudMachineCreateServerActionFailedReason = "CreateServerActionFailed"
+	// HCloudMachineGettingServerCreationStatusFailedReason indicates checking the server creation progress failed.
+	HCloudMachineGettingServerCreationStatusFailedReason = "GettingServerCreationStatusFailed"
 
 	// HCloudMachineWaitingForRescueSystemReason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemReason = "WaitingForRescueSystem"

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -431,14 +431,14 @@ const (
 	HCloudMachineProvisioningServerReason = "Provisioning"
 	// HCloudMachineServerStatusUnknownReason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownReason = "ServerStatusUnknown"
-	// HCloudMachineActionIDCreateNotSetReason indicates the action ID of the server create action is not set.
-	HCloudMachineActionIDCreateNotSetReason = "ActionIDCreateNotSet"
-	// HCloudMachineWaitingForCreateActionReason indicates waiting for the server create action to finish.
-	HCloudMachineWaitingForCreateActionReason = "WaitingForCreateAction"
-	// HCloudMachineGettingCreateActionFailedReason indicates getting the server create action failed.
-	HCloudMachineGettingCreateActionFailedReason = "GettingCreateActionFailed"
-	// HCloudMachineCreateActionFailedReason indicates the server create action failed.
-	HCloudMachineCreateActionFailedReason = "CreateActionFailed"
+	// HCloudMachineActionIDCreateServerNotSetReason indicates the action ID of the server create action is not set.
+	HCloudMachineActionIDCreateServerNotSetReason = "ActionIDCreateServerNotSet"
+	// HCloudMachineCreatingServerReason indicates the hcloud server is being created.
+	HCloudMachineCreatingServerReason = "CreatingServer"
+	// HCloudMachineGettingCreateServerActionFailedReason indicates getting the server create action failed.
+	HCloudMachineGettingCreateServerActionFailedReason = "GettingCreateServerActionFailed"
+	// HCloudMachineCreateServerActionFailedReason indicates the server create action failed.
+	HCloudMachineCreateServerActionFailedReason = "CreateServerActionFailed"
 
 	// HCloudMachineWaitingForRescueSystemReason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemReason = "WaitingForRescueSystem"

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -429,13 +429,21 @@ const (
 	HCloudMachineBootStateInitializingTimedOutReason = "BootStateInitializingTimedOut"
 	// HCloudMachineProvisioningServerReason indicates the server is being provisioned.
 	HCloudMachineProvisioningServerReason = "Provisioning"
-	// HCloudMachineServerNotRunningYetReason indicates the server is not running yet.
-	HCloudMachineServerNotRunningYetReason = "ServerNotRunningYet"
 	// HCloudMachineServerStatusUnknownReason indicates the hcloud server returned a status that the controller does not handle.
 	HCloudMachineServerStatusUnknownReason = "ServerStatusUnknown"
+	// HCloudMachineActionIDCreateNotSetReason indicates the action ID of the server create action is not set.
+	HCloudMachineActionIDCreateNotSetReason = "ActionIDCreateNotSet"
+	// HCloudMachineWaitingForCreateActionReason indicates waiting for the server create action to finish.
+	HCloudMachineWaitingForCreateActionReason = "WaitingForCreateAction"
+	// HCloudMachineGettingCreateActionFailedReason indicates getting the server create action failed.
+	HCloudMachineGettingCreateActionFailedReason = "GettingCreateActionFailed"
+	// HCloudMachineCreateActionFailedReason indicates the server create action failed.
+	HCloudMachineCreateActionFailedReason = "CreateActionFailed"
 
 	// HCloudMachineWaitingForRescueSystemReason indicates waiting for the rescue system to be enabled.
 	HCloudMachineWaitingForRescueSystemReason = "WaitingForRescueSystem"
+	// HCloudMachineEnablingRescueSystemFailedReason indicates enabling the rescue system failed.
+	HCloudMachineEnablingRescueSystemFailedReason = "EnablingRescueSystemFailed"
 	// HCloudMachineEnablingRescueTimedOutReason indicates enabling rescue system timed out.
 	HCloudMachineEnablingRescueTimedOutReason = "EnablingRescueTimedOut"
 	// HCloudMachineActionIDForEnablingRescueSystemNotSetReason indicates the action ID for enabling rescue is not set.
@@ -453,12 +461,8 @@ const (
 
 	// HCloudMachineGettingSSHPrivateKeyFailedReason indicates getting the SSH private key failed.
 	HCloudMachineGettingSSHPrivateKeyFailedReason = "GettingSSHPrivateKeyFailed"
-	// HCloudMachineGettingSSHClientFailedReason indicates getting the SSH client failed.
-	HCloudMachineGettingSSHClientFailedReason = "GettingSSHClientFailed"
 	// HCloudMachineRetryingSSHConnectionReason indicates the SSH connection is being retried.
 	HCloudMachineRetryingSSHConnectionReason = "RetryingSSHConnection"
-	// HCloudMachineRebootViaSSHFailedReason indicates rebooting via SSH failed.
-	HCloudMachineRebootViaSSHFailedReason = "RebootViaSSHFailed"
 	// HCloudMachineGettingHostnameFailedReason indicates getting the hostname failed.
 	HCloudMachineGettingHostnameFailedReason = "GettingHostnameFailed"
 	// HCloudMachineUnexpectedHostnameReason indicates the remote hostname was unexpected.

--- a/api/v1beta2/hcloudmachine_types.go
+++ b/api/v1beta2/hcloudmachine_types.go
@@ -239,9 +239,9 @@ type HCloudMachineStatusExternalIDs struct {
 	// +optional
 	ActionIDEnableRescueSystem int64 `json:"actionIdEnableRescueSystem,omitzero"`
 
-	// ActionIDCreate is the hcloud API Action result of CreateServer.
+	// ActionIDCreateServer is the hcloud API Action result of CreateServer.
 	// +optional
-	ActionIDCreate int64 `json:"actionIdCreate,omitzero"`
+	ActionIDCreateServer int64 `json:"actionIdCreateServer,omitzero"`
 }
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta2/hcloudmachine_types.go
+++ b/api/v1beta2/hcloudmachine_types.go
@@ -238,6 +238,10 @@ type HCloudMachineStatusExternalIDs struct {
 	// ActionIDEnableRescueSystem is the hcloud API Action result of EnableRescueSystem.
 	// +optional
 	ActionIDEnableRescueSystem int64 `json:"actionIdEnableRescueSystem,omitzero"`
+
+	// ActionIDCreate is the hcloud API Action result of CreateServer.
+	// +optional
+	ActionIDCreate int64 `json:"actionIdCreate,omitzero"`
 }
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -334,8 +334,8 @@ const (
 	// HCloudBootStateUnset is the initial state when the boot state has not been set yet.
 	HCloudBootStateUnset HCloudBootState = ""
 
-	// HCloudBootStateInitializing indicates that the controller waits for PreRescueOS.
-	// When it is available, then the rescue system gets enabled.
+	// HCloudBootStateInitializing indicates the controller waits for the server create action to
+	// finish. The server stays powered off; once it is provisioned, the rescue system gets enabled.
 	HCloudBootStateInitializing HCloudBootState = "Initializing"
 
 	// HCloudBootStateEnablingRescue indicates that the controller waits for the rescue system to be enabled. Then the server gets booted into the rescue system.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -267,9 +267,9 @@ spec:
                 description: ExternalIDs contains temporary data during the provisioning
                   process
                 properties:
-                  actionIdCreate:
-                    description: ActionIDCreate is the hcloud API Action result of
-                      CreateServer.
+                  actionIdCreateServer:
+                    description: ActionIDCreateServer is the hcloud API Action result
+                      of CreateServer.
                     format: int64
                     type: integer
                   actionIdEnableRescueSystem:
@@ -745,9 +745,9 @@ spec:
                 description: ExternalIDs contains temporary data during the provisioning
                   process
                 properties:
-                  actionIdCreate:
-                    description: ActionIDCreate is the hcloud API Action result of
-                      CreateServer.
+                  actionIdCreateServer:
+                    description: ActionIDCreateServer is the hcloud API Action result
+                      of CreateServer.
                     format: int64
                     type: integer
                   actionIdEnableRescueSystem:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -267,6 +267,11 @@ spec:
                 description: ExternalIDs contains temporary data during the provisioning
                   process
                 properties:
+                  actionIdCreate:
+                    description: ActionIDCreate is the hcloud API Action result of
+                      CreateServer.
+                    format: int64
+                    type: integer
                   actionIdEnableRescueSystem:
                     description: ActionIDEnableRescueSystem is the hcloud API Action
                       result of EnableRescueSystem.
@@ -740,6 +745,11 @@ spec:
                 description: ExternalIDs contains temporary data during the provisioning
                   process
                 properties:
+                  actionIdCreate:
+                    description: ActionIDCreate is the hcloud API Action result of
+                      CreateServer.
+                    format: int64
+                    type: integer
                   actionIdEnableRescueSystem:
                     description: ActionIDEnableRescueSystem is the hcloud API Action
                       result of EnableRescueSystem.

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -434,10 +434,11 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 			hcloudClient := testEnv.HCloudClientFactory.NewClient("dummy-token")
 
-			server, err := hcloudClient.CreateServer(ctx, hcloud.ServerCreateOpts{
+			result, err := hcloudClient.CreateServer(ctx, hcloud.ServerCreateOpts{
 				Name: "myserver",
 			})
 			Expect(err).ShouldNot(HaveOccurred())
+			server := result.Server
 
 			Eventually(func() error {
 				err := testEnv.Get(ctx, client.ObjectKeyFromObject(hcloudMachine), hcloudMachine)

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -54,7 +54,7 @@ type Client interface {
 	AddServiceToLoadBalancer(context.Context, *hcloud.LoadBalancer, hcloud.LoadBalancerAddServiceOpts) error
 	DeleteServiceFromLoadBalancer(context.Context, *hcloud.LoadBalancer, int) error
 	ListImages(context.Context, hcloud.ImageListOpts) ([]*hcloud.Image, error)
-	CreateServer(context.Context, hcloud.ServerCreateOpts) (*hcloud.Server, error)
+	CreateServer(context.Context, hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error)
 	AttachServerToNetwork(context.Context, *hcloud.Server, hcloud.ServerAttachToNetworkOpts) error
 	ListServers(context.Context, hcloud.ServerListOpts) ([]*hcloud.Server, error)
 	GetServer(context.Context, int64) (*hcloud.Server, error)
@@ -227,9 +227,9 @@ func (c *realClient) ListImages(ctx context.Context, opts hcloud.ImageListOpts) 
 	return c.client.Image.AllWithOpts(ctx, opts)
 }
 
-func (c *realClient) CreateServer(ctx context.Context, opts hcloud.ServerCreateOpts) (*hcloud.Server, error) {
+func (c *realClient) CreateServer(ctx context.Context, opts hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error) {
 	res, _, err := c.client.Server.Create(ctx, opts)
-	return res.Server, err
+	return res, err
 }
 
 func (c *realClient) AttachServerToNetwork(ctx context.Context, server *hcloud.Server, opts hcloud.ServerAttachToNetworkOpts) error {
@@ -357,6 +357,11 @@ func (c *realClient) GetAction(ctx context.Context, actionID int64) (*hcloud.Act
 			return action, fmt.Errorf("%w: getting hcloud action failed: %w", ErrUnauthorized, err)
 		}
 		return action, fmt.Errorf("getting hcloud action failed: %w", err)
+	}
+	// GetByID returns a nil action and no error when the action does not exist.
+	// Return an error instead, so callers can rely on the action being non-nil when err is nil.
+	if action == nil {
+		return nil, fmt.Errorf("hcloud action %d not found", actionID)
 	}
 	return action, nil
 }

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -472,12 +472,12 @@ func (c *cacheHCloudClient) ListImages(_ context.Context, opts hcloud.ImageListO
 	return nil, nil
 }
 
-func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCreateOpts) (*hcloud.Server, error) {
+func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	if _, found := c.serverCache.nameMap[opts.Name]; found {
-		return nil, fmt.Errorf("already exists")
+		return hcloud.ServerCreateResult{}, fmt.Errorf("already exists")
 	}
 
 	c.serverIDCounter++
@@ -490,11 +490,15 @@ func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCr
 		PlacementGroup: opts.PlacementGroup,
 		Status:         hcloud.ServerStatusRunning,
 	}
+	result := hcloud.ServerCreateResult{
+		Server: server,
+		Action: &hcloud.Action{ID: 1},
+	}
 
 	for _, network := range opts.Networks {
 		network, found := c.networkCache.idMap[network.ID]
 		if !found {
-			return server, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+			return result, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 		}
 		ip := network.IPRange.IP
 		server.PrivateNet = append(server.PrivateNet, hcloud.ServerPrivateNet{IP: ip})
@@ -503,7 +507,7 @@ func (c *cacheHCloudClient) CreateServer(_ context.Context, opts hcloud.ServerCr
 	// Add server to cache
 	c.serverCache.idMap[server.ID] = server
 	c.serverCache.nameMap[server.Name] = struct{}{}
-	return server, nil
+	return result, nil
 }
 
 func (c *cacheHCloudClient) AttachServerToNetwork(_ context.Context, server *hcloud.Server, opts hcloud.ServerAttachToNetworkOpts) error {

--- a/pkg/services/hcloud/client/fake/hcloud_client_test.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client_test.go
@@ -463,8 +463,9 @@ var _ = Describe("Server", func() {
 	BeforeEach(func() {
 		var err error
 		client = fake.NewHCloudClientFactory().NewClient("fake-hcloud-token")
-		server, err = client.CreateServer(ctx, opts)
+		result, err := client.CreateServer(ctx, opts)
 		Expect(err).To(Succeed())
+		server = result.Server
 
 		network, err = client.CreateNetwork(ctx, hcloud.NetworkCreateOpts{
 			Name: "network-name",
@@ -675,7 +676,7 @@ var _ = Describe("Placement groups", func() {
 	BeforeEach(func() {
 		var err error
 		client = fake.NewHCloudClientFactory().NewClient("fake-hcloud-token")
-		server, err = client.CreateServer(ctx, hcloud.ServerCreateOpts{
+		result, err := client.CreateServer(ctx, hcloud.ServerCreateOpts{
 			Name: "test-server",
 			Labels: map[string]string{
 				"key1": "val1",
@@ -692,6 +693,7 @@ var _ = Describe("Placement groups", func() {
 			},
 		})
 		Expect(err).To(Succeed())
+		server = result.Server
 
 		placementGroup, err = client.CreatePlacementGroup(ctx, opts)
 		Expect(err).To(Succeed())

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -587,24 +587,22 @@ func (_c *Client_CreatePlacementGroup_Call) RunAndReturn(run func(context.Contex
 }
 
 // CreateServer provides a mock function with given fields: _a0, _a1
-func (_m *Client) CreateServer(_a0 context.Context, _a1 hcloud.ServerCreateOpts) (*hcloud.Server, error) {
+func (_m *Client) CreateServer(_a0 context.Context, _a1 hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error) {
 	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateServer")
 	}
 
-	var r0 *hcloud.Server
+	var r0 hcloud.ServerCreateResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, hcloud.ServerCreateOpts) (*hcloud.Server, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error)); ok {
 		return rf(_a0, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, hcloud.ServerCreateOpts) *hcloud.Server); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, hcloud.ServerCreateOpts) hcloud.ServerCreateResult); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*hcloud.Server)
-		}
+		r0 = ret.Get(0).(hcloud.ServerCreateResult)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, hcloud.ServerCreateOpts) error); ok {
@@ -635,12 +633,12 @@ func (_c *Client_CreateServer_Call) Run(run func(_a0 context.Context, _a1 hcloud
 	return _c
 }
 
-func (_c *Client_CreateServer_Call) Return(_a0 *hcloud.Server, _a1 error) *Client_CreateServer_Call {
+func (_c *Client_CreateServer_Call) Return(_a0 hcloud.ServerCreateResult, _a1 error) *Client_CreateServer_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Client_CreateServer_Call) RunAndReturn(run func(context.Context, hcloud.ServerCreateOpts) (*hcloud.Server, error)) *Client_CreateServer_Call {
+func (_c *Client_CreateServer_Call) RunAndReturn(run func(context.Context, hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error)) *Client_CreateServer_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -615,7 +615,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 			})
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-		return res, fmt.Errorf("EnableRescueSystem failed: %w", err)
+		return res, handleRateLimit(hm, err, "EnableRescueSystem", "failed to enable rescue system")
 	}
 
 	// The API of hetzner is async. We get an Action-ID as result. We need to wait until the action
@@ -1705,6 +1705,7 @@ func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server
 		return nil, nil, err
 	}
 
+	// The imageName flow does not use the rescue system, so the server can start right after create.
 	result, err := s.createServer(ctx, userData, image, true)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -75,6 +75,24 @@ type Service struct {
 	scope *scope.MachineScope
 }
 
+// setBootState sets the BootState and logs the transition, together with how long the
+// machine was in the previous state.
+func (s *Service) setBootState(bootState infrav1.HCloudBootState) {
+	hm := s.scope.HCloudMachine
+	if hm.Status.BootState == bootState {
+		return
+	}
+	durationOfPreviousState := time.Duration(0)
+	if !hm.Status.BootStateSince.IsZero() {
+		durationOfPreviousState = time.Since(hm.Status.BootStateSince.Time).Round(time.Millisecond)
+	}
+	s.scope.Info("BootState changed",
+		"from", hm.Status.BootState,
+		"to", bootState,
+		"durationOfPreviousState", durationOfPreviousState)
+	hm.SetBootState(bootState)
+}
+
 // NewService outs a new service with machine scope.
 func NewService(scope *scope.MachineScope) *Service {
 	return &Service{
@@ -195,6 +213,14 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 		}
 	}
 
+	sinceBootStateChanged := time.Duration(0)
+	if !s.scope.HCloudMachine.Status.BootStateSince.IsZero() {
+		sinceBootStateChanged = time.Since(s.scope.HCloudMachine.Status.BootStateSince.Time).Round(time.Millisecond)
+	}
+	s.scope.V(1).Info("Reconciling BootState",
+		"bootState", s.scope.HCloudMachine.Status.BootState,
+		"sinceBootStateChanged", sinceBootStateChanged)
+
 	switch s.scope.HCloudMachine.Status.BootState {
 	case infrav1.HCloudBootStateUnset:
 		return s.handleBootStateUnset(ctx)
@@ -269,9 +295,9 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 
 		var msg string
 		if !hm.Status.Ready {
-			hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)
+			s.setBootState(infrav1.HCloudBootStateBootingToRealOS)
 		} else {
-			hm.SetBootState(infrav1.HCloudBootStateOperatingSystemRunning)
+			s.setBootState(infrav1.HCloudBootStateOperatingSystemRunning)
 		}
 		msg = fmt.Sprintf("Updating old resource (pre BootState) %s", hm.Status.BootState)
 
@@ -595,7 +621,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	// is done. After that we can power the server on, so that it boots into the rescue system.
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = result.Action.ID
 
-	hm.SetBootState(infrav1.HCloudBootStateEnablingRescue)
+	s.setBootState(infrav1.HCloudBootStateEnablingRescue)
 
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"WaitForRescueSystem", clusterv1beta1.ConditionSeverityInfo,
@@ -805,7 +831,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 
 	s.scope.Info("Power on started (first boot, into rescue system)")
 
-	hm.SetBootState(infrav1.HCloudBootStateBootingToRescue)
+	s.setBootState(infrav1.HCloudBootStateBootingToRescue)
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"BootingToRescue", clusterv1beta1.ConditionSeverityInfo,
 		"power on to rescue started")
@@ -1010,7 +1036,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		Reason:  infrav1.HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason,
 		Message: "custom provisioner running",
 	})
-	hm.SetBootState(infrav1.HCloudBootStateRunningImageCommand)
+	s.setBootState(infrav1.HCloudBootStateRunningImageCommand)
 	return reconcile.Result{RequeueAfter: 55 * time.Second}, nil
 }
 
@@ -1124,7 +1150,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			return reconcile.Result{}, fmt.Errorf("reboot after ImageURLCommand failed: %w", rebootErr)
 		}
 
-		hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)
+		s.setBootState(infrav1.HCloudBootStateBootingToRealOS)
 
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"BootingToRealOS", clusterv1beta1.ConditionSeverityInfo,
@@ -1250,7 +1276,7 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 
 	case hcloud.ServerStatusRunning:
-		hm.SetBootState(infrav1.HCloudBootStateOperatingSystemRunning)
+		s.setBootState(infrav1.HCloudBootStateOperatingSystemRunning)
 		v1beta1conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 		v1beta2conditions.Set(hm, metav1.Condition{
 			Type:    infrav1.HCloudMachineServerAvailableV1Beta2Condition,
@@ -1633,7 +1659,7 @@ func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server,
 	// handleBootStateInitializing waits for this action before enabling the rescue system.
 	hm.Status.ExternalIDs.ActionIDCreate = result.Action.ID
 
-	s.scope.HCloudMachine.SetBootState(infrav1.HCloudBootStateInitializing)
+	s.setBootState(infrav1.HCloudBootStateInitializing)
 	return result.Server, image, nil
 }
 
@@ -1680,7 +1706,7 @@ func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server
 		return nil, nil, err
 	}
 
-	hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)
+	s.setBootState(infrav1.HCloudBootStateBootingToRealOS)
 	return result.Server, image, nil
 }
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -384,15 +384,22 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
 	})
 
-	// Provisioning from a hcloud image like ubuntu-YY.MM takes roughly 11 seconds.
-	// Provisioning from a snapshot takes roughly 140 seconds.
-	// We do not want to do too many api-calls (rate-limiting). So we differentiate
-	// between both cases.
 	// These values get only used **once** after the server got created.
-
-	requeueAfter := 140 * time.Second
-	if image.RapidDeploy {
-		requeueAfter = 10 * time.Second
+	var requeueAfter time.Duration
+	if hm.Status.BootState == infrav1.HCloudBootStateInitializing {
+		// The imageURL flow created the server powered off. Only the create action needs
+		// to finish before the rescue system can be enabled, which takes a few seconds.
+		requeueAfter = 5 * time.Second
+	} else {
+		// The imageName flow boots the real image directly.
+		// Provisioning from a hcloud image like ubuntu-YY.MM takes roughly 11 seconds.
+		// Provisioning from a snapshot takes roughly 140 seconds.
+		// We do not want to do too many api-calls (rate-limiting). So we differentiate
+		// between both cases.
+		requeueAfter = 140 * time.Second
+		if image.RapidDeploy {
+			requeueAfter = 10 * time.Second
+		}
 	}
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"ProvisioningServer", clusterv1beta1.ConditionSeverityInfo,
@@ -452,36 +459,109 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 
 	updateHCloudMachineStatusFromServer(hm, server)
 
-	// analyze status of server
-	switch server.Status {
-	case hcloud.ServerStatusStarting, hcloud.ServerStatusInitializing:
+	// ActionIDCreate gets stored by createServerFromImageURL before the boot state becomes
+	// Initializing. This guard catches it early if that behavior ever changes.
+	if hm.Status.ExternalIDs.ActionIDCreate == 0 {
+		msg := "ActionIDCreate is missing in the status.externalIDs, cannot check whether the server is provisioned. Machine will be remediated"
+		s.scope.Error(nil, msg)
+		err := s.scope.SetErrorAndRemediate(ctx, msg)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"ServerNotRunningYet", clusterv1beta1.ConditionSeverityInfo,
-			"hcloud server is %q", server.Status)
+			"ActionIDCreateNotSet", clusterv1beta1.ConditionSeverityWarning, "%s", msg)
 		v1beta2conditions.Set(hm, metav1.Condition{
 			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineServerNotRunningYetV1Beta2Reason,
-			Message: fmt.Sprintf("hcloud server is %q", server.Status),
+			Reason:  infrav1.HCloudMachineActionIDCreateNotSetV1Beta2Reason,
+			Message: msg,
 		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	case hcloud.ServerStatusRunning:
-		// execute below code
-	default:
-		// some temporary status
-		s.scope.Info("Unknown hcloud server status", "status", server.Status)
-		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"ServerStatusUnknown", clusterv1beta1.ConditionSeverityInfo, "hcloud server has unknown status: %q", server.Status)
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineServerStatusUnknownV1Beta2Reason,
-			Message: fmt.Sprintf("hcloud server has unknown status: %q", server.Status),
-		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, nil
 	}
 
-	// Server is Running.
+	// The server was created with StartAfterCreate=false and is still powered off. Wait until
+	// the create action is finished, which means the server is provisioned and unlocked. After
+	// that the rescue system can be enabled. Once finished, ActionIDCreate is set to actionDone
+	// so a later EnableRescueSystem retry does not fetch the finished action again.
+	if hm.Status.ExternalIDs.ActionIDCreate != actionDone {
+		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDCreate)
+		if err != nil {
+			if errors.Is(err, hcloudclient.ErrUnauthorized) {
+				v1beta1conditions.MarkFalse(
+					hm,
+					infrav1.HCloudTokenAvailableCondition,
+					infrav1.HCloudCredentialsInvalidReason,
+					clusterv1beta1.ConditionSeverityError,
+					"wrong hcloud token",
+				)
+				v1beta2conditions.Set(hm, metav1.Condition{
+					Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
+					Message: "wrong hcloud token",
+				})
+				return reconcile.Result{}, nil
+			}
+			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+				return reconcile.Result{}, handleRateLimit(hm, err, "GetAction", "failed to get server create action")
+			}
+
+			// If this error persists, then the BootState will time out, and a new
+			// machine will be created.
+			err = fmt.Errorf("GetAction failed: %w", err)
+			s.scope.Error(err, "")
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"GettingCreateActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"%s", err.Error())
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  infrav1.HCloudMachineGettingCreateActionFailedV1Beta2Reason,
+				Message: err.Error(),
+			})
+			return reconcile.Result{}, err
+		}
+
+		if action.Finished.IsZero() {
+			// not finished yet.
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"WaitingForCreateAction", clusterv1beta1.ConditionSeverityInfo,
+				"Waiting until server create action is finished")
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineWaitingForCreateActionV1Beta2Reason,
+				Message: "Waiting until server create action is finished",
+			})
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		err = action.Error()
+		if err != nil {
+			err = fmt.Errorf("action %+v failed (wait for server create): %w", action, err)
+			msg := err.Error()
+			s.scope.Error(err, "")
+			remediateErr := s.scope.SetErrorAndRemediate(ctx, msg)
+			if remediateErr != nil {
+				return reconcile.Result{}, remediateErr
+			}
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"CreateActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"%s", msg)
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineCreateActionFailedV1Beta2Reason,
+				Message: msg,
+			})
+			return reconcile.Result{}, nil
+		}
+
+		// The create action finished successfully.
+		hm.Status.ExternalIDs.ActionIDCreate = actionDone
+	}
+
+	// The create action is finished. The server is provisioned and still powered off.
 
 	_, hcloudSSHKeys, err := s.getSSHKeys(ctx)
 	if err != nil {
@@ -494,12 +574,25 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 	}
 	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, server, rescueOpts)
 	if err != nil {
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+			// a fresh server is locked only for a short time after create, so a short retry
+			// interval is enough
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"EnablingRescueSystemFailed", clusterv1beta1.ConditionSeverityInfo,
+				"EnableRescueSystem: server locked. Will retry")
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineEnablingRescueSystemFailedV1Beta2Reason,
+				Message: "EnableRescueSystem: server locked. Will retry",
+			})
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		return res, fmt.Errorf("EnableRescueSystem failed: %w", err)
 	}
 
 	// The API of hetzner is async. We get an Action-ID as result. We need to wait until the action
-	// is done. After that we can trigger the reboot, so that the machine boots into the rescue
-	// system.
+	// is done. After that we can power the server on, so that it boots into the rescue system.
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = result.Action.ID
 
 	hm.SetBootState(infrav1.HCloudBootStateEnablingRescue)
@@ -561,8 +654,10 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 
 	updateHCloudMachineStatusFromServer(hm, server)
 
+	// ActionIDEnableRescueSystem gets stored by handleBootStateInitializing before the boot
+	// state becomes EnablingRescue. This guard catches it early if that behavior ever changes.
 	if hm.Status.ExternalIDs.ActionIDEnableRescueSystem == 0 {
-		msg := "handleBootStateEnablingRescue ActionIdEnableRescueSystem not set? Can not continue. Provisioning Failed"
+		msg := "ActionIDEnableRescueSystem is missing in the status.externalIDs, cannot check whether the rescue system is enabled. Machine will be remediated"
 		s.scope.Error(nil, msg)
 		err := s.scope.SetErrorAndRemediate(ctx, msg)
 		if err != nil {
@@ -668,9 +763,8 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 			Reason:  infrav1.HCloudMachineEnablingRescueActionDoneV1Beta2Reason,
 			Message: "Action RescueEnabled is finished",
 		})
-		// When the reboot is triggered immediately after the action is finished,
-		// then the reboot might get ignored.
-		return reconcile.Result{RequeueAfter: 4 * time.Second}, nil
+		// Requeue immediately as Hetzner accepts the power on directly after the enable rescue action is finished.
+		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
 	if !server.RescueEnabled {
@@ -688,68 +782,38 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// Now we know that the rescue-system was enabled. Up to now the PreRescueOS is running. Next
-	// step is to reboot the server into the rescue system.
-
-	// Reboot via ssh, avoid API calls to hcloud (rate-limit)
-	sshClient, err := s.getSSHClient(ctx)
-	if err != nil {
-		err = fmt.Errorf("getSSHClient failed: %w", err)
-		s.scope.Error(err, "")
-		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"GetSSHClientFailed", clusterv1beta1.ConditionSeverityWarning,
-			"%s", err.Error())
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineGettingSSHClientFailedV1Beta2Reason,
-			Message: err.Error(),
-		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	// There is a delay between the server reporting StatusRunning and SSH actually becoming
-	// reachable. During this window, ECONNREFUSED is expected, so we retry on that error.
-	err = sshClient.Reboot(ctx).Err
-	if err != nil {
-		if errors.Is(err, syscall.ECONNREFUSED) {
+	// Now we know that the rescue-system was enabled. The server was created with
+	// StartAfterCreate=false and has never been started, so powering it on boots it
+	// directly into the rescue system.
+	if err := s.scope.HCloudClient.PowerOnServer(ctx, server); err != nil {
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+			// a fresh server is locked only for a short time after create, so a short retry
+			// interval is enough
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"RetryingSSHConnection",
-				clusterv1beta1.ConditionSeverityInfo, "Rebooting")
+				"PowerOnServerFailed", clusterv1beta1.ConditionSeverityInfo,
+				"PowerOnServer: server locked. Will retry")
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineRetryingSSHConnectionV1Beta2Reason,
-				Message: "Rebooting",
+				Reason:  infrav1.HCloudMachinePoweringOnServerFailedV1Beta2Reason,
+				Message: "PowerOnServer: server locked. Will retry",
 			})
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-
-		err = fmt.Errorf("reboot to rescue: reboot via ssh failed: %w", err)
-		s.scope.Error(err, "")
-		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"RebootViaSSHFailed",
-			clusterv1beta1.ConditionSeverityWarning, "%s", err.Error())
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
-			Status:  metav1.ConditionUnknown,
-			Reason:  infrav1.HCloudMachineRebootViaSSHFailedV1Beta2Reason,
-			Message: err.Error(),
-		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, handleRateLimit(hm, err, "PowerOnServer", "failed to power on server")
 	}
 
-	s.scope.Info("Reboot started (via ssh)")
+	s.scope.Info("Power on started (first boot, into rescue system)")
 
 	hm.SetBootState(infrav1.HCloudBootStateBootingToRescue)
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"BootingToRescue", clusterv1beta1.ConditionSeverityInfo,
-		"reboot to rescue started")
+		"power on to rescue started")
 	v1beta2conditions.Set(hm, metav1.Condition{
 		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 		Status:  metav1.ConditionFalse,
 		Reason:  infrav1.HCloudMachineBootingToRescueV1Beta2Reason,
-		Message: "reboot to rescue started",
+		Message: "power on to rescue started",
 	})
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
@@ -1225,6 +1289,7 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 
 	// Clean up old Status fields
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = 0
+	hm.Status.ExternalIDs.ActionIDCreate = 0
 
 	v1beta1conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 	// Provisioning is complete.
@@ -1558,13 +1623,18 @@ func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server,
 		return nil, nil, err
 	}
 
-	server, err := s.createServer(ctx, nil, image)
+	// Create the server powered off. Enabling the rescue system while the server is off means
+	// its first boot goes directly into the rescue system, and the pre-rescue-OS image never boots.
+	result, err := s.createServer(ctx, nil, image, false)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// handleBootStateInitializing waits for this action before enabling the rescue system.
+	hm.Status.ExternalIDs.ActionIDCreate = result.Action.ID
+
 	s.scope.HCloudMachine.SetBootState(infrav1.HCloudBootStateInitializing)
-	return server, image, nil
+	return result.Server, image, nil
 }
 
 func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server, *hcloud.Image, error) {
@@ -1605,19 +1675,18 @@ func (s *Service) createServerFromImageName(ctx context.Context) (*hcloud.Server
 		return nil, nil, err
 	}
 
-	server, err := s.createServer(ctx, userData, image)
+	result, err := s.createServer(ctx, userData, image, true)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	hm.SetBootState(infrav1.HCloudBootStateBootingToRealOS)
-	return server, image, nil
+	return result.Server, image, nil
 }
 
-func (s *Service) createServer(ctx context.Context, userData []byte, image *hcloud.Image) (*hcloud.Server, error) {
+func (s *Service) createServer(ctx context.Context, userData []byte, image *hcloud.Image, startAfterCreate bool) (hcloud.ServerCreateResult, error) {
 	hm := s.scope.HCloudMachine
 	automount := false
-	startAfterCreate := true
 	opts := hcloud.ServerCreateOpts{
 		Name:   s.scope.Name(),
 		Labels: s.createLabels(),
@@ -1665,13 +1734,13 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 				Reason:  infrav1.HCloudMachineServerPlacementGroupNotFoundV1Beta2Reason,
 				Message: msg,
 			})
-			return nil, fmt.Errorf("%s: %w", msg, errServerCreateNotPossible)
+			return hcloud.ServerCreateResult{}, fmt.Errorf("%s: %w", msg, errServerCreateNotPossible)
 		}
 	}
 
 	caphSSHKeys, hcloudSSHKeys, err := s.getSSHKeys(ctx)
 	if err != nil {
-		return nil, err
+		return hcloud.ServerCreateResult{}, err
 	}
 	opts.SSHKeys = hcloudSSHKeys
 
@@ -1688,7 +1757,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 	}
 
 	// Create the server
-	server, err := s.scope.HCloudClient.CreateServer(ctx, opts)
+	result, err := s.scope.HCloudClient.CreateServer(ctx, opts)
 	if err != nil {
 		serverType := "nil"
 		if opts.ServerType != nil {
@@ -1700,7 +1769,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 
 		if hcloudutil.HandleRateLimitExceededV1Beta1(hm, err, "CreateServer") {
 			// RateLimit was reached. Condition and Event got already created.
-			return nil, fmt.Errorf("%s: %w", msg, err)
+			return hcloud.ServerCreateResult{}, fmt.Errorf("%s: %w", msg, err)
 		}
 
 		msg = fmt.Sprintf("%s: %s", msg, err.Error())
@@ -1715,7 +1784,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 			Message: msg,
 		})
 		record.Warn(hm, "FailedCreateHCloudServer", msg)
-		return nil, handleRateLimit(hm, err, "CreateServer", msg)
+		return hcloud.ServerCreateResult{}, handleRateLimit(hm, err, "CreateServer", msg)
 	}
 
 	// set ssh keys to status
@@ -1727,8 +1796,8 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 		Status: metav1.ConditionTrue,
 		Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
 	})
-	record.Eventf(hm, "SuccessfulCreate", "Created new server %s with ID %d", server.Name, server.ID)
-	return server, nil
+	record.Eventf(hm, "SuccessfulCreate", "Created new server %s with ID %d", result.Server.Name, result.Server.ID)
+	return result, nil
 }
 
 // getSSHKeys collects the set of SSH keys to use when creating a server in Hetzner Cloud,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -314,9 +314,10 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	// Fetch the SSH private key from the secret referenced in HetznerCluster.Spec.SSHKeys.RobotRescueSecretRef.
-	// Check that we have valid SSH private key in the secret. A failure could also mean there is a
-	// network failure while trying to access the api-server.
+	// The imageURL flow installs the image via SSH in the rescue system, so it needs a valid
+	// SSH private key. Check that before creating the server, so that no server gets created
+	// when the key is misconfigured. Other failures could also mean a network failure while
+	// trying to access the api-server, so they get retried.
 	if hm.Spec.ImageURL != "" {
 		_, err := s.getSSHPrivateKey(ctx)
 		if err != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -414,8 +414,8 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 	var requeueAfter time.Duration
 	if hm.Status.BootState == infrav1.HCloudBootStateInitializing {
 		// The imageURL flow created the server powered off. Only the create action needs
-		// to finish before the rescue system can be enabled, which takes a few seconds.
-		requeueAfter = 5 * time.Second
+		// to finish before the rescue system can be enabled.
+		requeueAfter = 15 * time.Second
 	} else {
 		// The imageName flow boots the real image directly.
 		// Provisioning from a hcloud image like ubuntu-YY.MM takes roughly 11 seconds.
@@ -632,7 +632,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 		Reason:  infrav1.HCloudMachineWaitingForRescueSystemV1Beta2Reason,
 		Message: "waiting for rescue system to be enabled",
 	})
-	return reconcile.Result{RequeueAfter: 4 * time.Second}, nil
+	return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 }
 
 // handleBootStateEnablingRescue is for provisioning with imageURL and image-url-command.
@@ -750,7 +750,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 				Reason:  infrav1.HCloudMachineWaitingForEnablingRescueActionV1Beta2Reason,
 				Message: "Waiting until Action RescueEnabled is finished",
 			})
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
 		err = action.Error()
@@ -904,7 +904,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 			Reason:  infrav1.HCloudMachineWaitForRescueEnabledToBeFalseV1Beta2Reason,
 			Message: msg,
 		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	sshClient, err := s.getSSHClient(ctx)
@@ -1037,7 +1037,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		Message: "custom provisioner running",
 	})
 	s.setBootState(infrav1.HCloudBootStateRunningImageCommand)
-	return reconcile.Result{RequeueAfter: 55 * time.Second}, nil
+	return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
 }
 
 // handleBootStateRunningImageCommand is for provisioning with imageURL and image-url-command.
@@ -1129,7 +1129,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			Reason:  infrav1.HCloudMachineCustomProvisionerRunningV1Beta2Reason,
 			Message: msg,
 		})
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -538,12 +538,12 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 			err = fmt.Errorf("GetAction failed: %w", err)
 			s.scope.Error(err, "")
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"GettingCreateServerActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"GettingServerCreationStatusFailed", clusterv1beta1.ConditionSeverityWarning,
 				"%s", err.Error())
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionUnknown,
-				Reason:  infrav1.HCloudMachineGettingCreateServerActionFailedV1Beta2Reason,
+				Reason:  infrav1.HCloudMachineGettingServerCreationStatusFailedV1Beta2Reason,
 				Message: err.Error(),
 			})
 			return reconcile.Result{}, err
@@ -553,12 +553,12 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 			// not finished yet.
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"CreatingServer", clusterv1beta1.ConditionSeverityInfo,
-				"Waiting until server create action is finished")
+				"Waiting until the server is created")
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
 				Reason:  infrav1.HCloudMachineCreatingServerV1Beta2Reason,
-				Message: "Waiting until server create action is finished",
+				Message: "Waiting until the server is created",
 			})
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 		}
@@ -573,12 +573,12 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 				return reconcile.Result{}, remediateErr
 			}
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"CreateServerActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"CreationFailed", clusterv1beta1.ConditionSeverityWarning,
 				"%s", msg)
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineCreateServerActionFailedV1Beta2Reason,
+				Reason:  infrav1.HCloudMachineServerCreationFailedV1Beta2Reason,
 				Message: msg,
 			})
 			return reconcile.Result{}, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -412,11 +412,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 
 	// These values get only used **once** after the server got created.
 	var requeueAfter time.Duration
-	if hm.Status.BootState == infrav1.HCloudBootStateInitializing {
-		// The imageURL flow created the server powered off. Only the create action needs
-		// to finish before the rescue system can be enabled.
-		requeueAfter = 15 * time.Second
-	} else {
+	if hm.Spec.ImageName != "" {
 		// The imageName flow boots the real image directly.
 		// Provisioning from a hcloud image like ubuntu-YY.MM takes roughly 11 seconds.
 		// Provisioning from a snapshot takes roughly 140 seconds.
@@ -426,6 +422,10 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		if image.RapidDeploy {
 			requeueAfter = 10 * time.Second
 		}
+	} else {
+		// The imageURL flow created the server powered off. Only the server create action needs
+		// to finish before the rescue system can be enabled.
+		requeueAfter = 15 * time.Second
 	}
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 		"ProvisioningServer", clusterv1beta1.ConditionSeverityInfo,
@@ -485,32 +485,32 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 
 	updateHCloudMachineStatusFromServer(hm, server)
 
-	// ActionIDCreate gets stored by createServerFromImageURL before the boot state becomes
+	// ActionIDCreateServer gets stored by createServerFromImageURL before the boot state becomes
 	// Initializing. This guard catches it early if that behavior ever changes.
-	if hm.Status.ExternalIDs.ActionIDCreate == 0 {
-		msg := "ActionIDCreate is missing in the status.externalIDs, cannot check whether the server is provisioned. Machine will be remediated"
+	if hm.Status.ExternalIDs.ActionIDCreateServer == 0 {
+		msg := "ActionIDCreateServer is missing in the status.externalIDs, cannot check whether the server is provisioned. Machine will be remediated"
 		s.scope.Error(nil, msg)
 		err := s.scope.SetErrorAndRemediate(ctx, msg)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"ActionIDCreateNotSet", clusterv1beta1.ConditionSeverityWarning, "%s", msg)
+			"ActionIDCreateServerNotSet", clusterv1beta1.ConditionSeverityWarning, "%s", msg)
 		v1beta2conditions.Set(hm, metav1.Condition{
 			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineActionIDCreateNotSetV1Beta2Reason,
+			Reason:  infrav1.HCloudMachineActionIDCreateServerNotSetV1Beta2Reason,
 			Message: msg,
 		})
 		return reconcile.Result{}, nil
 	}
 
 	// The server was created with StartAfterCreate=false and is still powered off. Wait until
-	// the create action is finished, which means the server is provisioned and unlocked. After
-	// that the rescue system can be enabled. Once finished, ActionIDCreate is set to actionDone
+	// the server create action is finished, which means the server is provisioned and unlocked. After
+	// that the rescue system can be enabled. Once finished, ActionIDCreateServer is set to actionDone
 	// so a later EnableRescueSystem retry does not fetch the finished action again.
-	if hm.Status.ExternalIDs.ActionIDCreate != actionDone {
-		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDCreate)
+	if hm.Status.ExternalIDs.ActionIDCreateServer != actionDone {
+		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDCreateServer)
 		if err != nil {
 			if errors.Is(err, hcloudclient.ErrUnauthorized) {
 				v1beta1conditions.MarkFalse(
@@ -537,12 +537,12 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 			err = fmt.Errorf("GetAction failed: %w", err)
 			s.scope.Error(err, "")
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"GettingCreateActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"GettingCreateServerActionFailed", clusterv1beta1.ConditionSeverityWarning,
 				"%s", err.Error())
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionUnknown,
-				Reason:  infrav1.HCloudMachineGettingCreateActionFailedV1Beta2Reason,
+				Reason:  infrav1.HCloudMachineGettingCreateServerActionFailedV1Beta2Reason,
 				Message: err.Error(),
 			})
 			return reconcile.Result{}, err
@@ -551,12 +551,12 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 		if action.Finished.IsZero() {
 			// not finished yet.
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"WaitingForCreateAction", clusterv1beta1.ConditionSeverityInfo,
+				"CreatingServer", clusterv1beta1.ConditionSeverityInfo,
 				"Waiting until server create action is finished")
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineWaitingForCreateActionV1Beta2Reason,
+				Reason:  infrav1.HCloudMachineCreatingServerV1Beta2Reason,
 				Message: "Waiting until server create action is finished",
 			})
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
@@ -572,22 +572,22 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 				return reconcile.Result{}, remediateErr
 			}
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-				"CreateActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"CreateServerActionFailed", clusterv1beta1.ConditionSeverityWarning,
 				"%s", msg)
 			v1beta2conditions.Set(hm, metav1.Condition{
 				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineCreateActionFailedV1Beta2Reason,
+				Reason:  infrav1.HCloudMachineCreateServerActionFailedV1Beta2Reason,
 				Message: msg,
 			})
 			return reconcile.Result{}, nil
 		}
 
-		// The create action finished successfully.
-		hm.Status.ExternalIDs.ActionIDCreate = actionDone
+		// The server create action finished successfully.
+		hm.Status.ExternalIDs.ActionIDCreateServer = actionDone
 	}
 
-	// The create action is finished. The server is provisioned and still powered off.
+	// The server create action is finished. The server is provisioned and still powered off.
 
 	_, hcloudSSHKeys, err := s.getSSHKeys(ctx)
 	if err != nil {
@@ -828,8 +828,6 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		}
 		return reconcile.Result{}, handleRateLimit(hm, err, "PowerOnServer", "failed to power on server")
 	}
-
-	s.scope.Info("Power on started (first boot, into rescue system)")
 
 	s.setBootState(infrav1.HCloudBootStateBootingToRescue)
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
@@ -1146,6 +1144,11 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		s.scope.Info("CustomProvisionerOutputJSON", "outputJSON", outputJSON)
 
 		// The image got installed. Now reboot in the real operating system.
+		// The reboot runs inside the operating system, so the hcloud server status stays
+		// "running" the whole time. handleBootingToRealOS therefore moves on to
+		// OperatingSystemRunning right away, usually while the reboot is still ongoing.
+		// That is fine: the machine only becomes ready once the node has joined the
+		// cluster, which CAPI checks, so nothing is gated on the reboot being finished.
 		if rebootErr := hcloudSSHClient.Reboot(ctx).Err; rebootErr != nil {
 			return reconcile.Result{}, fmt.Errorf("reboot after ImageURLCommand failed: %w", rebootErr)
 		}
@@ -1315,7 +1318,7 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hclo
 
 	// Clean up old Status fields
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = 0
-	hm.Status.ExternalIDs.ActionIDCreate = 0
+	hm.Status.ExternalIDs.ActionIDCreateServer = 0
 
 	v1beta1conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 	// Provisioning is complete.
@@ -1657,7 +1660,7 @@ func (s *Service) createServerFromImageURL(ctx context.Context) (*hcloud.Server,
 	}
 
 	// handleBootStateInitializing waits for this action before enabling the rescue system.
-	hm.Status.ExternalIDs.ActionIDCreate = result.Action.ID
+	hm.Status.ExternalIDs.ActionIDCreateServer = result.Action.ID
 
 	s.setBootState(infrav1.HCloudBootStateInitializing)
 	return result.Server, image, nil

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -593,7 +593,7 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 })
 
 var _ = Describe("handleBootStateInitializing", func() {
-	It("sets an error and remediates when the create action finished with an error", func() {
+	It("sets an error and remediates when the server create action finished with an error", func() {
 		hcloudMachine := &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-machine",
@@ -602,7 +602,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 			Status: infrav1.HCloudMachineStatus{
 				BootStateSince: metav1.Now(),
 				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
-					ActionIDCreate: 998877,
+					ActionIDCreateServer: 998877,
 				},
 			},
 		}
@@ -626,12 +626,12 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
 		Expect(exists).To(BeTrue())
-		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "CreateActionFailed")).To(BeTrue())
-		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineCreateActionFailedV1Beta2Reason)).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "CreateServerActionFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineCreateServerActionFailedV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 
-	It("remediates when the create action ID is not set", func() {
+	It("remediates when the server create action ID is not set", func() {
 		hcloudMachine := &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-machine",
@@ -653,12 +653,12 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
 		Expect(exists).To(BeTrue())
-		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "ActionIDCreateNotSet")).To(BeTrue())
-		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineActionIDCreateNotSetV1Beta2Reason)).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "ActionIDCreateServerNotSet")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineActionIDCreateServerNotSetV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 
-	It("returns an error and marks GettingCreateActionFailed when GetAction fails", func() {
+	It("returns an error and marks GettingCreateServerActionFailed when GetAction fails", func() {
 		hcloudMachine := &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-machine",
@@ -667,7 +667,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 			Status: infrav1.HCloudMachineStatus{
 				BootStateSince: metav1.Now(),
 				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
-					ActionIDCreate: 998877,
+					ActionIDCreateServer: 998877,
 				},
 			},
 		}
@@ -683,8 +683,8 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("GetAction failed"))
-		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingCreateActionFailed")).To(BeTrue())
-		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingCreateActionFailedV1Beta2Reason)).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingCreateServerActionFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingCreateServerActionFailedV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 })
@@ -1317,12 +1317,12 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
-		By("ensuring the bootstate has transitioned to Initializing and the create action is stored")
+		By("ensuring the bootstate has transitioned to Initializing and the server create action is stored")
 
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
-		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreate).To(Equal(int64(998877)))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreateServer).To(Equal(int64(998877)))
 
-		By("reconciling again: create action not finished yet")
+		By("reconciling again: server create action not finished yet")
 		startTime := time.Now()
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:     1,
@@ -1339,10 +1339,10 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
-		By("ensuring the bootstate stays Initializing while the create action is running")
+		By("ensuring the bootstate stays Initializing while the server create action is running")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
-		By("reconciling again: create action finished, rescue system gets enabled")
+		By("reconciling again: server create action finished, rescue system gets enabled")
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:     1,
 			Name:   "my-machine",

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1534,7 +1534,7 @@ var _ = Describe("Reconcile", func() {
 		By("reconciling")
 		result, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
-		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 
 		By("ensuring the machine stays in RunningImageCommand")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -626,8 +626,8 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
 		Expect(exists).To(BeTrue())
-		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "CreateServerActionFailed")).To(BeTrue())
-		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineCreateServerActionFailedV1Beta2Reason)).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "CreationFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineServerCreationFailedV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 
@@ -658,7 +658,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 
-	It("returns an error and marks GettingCreateServerActionFailed when GetAction fails", func() {
+	It("returns an error and marks GettingServerCreationStatusFailed when GetAction fails", func() {
 		hcloudMachine := &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-machine",
@@ -683,8 +683,8 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("GetAction failed"))
-		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingCreateServerActionFailed")).To(BeTrue())
-		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingCreateServerActionFailedV1Beta2Reason)).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingServerCreationStatusFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingServerCreationStatusFailedV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 })

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -134,9 +134,9 @@ var _ = Describe("handleServerStatusOff", func() {
 	BeforeEach(func() {
 		client = fakehcloudclient.NewHCloudClientFactory().NewClient("")
 
-		var err error
-		server, err = client.CreateServer(context.Background(), hcloud.ServerCreateOpts{Name: "serverName"})
+		result, err := client.CreateServer(context.Background(), hcloud.ServerCreateOpts{Name: "serverName"})
 		Expect(err).To(Succeed())
+		server = result.Server
 
 		hcloudMachine = &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -554,6 +554,137 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		Expect(hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded)).To(BeTrue())
 		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.HetznerAPIReachableCondition, infrav1.RateLimitExceededReason)).To(BeTrue())
 		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudRateLimitExceededV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudRateLimitExceededV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("requeues after 5 seconds when PowerOnServer returns a locked error", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDEnableRescueSystem: actionDone,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(hcloud.Error{
+			Code:    hcloud.ErrorCodeLocked,
+			Message: "server is locked",
+		}).Once()
+
+		res, err := service.handleBootStateEnablingRescue(context.Background(), &hcloud.Server{
+			ID:            1,
+			RescueEnabled: true,
+			Status:        hcloud.ServerStatusOff,
+		})
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "PowerOnServerFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachinePoweringOnServerFailedV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudMachine.Status.BootState).ToNot(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+})
+
+var _ = Describe("handleBootStateInitializing", func() {
+	It("sets an error and remediates when the create action finished with an error", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDCreate: 998877,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(&hcloud.Action{
+			ID:           998877,
+			Status:       hcloud.ActionStatusError,
+			Started:      time.Now().Add(-time.Minute),
+			Finished:     time.Now(),
+			ErrorCode:    "server_creation_failed",
+			ErrorMessage: "server creation failed",
+		}, nil).Once()
+
+		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
+			ID:     1,
+			Status: hcloud.ServerStatusOff,
+		})
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
+		Expect(exists).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "CreateActionFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineCreateActionFailedV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("remediates when the create action ID is not set", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+
+		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
+			ID:     1,
+			Status: hcloud.ServerStatusOff,
+		})
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
+		Expect(exists).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "ActionIDCreateNotSet")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineActionIDCreateNotSetV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("returns an error and marks GettingCreateActionFailed when GetAction fails", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDCreate: 998877,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(nil, fmt.Errorf("hcloud is down")).Once()
+
+		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
+			ID:     1,
+			Status: hcloud.ServerStatusOff,
+		})
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("GetAction failed"))
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingCreateActionFailed")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingCreateActionFailedV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 })
@@ -1085,10 +1216,17 @@ var _ = Describe("Reconcile", func() {
 			},
 		}, nil)
 
-		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:     1,
-			Name:   "my-machine",
-			Status: hcloud.ServerStatusInitializing,
+		hcloudClient.On("CreateServer", mock.Anything, mock.MatchedBy(func(opts hcloud.ServerCreateOpts) bool {
+			// an imageName machine must be created with StartAfterCreate=true, so it boots
+			// the real image directly and never goes through the rescue system
+			return opts.StartAfterCreate != nil && *opts.StartAfterCreate
+		})).Return(hcloud.ServerCreateResult{
+			Server: &hcloud.Server{
+				ID:     1,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusInitializing,
+			},
+			Action: &hcloud.Action{ID: 998877},
 		}, nil)
 
 		By("calling reconcile")
@@ -1162,10 +1300,16 @@ var _ = Describe("Reconcile", func() {
 			},
 		}, nil)
 
-		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:     1,
-			Name:   "my-machine",
-			Status: hcloud.ServerStatusInitializing,
+		hcloudClient.On("CreateServer", mock.Anything, mock.MatchedBy(func(opts hcloud.ServerCreateOpts) bool {
+			// an imageURL machine must be created powered off, so its first boot goes into the rescue system
+			return opts.StartAfterCreate != nil && !*opts.StartAfterCreate
+		})).Return(hcloud.ServerCreateResult{
+			Server: &hcloud.Server{
+				ID:     1,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusInitializing,
+			},
+			Action: &hcloud.Action{ID: 998877},
 		}, nil)
 
 		By("calling reconcile")
@@ -1173,18 +1317,44 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
-		By("ensuring the bootstate has transitioned to Initializing")
+		By("ensuring the bootstate has transitioned to Initializing and the create action is stored")
 
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreate).To(Equal(int64(998877)))
 
-		By("reconciling again")
+		By("reconciling again: create action not finished yet")
+		startTime := time.Now()
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:     1,
 			Name:   "my-machine",
-			Status: hcloud.ServerStatusRunning,
+			Status: hcloud.ServerStatusOff,
 		}, nil).Once()
+		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(
+			&hcloud.Action{
+				ID:      998877,
+				Status:  hcloud.ActionStatusRunning,
+				Started: startTime,
+			}, nil).Once()
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
-		startTime := time.Now()
+		By("ensuring the bootstate stays Initializing while the create action is running")
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
+
+		By("reconciling again: create action finished, rescue system gets enabled")
+		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
+			ID:     1,
+			Name:   "my-machine",
+			Status: hcloud.ServerStatusOff,
+		}, nil).Once()
+		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(
+			&hcloud.Action{
+				ID:       998877,
+				Status:   hcloud.ActionStatusSuccess,
+				Started:  startTime,
+				Finished: time.Now(),
+			}, nil).Once()
 		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(
 			hcloud.ServerEnableRescueResult{
 				Action: &hcloud.Action{
@@ -1207,16 +1377,16 @@ var _ = Describe("Reconcile", func() {
 		By("ensuring the bootstate has transitioned to EnablingRescue")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
-		By("reconcile again --------------------------------------------------------")
+		By("reconcile again: enable rescue action finished ---------------------------")
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:            1,
 			Name:          "my-machine",
 			RescueEnabled: true,
-			Status:        hcloud.ServerStatusRunning,
+			Status:        hcloud.ServerStatusOff,
 		}, nil).Once()
-		hcloudClient.On("GetAction", mock.Anything, mock.Anything).Return(
+		hcloudClient.On("GetAction", mock.Anything, int64(334455)).Return(
 			&hcloud.Action{
-				ID:           1,
+				ID:           334455,
 				Status:       hcloud.ActionStatusSuccess,
 				Command:      "",
 				Progress:     0,
@@ -1231,22 +1401,17 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
-		By("ensuring the bootstate has transitioned to EnablingRescue")
+		By("ensuring the bootstate stays EnablingRescue until the server is powered on")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
-		By("reconcile again --------------------------------------------------------")
+		By("reconcile again: server gets powered on ---------------------------------")
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:            1,
-			Name:          "hcloudmachinenameWithRescueEnabled",
+			Name:          "my-machine",
 			RescueEnabled: true,
-			Status:        hcloud.ServerStatusRunning,
+			Status:        hcloud.ServerStatusOff,
 		}, nil).Once()
-
-		testEnv.HCloudSSHClient.On("Reboot", mock.Anything).Return(sshclient.Output{
-			Err:    nil,
-			StdOut: "ok",
-			StdErr: "",
-		})
+		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(nil).Once()
 		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
@@ -1282,6 +1447,11 @@ var _ = Describe("Reconcile", func() {
 		})
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "output-of-image-url-command", nil)
 		testEnv.HCloudSSHClient.On("ReadOutputJSON", mock.Anything).Return(`{"status":"Succeeded"}`, nil).Once()
+		testEnv.HCloudSSHClient.On("Reboot", mock.Anything).Return(sshclient.Output{
+			Err:    nil,
+			StdOut: "ok",
+			StdErr: "",
+		})
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
 			ID:            1,
 			Name:          "hcloudmachinenameWithRescueEnabled",


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Boot HCloud imageURL machines directly into rescue system

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2153

**Special notes for your reviewer**:
Beyond the issue:

- After the enable rescue action finishes, the handler requeues once (`requeueImmediately`) instead of powering on in the same reconcile. This keeps the `EnablingRescueActionDone` condition observable and runs the `RescueEnabled` check on a fresh server object. Same pattern as `handleBootingToRealOS` ("Show changes in Status and go to next BootState").
- `GetAction` in the hcloud client now returns an error when the action does not exist. hcloud-go returns a nil action with no error on 404 ([`ResourceActionClient.GetByID`, v2.32.0](https://github.com/hetznercloud/hcloud-go/blob/v2.32.0/hcloud/action.go#L156-L170)), which would panic both action-wait handlers at `action.Finished`.
- `Initializing` got the same "action ID missing" guard as `EnablingRescue`, and both guard messages are reworded to say what is missing and that the machine will be remediated.
- The timing decisions were verified with a standalone PoC program that runs the exact controller sequence against the real Hetzner API, with the same hcloud-go version as CAPH (v2.32.0): create with `start_after_create=false`, wait for the create action, call `enable_rescue` immediately, wait for its action, power on immediately with no delay, then confirm the server starts and `rescue_enabled` clears (booted into rescue).

  Results over 5 servers: create action finished in 3.4 to 6.6 s, `enable_rescue` accepted on the first try 5/5, power on accepted directly after the enable action 5/5, server status changed from `off` to `running` right after the power on (the power on took effect) 5/5, rescue reached (`rescue_enabled` cleared) 5/5, `locked` never seen. 40 to 49 s from create to rescue, against 90 to 120 s today.


**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

