### PR TITLE
Add regression guard for GetServer call count in imageURL provisioning

### DIFF
--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1477,6 +1477,15 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
 		By("ensuring the bootstate has transitioned to OperatingSystemRunning")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
+
+		getServerCalls := 0
+		for _, call := range hcloudClient.Calls {
+			if call.Method == "GetServer" {
+				getServerCalls++
+			}
+		}
+		GinkgoWriter.Printf("GetServer was called %d times during provisioning (imageURL)\n", getServerCalls)
+		Expect(getServerCalls).To(BeNumerically("<=", 7), "GetServer should not be called more than 7 times during imageURL provisioning (see issue #2163)")
 	})
 
 	It("ignores status in output.json when IMAGE_URL_DONE in stdout", func() {


### PR DESCRIPTION
## Summary
- Adds a call-count assertion to the existing `imageURL` full-provisioning test in `pkg/services/hcloud/server/server_test.go`, so `GetServer` calls don't silently grow beyond the current baseline of 7.
- First step towards #2163: a concrete, tracked number for `GetServer` call volume during provisioning, as a baseline for future work to reduce it.

Relates to #2163

## TODO: no e2e test for image-url provisioning

Currently, the e2e tests do not use image-url via an image-url-command. This means the number generated by the e2e tests do not reflect that kind of provisioning.