### PR TITLE
🌱 Show permanent error via `ActionCompleted` condition (backport #2076)

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -189,6 +189,15 @@ const (
 )
 
 const (
+	// ActionCompletedCondition reports whether the last action on the host completed successfully.
+	// Set to False when a fatal, non-recoverable error is detected that requires manual intervention.
+	// Absent on healthy hosts; only present when a permanent error has been recorded.
+	ActionCompletedCondition clusterv1beta1.ConditionType = "ActionCompleted"
+	// ActionCompletedPermanentErrorReason represents a fatal, non-recoverable error that persists on the host.
+	ActionCompletedPermanentErrorReason = "PermanentError"
+)
+
+const (
 	// ProvisionSucceededCondition indicates that a host has been provisioned.
 	ProvisionSucceededCondition clusterv1beta1.ConditionType = "ProvisionSucceeded"
 	// StillProvisioningReason indicates that the server is still provisioning.
@@ -701,4 +710,13 @@ const (
 	HetznerBareMetalHostRobotRateLimitExceededV1Beta2Condition = "RobotRateLimitExceeded"
 	// HetznerBareMetalHostRobotRateLimitExceededV1Beta2Reason indicates the Robot API rate limit has been exceeded.
 	HetznerBareMetalHostRobotRateLimitExceededV1Beta2Reason = "Exceeded"
+)
+
+const (
+	// HetznerBareMetalHostActionCompletedV1Beta2Condition reports whether the last action on the host completed
+	// successfully. Set to False when a fatal, non-recoverable error is detected that requires manual intervention.
+	// Absent on healthy hosts; only present when a permanent error has been recorded.
+	HetznerBareMetalHostActionCompletedV1Beta2Condition = "ActionCompleted"
+	// HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason represents a fatal, non-recoverable error that persists on the host.
+	HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason = "PermanentError"
 )

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/record"
 )
@@ -426,13 +427,14 @@ func (host *HetznerBareMetalHost) SetV1Beta2Conditions(conditions []metav1.Condi
 // order (highest-priority first). Credentials and provisioning problems must outrank
 // Deleting, since deletion may itself need credentials to succeed.
 //  1. RobotCredentialsAvailable - invalid Robot credentials block every Robot API call.
-//  2. RobotRateLimitExceeded    - rate-limit issues (negative polarity).
-//  3. SSHKeysAvailable          - missing/invalid SSH keys block (de)provisioning.
-//  4. RootDeviceHintsValidated  - device hints must validate before provisioning.
-//  5. ProvisionSucceeded        - provisioning state (rescue -> image -> OS).
-//  6. RebootSucceeded           - post-provision reboot via annotation.
-//  7. NodeBootIDRetrieved       - workload-cluster Node check after provisioning.
-//  8. Deleting                  - deletion state (negative polarity).
+//  2. ActionCompleted           - fatal permanent error requiring manual intervention.
+//  3. RobotRateLimitExceeded    - rate-limit issues (negative polarity).
+//  4. SSHKeysAvailable          - missing/invalid SSH keys block (de)provisioning.
+//  5. RootDeviceHintsValidated  - device hints must validate before provisioning.
+//  6. ProvisionSucceeded        - provisioning state (rescue -> image -> OS).
+//  7. RebootSucceeded           - post-provision reboot via annotation.
+//  8. NodeBootIDRetrieved       - workload-cluster Node check after provisioning.
+//  9. Deleting                  - deletion state (negative polarity).
 func HetznerBareMetalHostV1Beta2SummaryOpts() []v1beta2conditions.SummaryOption {
 	return []v1beta2conditions.SummaryOption{
 		// ForConditionTypes lists every condition that contributes to Ready, in
@@ -440,6 +442,7 @@ func HetznerBareMetalHostV1Beta2SummaryOpts() []v1beta2conditions.SummaryOption 
 		// surfaces them in this order, so the most important issue is listed first.
 		v1beta2conditions.ForConditionTypes{
 			HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Condition,
+			HetznerBareMetalHostActionCompletedV1Beta2Condition,
 			HetznerBareMetalHostRobotRateLimitExceededV1Beta2Condition,
 			HetznerBareMetalHostSSHKeysAvailableV1Beta2Condition,
 			HetznerBareMetalHostRootDeviceHintsValidatedV1Beta2Condition,
@@ -454,6 +457,7 @@ func HetznerBareMetalHostV1Beta2SummaryOpts() []v1beta2conditions.SummaryOption 
 		// checked or before the host has been provisioned), and we don't want
 		// those early exits to flip Ready to Unknown.
 		v1beta2conditions.IgnoreTypesIfMissing{
+			HetznerBareMetalHostActionCompletedV1Beta2Condition,
 			HetznerBareMetalHostSSHKeysAvailableV1Beta2Condition,
 			HetznerBareMetalHostRootDeviceHintsValidatedV1Beta2Condition,
 			HetznerBareMetalHostProvisionSucceededV1Beta2Condition,
@@ -722,12 +726,28 @@ func (host *HetznerBareMetalHost) SetError(errType ErrorType, errMessage string)
 	host.Spec.Status.ErrorType = errType
 	host.Spec.Status.ErrorMessage = errMessage
 	if errType == PermanentError {
+		// set the permanent error annotation.
 		if host.Annotations == nil {
 			host.Annotations = make(map[string]string, 1)
 		}
+
 		host.Annotations[PermanentErrorAnnotation] = time.Now().Format(time.RFC3339)
-		record.Warnf(host, "PermanentErrorSet", "Remove annotation %q, if you want the controller to use the hbmh again.",
-			PermanentErrorAnnotation)
+
+		message := fmt.Sprintf("%s. Remove annotation %q, if you want the controller to use the hbmh again.",
+			errMessage, PermanentErrorAnnotation)
+
+		record.Warn(host, "PermanentErrorSet", message)
+
+		// set the ActionCompleted condition to false with reason PermanentError.
+		v1beta1conditions.MarkFalse(host, ActionCompletedCondition,
+			ActionCompletedPermanentErrorReason, clusterv1beta1.ConditionSeverityError,
+			"%s", message)
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    HetznerBareMetalHostActionCompletedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason,
+			Message: message,
+		})
 	}
 }
 
@@ -741,6 +761,8 @@ func (host *HetznerBareMetalHost) ClearError() {
 		host.Spec.Status.ErrorMessage = ""
 	}
 	host.Spec.Status.ErrorCount = 0
+	v1beta1conditions.Delete(host, ActionCompletedCondition)
+	v1beta2conditions.Delete(host, HetznerBareMetalHostActionCompletedV1Beta2Condition)
 }
 
 // HasRebootAnnotation checks for the existence of reboot annotations and returns true if at least one exists.

--- a/api/v1beta1/hetznerbaremetalhost_types_test.go
+++ b/api/v1beta1/hetznerbaremetalhost_types_test.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
 	"testing"
 
@@ -26,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 )
 
 var _ = Describe("Test update secret status", func() {
@@ -469,7 +472,9 @@ func mapKeys[K cmp.Ordered, V any](m map[K]V) []K {
 }
 
 func TestHetznerBareMetalHost_SetError(t *testing.T) {
-	// A PermanentError should add the PermanentErrorAnnotation
+	// A PermanentError should add the PermanentErrorAnnotation and set the ActionCompleted condition
+	// in both the old-style and the v1beta2-style condition lists, instructing the user to remove
+	// the annotation to resolve it.
 	host := HetznerBareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -480,7 +485,33 @@ func TestHetznerBareMetalHost_SetError(t *testing.T) {
 	host.SetError(PermanentError, "some error")
 	require.Equal(t, []string{PermanentErrorAnnotation, "other-annotation"}, mapKeys(host.Annotations))
 
-	// Other errors should not add the PermanentErrorAnnotation
+	wantMessage := fmt.Sprintf("some error. Remove annotation %q, if you want the controller to use the hbmh again.",
+		PermanentErrorAnnotation)
+
+	actionCompletedCondition := v1beta2conditions.Get(&host, HetznerBareMetalHostActionCompletedV1Beta2Condition)
+	require.NotNil(t, actionCompletedCondition)
+	require.Equal(t, metav1.ConditionFalse, actionCompletedCondition.Status)
+	require.Equal(t, HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason, actionCompletedCondition.Reason)
+	require.Equal(t, wantMessage, actionCompletedCondition.Message)
+	require.Equal(t, 1, host.Spec.Status.ErrorCount)
+
+	v1beta1ActionCompletedCondition := v1beta1conditions.Get(&host, ActionCompletedCondition)
+	require.NotNil(t, v1beta1ActionCompletedCondition)
+	require.Equal(t, corev1.ConditionFalse, v1beta1ActionCompletedCondition.Status)
+	require.Equal(t, ActionCompletedPermanentErrorReason, v1beta1ActionCompletedCondition.Reason)
+	require.Equal(t, wantMessage, v1beta1ActionCompletedCondition.Message)
+
+	// Calling SetError again with the same type and message (as happens on every reconcile while the
+	// annotation is present) must keep the condition stable and increment ErrorCount.
+	host.SetError(PermanentError, "some error")
+	actionCompletedCondition = v1beta2conditions.Get(&host, HetznerBareMetalHostActionCompletedV1Beta2Condition)
+	require.NotNil(t, actionCompletedCondition)
+	require.Equal(t, metav1.ConditionFalse, actionCompletedCondition.Status)
+	require.Equal(t, HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason, actionCompletedCondition.Reason)
+	require.Equal(t, wantMessage, actionCompletedCondition.Message)
+	require.Equal(t, 2, host.Spec.Status.ErrorCount)
+
+	// Other errors should not add the PermanentErrorAnnotation or set the ActionCompleted condition.
 	host = HetznerBareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -490,4 +521,6 @@ func TestHetznerBareMetalHost_SetError(t *testing.T) {
 	}
 	host.SetError(ProvisioningError, "some error")
 	require.Equal(t, []string{"other-annotation"}, mapKeys(host.Annotations))
+	require.Nil(t, v1beta2conditions.Get(&host, HetznerBareMetalHostActionCompletedV1Beta2Condition))
+	require.Nil(t, v1beta1conditions.Get(&host, ActionCompletedCondition))
 }

--- a/api/v1beta1/hetznerbaremetalremediation_types.go
+++ b/api/v1beta1/hetznerbaremetalremediation_types.go
@@ -25,8 +25,9 @@ const (
 	RebootAnnotation = "capi.syself.com/reboot"
 
 	// PermanentErrorAnnotation indicates that the bare metal host has an error which needs to be resolved manually.
-	// After the permanent error the annotation got removed (usually by a human), the controller removes
-	// ErrorType, ErrorCount and ErrorMessages, so that the hbmh will be usable again.
+	// After the annotation is removed (usually by a human), the controller removes ErrorType, ErrorCount and
+	// ErrorMessage, so that the hbmh will be usable again. The ActionCompleted condition explains the underlying
+	// problem and tells the user to remove this annotation to resolve it.
 	PermanentErrorAnnotation = "capi.syself.com/permanent-error"
 )
 

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -594,6 +594,8 @@ func (r *HetznerBareMetalHostReconciler) SetupWithManager(ctx context.Context, m
 	return nil
 }
 
+// removePermanentErrorIfAnnotationIsGone clears the permanent error status once the user removes
+// the permanent-error annotation.
 func removePermanentErrorIfAnnotationIsGone(bmHost *infrav1.HetznerBareMetalHost,
 ) (removed bool) {
 	if bmHost.Spec.Status.ErrorType != infrav1.PermanentError {
@@ -606,9 +608,12 @@ func removePermanentErrorIfAnnotationIsGone(bmHost *infrav1.HetznerBareMetalHost
 			return false
 		}
 	}
+
 	bmHost.Spec.Status.ErrorType = ""
 	bmHost.Spec.Status.ErrorMessage = ""
 	bmHost.Spec.Status.ErrorCount = 0
+	v1beta1conditions.Delete(bmHost, infrav1.ActionCompletedCondition)
+	v1beta2conditions.Delete(bmHost, infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition)
 	record.Eventf(bmHost, "PermanentErrorWasRemoved", "The permanent error was removed, because the annotation %q was removed",
 		infrav1.PermanentErrorAnnotation)
 	return true

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -33,7 +33,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1081,8 +1084,8 @@ name="eth0" model="Realtek Semiconductor Co., Ltd. RTL8111/8168/8411 PCI Express
 	sshClient.On("GetResultOfInstallImage", mock.Anything).Return(hostpkg.PostInstallScriptFinished, nil)
 }
 
-func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
-	// PermanentError with annotation --> Error should not get removed
+func Test_removePermanentErrorIfAnnotationIsGone_AnnotationPresent(t *testing.T) {
+	// PermanentError with annotation still present: Error should not get removed.
 	bmHost := infrav1.HetznerBareMetalHost{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1103,9 +1106,12 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorType)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorCount)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorMessage)
+	require.Contains(t, bmHost.Annotations, infrav1.PermanentErrorAnnotation)
+}
 
-	// PermanentError without annotation --> Error should get removed
-	bmHost = infrav1.HetznerBareMetalHost{
+func Test_removePermanentErrorIfAnnotationIsGone_AnnotationRemoved(t *testing.T) {
+	// PermanentError with annotation removed: Error and both old- and new-style conditions should get removed.
+	bmHost := infrav1.HetznerBareMetalHost{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -1117,18 +1123,40 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 				ErrorType:    infrav1.PermanentError,
 				ErrorCount:   1,
 				ErrorMessage: "my err",
+				Conditions: clusterv1beta1.Conditions{
+					{
+						Type:    infrav1.ActionCompletedCondition,
+						Status:  corev1.ConditionFalse,
+						Reason:  infrav1.ActionCompletedPermanentErrorReason,
+						Message: "my err",
+					},
+				},
+				V1Beta2: &infrav1.HetznerBareMetalHostV1Beta2Status{
+					Conditions: []metav1.Condition{
+						{
+							Type:    infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition,
+							Status:  metav1.ConditionFalse,
+							Reason:  infrav1.HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason,
+							Message: "my err",
+						},
+					},
+				},
 			},
 		},
 	}
-	removed = removePermanentErrorIfAnnotationIsGone(&bmHost)
+	removed := removePermanentErrorIfAnnotationIsGone(&bmHost)
 	require.True(t, removed)
 	require.Empty(t, bmHost.Spec.Status.ErrorType)
 	require.Empty(t, bmHost.Spec.Status.ErrorCount)
 	require.Empty(t, bmHost.Spec.Status.ErrorMessage)
 	require.Equal(t, map[string]string{"other-annotation": "some value"}, bmHost.Annotations)
+	require.Nil(t, v1beta1conditions.Get(&bmHost, infrav1.ActionCompletedCondition))
+	require.Nil(t, v1beta2conditions.Get(&bmHost, infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition))
+}
 
-	// Other Error without annotation --> Error should not get removed
-	bmHost = infrav1.HetznerBareMetalHost{
+func Test_removePermanentErrorIfAnnotationIsGone_NonPermanentError(t *testing.T) {
+	// Other error type: Error should not get removed (guarded on PermanentError).
+	bmHost := infrav1.HetznerBareMetalHost{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
@@ -1141,7 +1169,7 @@ func Test_removePermanentErrorIfAnnotationIsGone(t *testing.T) {
 			},
 		},
 	}
-	removed = removePermanentErrorIfAnnotationIsGone(&bmHost)
+	removed := removePermanentErrorIfAnnotationIsGone(&bmHost)
 	require.False(t, removed)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorType)
 	require.NotEmpty(t, bmHost.Spec.Status.ErrorCount)

--- a/pkg/scope/baremetalhost.go
+++ b/pkg/scope/baremetalhost.go
@@ -217,6 +217,7 @@ func BareMetalHostPatchOpts() []v1beta1patch.Option {
 			infrav1.RootDeviceHintsValidatedCondition,
 			infrav1.ProvisionSucceededCondition,
 			infrav1.HetznerAPIReachableCondition,
+			infrav1.ActionCompletedCondition,
 		}},
 		v1beta1patch.WithOwnedV1Beta2Conditions{Conditions: []string{
 			clusterv1beta1.ReadyV1Beta2Condition,
@@ -228,6 +229,7 @@ func BareMetalHostPatchOpts() []v1beta1patch.Option {
 			infrav1.HetznerBareMetalHostRebootSucceededV1Beta2Condition,
 			infrav1.HetznerBareMetalHostDeletingV1Beta2Condition,
 			infrav1.HetznerBareMetalHostRobotRateLimitExceededV1Beta2Condition,
+			infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition,
 		}},
 	}
 }

--- a/pkg/scope/baremetalhost_test.go
+++ b/pkg/scope/baremetalhost_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
+
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+)
+
+var _ = Describe("SetHetznerBareMetalHostV1Beta2ReadySummary", func() {
+	It("sets Ready=False with reason NotReady when ActionCompleted=False (PermanentError)", func() {
+		host := &infrav1.HetznerBareMetalHost{}
+
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:   infrav1.HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: infrav1.HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Reason,
+		})
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason,
+			Message: "reboot to rescue mode timed out",
+		})
+
+		SetHetznerBareMetalHostV1Beta2ReadySummary(host)
+
+		ready := v1beta2conditions.Get(host, clusterv1beta1.ReadyV1Beta2Condition)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+		Expect(ready.Reason).To(Equal(clusterv1beta1.NotReadyV1Beta2Reason))
+		Expect(ready.Message).To(ContainSubstring("reboot to rescue mode timed out"))
+	})
+
+	It("ActionCompleted=False takes priority over other non-credential conditions", func() {
+		host := &infrav1.HetznerBareMetalHost{}
+
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:   infrav1.HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: infrav1.HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Reason,
+		})
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason,
+			Message: "reboot to rescue mode timed out",
+		})
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    infrav1.HetznerBareMetalHostProvisionSucceededV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HetznerBareMetalHostServerNotFoundV1Beta2Reason,
+			Message: "server not found",
+		})
+
+		SetHetznerBareMetalHostV1Beta2ReadySummary(host)
+
+		ready := v1beta2conditions.Get(host, clusterv1beta1.ReadyV1Beta2Condition)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+		Expect(ready.Reason).To(Equal(clusterv1beta1.NotReadyV1Beta2Reason))
+		// The summary lists all failing conditions in priority order. ActionCompleted (priority 2)
+		// must appear before ProvisionSucceeded (priority 6).
+		Expect(ready.Message).To(ContainSubstring("reboot to rescue mode timed out"))
+		Expect(ready.Message).To(ContainSubstring("server not found"))
+		Expect(strings.Index(ready.Message, "reboot to rescue mode timed out")).
+			To(BeNumerically("<", strings.Index(ready.Message, "server not found")))
+	})
+
+	It("RobotCredentialsAvailable=False takes priority over ActionCompleted=False", func() {
+		host := &infrav1.HetznerBareMetalHost{}
+
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    infrav1.HetznerBareMetalHostRobotCredentialsAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HetznerBareMetalHostRobotCredentialsInvalidV1Beta2Reason,
+			Message: "invalid credentials",
+		})
+		v1beta2conditions.Set(host, metav1.Condition{
+			Type:    infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason,
+			Message: "reboot to rescue mode timed out",
+		})
+
+		SetHetznerBareMetalHostV1Beta2ReadySummary(host)
+
+		ready := v1beta2conditions.Get(host, clusterv1beta1.ReadyV1Beta2Condition)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+		Expect(ready.Reason).To(Equal(clusterv1beta1.NotReadyV1Beta2Reason))
+		// The summary lists all failing conditions in priority order. RobotCredentialsAvailable
+		// (priority 1) must appear before ActionCompleted (priority 2).
+		Expect(ready.Message).To(ContainSubstring("invalid credentials"))
+		Expect(ready.Message).To(ContainSubstring("reboot to rescue mode timed out"))
+		Expect(strings.Index(ready.Message, "invalid credentials")).
+			To(BeNumerically("<", strings.Index(ready.Message, "reboot to rescue mode timed out")))
+	})
+})

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
@@ -1046,6 +1047,10 @@ var _ = Describe("actionPreparing", func() {
 		Expect(host.Spec.Status.ErrorMessage).To(ContainSubstring("no IPv4"))
 		Expect(host.Spec.Status.IPv4).To(BeEmpty())
 		Expect(host.Annotations).To(HaveKey(infrav1.PermanentErrorAnnotation))
+		actionCompletedCondition := v1beta2conditions.Get(host, infrav1.HetznerBareMetalHostActionCompletedV1Beta2Condition)
+		Expect(actionCompletedCondition).NotTo(BeNil())
+		Expect(actionCompletedCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(actionCompletedCondition.Reason).To(Equal(infrav1.HetznerBareMetalHostActionCompletedPermanentErrorV1Beta2Reason))
 	})
 })
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Surfaces a permanent host error through the ActionCompleted condition.

**Which issue(s) this PR fixes**:
None (backport of PR #2076).

**Special notes for your reviewer**:
Cherry-picked from main (d3a0ce036), no conflicts. release-1.1 