### PR TITLE
🐛 Fix `retryLimit: 0` in remediation still doing one reboot (backport #2146)

### DIFF
--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -331,6 +331,46 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					isPresentAndFalseWithReasonV2(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason)
 			}, timeout).Should(BeTrue())
 		})
+		It("does no reboot and deletes the machine when retryLimit is 0", func() {
+			By("waiting until the machine has a ProviderID and is running")
+			Eventually(func() error {
+				if err := testEnv.Client.Get(ctx, hcloudMachineKey, hcloudMachine); err != nil {
+					return err
+				}
+				if hcloudMachine.Spec.ProviderID == nil {
+					return fmt.Errorf("hcloudMachine.Spec.ProviderID is still nil")
+				}
+				if hcloudMachine.Status.BootState != infrav1.HCloudBootStateOperatingSystemRunning {
+					return fmt.Errorf("hcloudMachine.Status.BootState is not HCloudBootStateOperatingSystemRunning, but: %q", hcloudMachine.Status.BootState)
+				}
+				return nil
+			}, timeout).NotTo(HaveOccurred())
+
+			By("creating the hcloudRemediation with retryLimit 0")
+			hcloudRemediation.Spec.Strategy.RetryLimit = 0
+			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
+
+			By("checking that no reboot happened and the machine is handed to CAPI for deletion")
+			Eventually(func() error {
+				if err := testEnv.Get(ctx, hcloudRemediationkey, hcloudRemediation); err != nil {
+					return err
+				}
+				if hcloudRemediation.Status.RetryCount != 0 {
+					return fmt.Errorf("expected RetryCount 0, got %d", hcloudRemediation.Status.RetryCount)
+				}
+				if hcloudRemediation.Status.LastRemediated != nil {
+					return fmt.Errorf("expected LastRemediated to be nil")
+				}
+				if hcloudRemediation.Status.Phase != infrav1.PhaseDeleting {
+					return fmt.Errorf("expected Phase %q, got %q", infrav1.PhaseDeleting, hcloudRemediation.Status.Phase)
+				}
+				if !isPresentAndFalseWithReasonV2(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
+					return fmt.Errorf("MachineOwnerRemediatedCondition not set")
+				}
+				return nil
+			}, timeout).ShouldNot(HaveOccurred())
+		})
+
 		It("should set RemediationSkippedCondition when HCloudMachine has irrecoverable server creation failure", func() {
 			By("waiting for HCloudMachine to be fully provisioned")
 			Eventually(func() error {

--- a/controllers/hetznerbaremetalremediation_controller_test.go
+++ b/controllers/hetznerbaremetalremediation_controller_test.go
@@ -379,6 +379,32 @@ var _ = Describe("HetznerBareMetalRemediationReconciler", func() {
 							isPresentAndFalseWithReasonV2(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason)
 					}, timeout).Should(BeTrue())
 				})
+
+				It("does no reboot and deletes the machine when retryLimit is 0", func() {
+					By("creating hetznerBareMetalRemediation object with retryLimit 0")
+					hetznerBareMetalRemediation.Spec.Strategy.RetryLimit = 0
+					Expect(testEnv.Create(ctx, hetznerBareMetalRemediation)).To(Succeed())
+
+					By("checking that no reboot happened and the machine is handed to CAPI for deletion")
+					Eventually(func() error {
+						if err := testEnv.Get(ctx, hetznerBaremetalRemediationkey, hetznerBareMetalRemediation); err != nil {
+							return err
+						}
+						if hetznerBareMetalRemediation.Status.RetryCount != 0 {
+							return fmt.Errorf("expected RetryCount 0, got %d", hetznerBareMetalRemediation.Status.RetryCount)
+						}
+						if hetznerBareMetalRemediation.Status.LastRemediated != nil {
+							return fmt.Errorf("expected LastRemediated to be nil")
+						}
+						if hetznerBareMetalRemediation.Status.Phase != infrav1.PhaseDeleting {
+							return fmt.Errorf("expected Phase %q, got %q", infrav1.PhaseDeleting, hetznerBareMetalRemediation.Status.Phase)
+						}
+						if !isPresentAndFalseWithReasonV2(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
+							return fmt.Errorf("MachineOwnerRemediatedCondition not set")
+						}
+						return nil
+					}, timeout).ShouldNot(HaveOccurred())
+				})
 			})
 		})
 

--- a/pkg/scope/hcloudremediation.go
+++ b/pkg/scope/hcloudremediation.go
@@ -143,6 +143,12 @@ func (m *HCloudRemediationScope) Namespace() string {
 	return m.HCloudRemediation.Namespace
 }
 
+// HasRetriesLeft returns true if the retry limit is greater than retry count.
+func (m *HCloudRemediationScope) HasRetriesLeft() bool {
+	return m.HCloudRemediation.Spec.Strategy.RetryLimit > 0 &&
+		m.HCloudRemediation.Spec.Strategy.RetryLimit > m.HCloudRemediation.Status.RetryCount
+}
+
 // ServerIDFromProviderID returns the namespace name.
 func (m *HCloudRemediationScope) ServerIDFromProviderID() (int64, error) {
 	return hcloudutil.ServerIDFromProviderID(m.HCloudMachine.Spec.ProviderID)

--- a/pkg/services/baremetal/remediation/remediation.go
+++ b/pkg/services/baremetal/remediation/remediation.go
@@ -133,6 +133,16 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 }
 
 func (s *Service) handlePhaseRunning(ctx context.Context, host *infrav1.HetznerBareMetalHost) (res reconcile.Result, err error) {
+	// retryLimit 0 disables reboots (see RemediationStrategy.RetryLimit), so there
+	// is no remediation to perform. Mark the machine for deletion by CAPI.
+	if !s.scope.HasRetriesLeft() && s.scope.BareMetalRemediation.Status.LastRemediated == nil {
+		if err := s.setOwnerRemediatedConditionToFailed(ctx, "exit remediation because retryLimit is 0 (no reboot performed)"); err != nil {
+			record.Warn(s.scope.BareMetalRemediation, "FailedSettingConditionOnMachine", err.Error())
+			return reconcile.Result{}, fmt.Errorf("failed to set conditions on CAPI machine: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// if host has not been remediated yet, do that now
 	if s.scope.BareMetalRemediation.Status.LastRemediated == nil {
 		if err := s.remediate(ctx, host); err != nil {
@@ -143,7 +153,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, host *infrav1.HetznerB
 	// if no retries are left, then change to phase waiting and return
 	if !s.scope.HasRetriesLeft() {
 		s.scope.BareMetalRemediation.Status.Phase = infrav1.PhaseWaiting
-		return
+		return reconcile.Result{}, nil
 	}
 
 	nextRemediation := s.timeUntilNextRemediation(time.Now())

--- a/pkg/services/hcloud/remediation/remediation.go
+++ b/pkg/services/hcloud/remediation/remediation.go
@@ -136,6 +136,16 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server) (res reconcile.Result, err error) {
 	now := metav1.Now()
 
+	// retryLimit 0 disables reboots (see RemediationStrategy.RetryLimit), so there
+	// is no remediation to perform. Mark the machine for deletion by CAPI.
+	if !s.scope.HasRetriesLeft() && s.scope.HCloudRemediation.Status.LastRemediated == nil {
+		if err := s.setOwnerRemediatedConditionToFailed(ctx, "exit remediation because retryLimit is 0 (no reboot performed)"); err != nil {
+			record.Warn(s.scope.HCloudRemediation, "FailedSettingConditionOnMachine", err.Error())
+			return reconcile.Result{}, fmt.Errorf("failed to set conditions on CAPI machine: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// if server has never been remediated, then do that now
 	if s.scope.HCloudRemediation.Status.LastRemediated == nil {
 		if err := s.scope.HCloudClient.RebootServer(ctx, server); err != nil {
@@ -149,11 +159,8 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 		s.scope.HCloudRemediation.Status.RetryCount++
 	}
 
-	retryLimit := s.scope.HCloudRemediation.Spec.Strategy.RetryLimit
-	retryCount := s.scope.HCloudRemediation.Status.RetryCount
-
 	// check whether retry limit has been reached
-	if retryLimit == 0 || retryCount >= retryLimit {
+	if !s.scope.HasRetriesLeft() {
 		s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseWaiting
 	}
 
@@ -201,7 +208,7 @@ func (s *Service) handlePhaseWaiting(ctx context.Context) (reconcile.Result, err
 	}
 
 	err := s.setOwnerRemediatedConditionToFailed(ctx,
-		"exit remediation because because retryLimit is reached and reboot timed out")
+		"exit remediation because retryLimit is reached and reboot timed out")
 	if err != nil {
 		record.Warn(s.scope.HCloudRemediation, "FailedSettingConditionOnMachine", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to set conditions on CAPI machine: %w", err)


### PR DESCRIPTION


**What this PR does / why we need it**:
Fixes remediation performing one reboot even when retryLimit is 0.

**Which issue(s) this PR fixes**:
None (backport of PR #2146).

**Special notes for your reviewer**:
Cherry-picked cleanly from main (f3942e903), no conflicts.