### PR TITLE
Set fatal error instead of permanent/provisioning error when reboot times out

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -668,7 +668,7 @@ func (s *Service) actionRegistering(ctx context.Context) actionResult {
 
 		failed, err := s.handleIncompleteBoot(ctx, true, isSSHTimeoutError, isSSHConnectionRefusedError)
 		if failed {
-			return s.recordActionFailure(infrav1.PermanentError, err.Error())
+			return s.recordActionFailure(infrav1.FatalError, err.Error())
 		}
 		if err != nil {
 			return actionError{err: fmt.Errorf(errMsgFailedHandlingIncompleteBoot, err)}
@@ -2047,7 +2047,7 @@ func (s *Service) actionEnsureProvisioned(ctx context.Context) (ar actionResult)
 			}
 			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,
 				infrav1.StateEnsureProvisioned, msg)
-			return s.recordActionFailure(infrav1.ProvisioningError, msg)
+			return s.recordActionFailure(infrav1.FatalError, msg)
 		}
 		if err != nil {
 			markProvisionPendingWithInfo(s.scope.HetznerBareMetalHost,

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -1585,6 +1585,29 @@ var _ = Describe("actionRegistering", func() {
 			expectedErrorType: infrav1.ErrorTypeConnectionError,
 		}),
 	)
+
+	It("sets a fatal error when the reboot into rescue times out", func() {
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithRootDeviceHintWWN(),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+			helpers.WithError(infrav1.ErrorTypeHardwareRebootTriggered, "", 1),
+			helpers.WithRebootTriggeredAt(metav1.NewTime(time.Now().Add(-time.Hour))),
+		)
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{Err: timeout})
+
+		service := newTestService(host, &robotmock.Client{}, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), nil, helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+
+		actResult := service.actionRegistering(ctx)
+
+		Expect(actResult).To(BeAssignableToTypeOf(actionFailed{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.FatalError))
+		Expect(host.Spec.Status.ErrorMessage).To(ContainSubstring("hardware reboot (to rescue mode) timed out"))
+	})
 })
 
 func registeringSSHMock(storageStdOut string) *sshmock.Client {
@@ -1899,6 +1922,32 @@ var _ = Describe("actionEnsureProvisioned", func() {
 			},
 		),
 	)
+
+	It("sets a fatal error when the reboot into the OS times out", func() {
+		ctx := context.Background()
+		portAfterInstallImage := 24
+
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithSSHSpecInclPorts(portAfterInstallImage),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+			helpers.WithError(infrav1.ErrorTypeHardwareRebootTriggered, "", 1),
+			helpers.WithRebootTriggeredAt(metav1.NewTime(time.Now().Add(-time.Hour))),
+		)
+
+		sshMock := &sshmock.Client{}
+		sshMock.On("GetHostName", mock.Anything).Return(sshclient.Output{Err: timeout})
+
+		service := newTestService(host, &robotmock.Client{}, bmmock.NewSSHFactory(sshMock, sshMock, sshMock), helpers.GetDefaultSSHSecret(osSSHKeyName, "default"), nil)
+
+		actResult := service.actionEnsureProvisioned(ctx)
+
+		Expect(actResult).To(BeAssignableToTypeOf(actionFailed{}))
+		Expect(host.Spec.Status.ErrorType).To(Equal(infrav1.FatalError))
+		Expect(host.Spec.Status.ErrorMessage).To(ContainSubstring("hardware reboot (to node) timed out"))
+	})
 })
 
 var _ = Describe("actionProvisioned NoSSHAfterInstallImage=false", func() {


### PR DESCRIPTION
## Summary
- When the reboot into the rescue system times out during host registration (`actionRegistering`), set a fatal error instead of a permanent error.
- When the reboot into the installed OS times out (`actionEnsureProvisioned`), set a fatal error instead of a provisioning error.

A fatal error deletes the machine and deprovisions the host, clearing its error so it returns to the pool for another machine to pick up and retry — instead of requiring manual clearing of the `permanent-error` annotation, or retrying forever on the same host with a growing backoff.

**Accepted drawback (from the issue):** a server that truly cannot boot into rescue will retry forever (provision → timeout → fatal error → delete → deprovision → re-pick-up → provision). This is acceptable since the server stays visibly stuck rather than silently leaving the pool. A follow-up initial-check mechanism is out of scope here.

Other permanent error cases (disk checks, wrong hostname, etc.) are unchanged.

Fixes #2147
