### PR TITLE
🐛 Fix server creation getting stuck forever on name-uniqueness error

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1837,7 +1837,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 			// concrete fix instead of the raw uniqueness error.
 			msg = fmt.Sprintf(
 				"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
-					"Delete the conflicting HCloud server, or delete this Machine so its replacement is created with a new name.",
+					"Check for a dangling HCloud server with this name and delete it, or delete this Machine so its replacement is created with a new name.",
 				hm.Name, err.Error())
 		}
 		s.scope.Error(nil, msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -351,25 +351,42 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			return reconcile.Result{}, nil
 		}
 
+		// A uniqueness_error that createServer's own recovery (adopting the existing server) could
+		// not resolve means a server with this name already exists but is not this machine's. Unlike
+		// invalid_input/resource_unavailable, this can clear from the outside when the conflicting
+		// server is deleted. Nothing watches HCloud, so we requeue on a slow interval to retry the
+		// create, otherwise deleting the conflicting server would never trigger a new attempt.
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			msg := fmt.Sprintf(
+				"a server named %q already exists and could not be adopted, retrying: %s. "+
+					"Delete the conflicting HCloud server, or delete this Machine to create a new one.",
+				s.scope.Name(), err.Error(),
+			)
+			v1beta1conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.ServerCreateSucceededCondition,
+				infrav1.ServerCreateFailedReason,
+				clusterv1beta1.ConditionSeverityWarning,
+				"%s",
+				msg,
+			)
+			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerCreatedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineServerCreationFailedV1Beta2Reason,
+				Message: msg,
+			})
+			return reconcile.Result{RequeueAfter: 10 * time.Minute}, nil
+		}
+
 		// Terminal errors like invalid_input (e.g. unsupported location for server type)
 		// or resource_unavailable (e.g. server location disabled) will never succeed on retry.
-		// A uniqueness_error that createServer's own recovery (adopting the existing server)
-		// could not resolve is equally terminal: retrying CreateServer with the same name will
-		// hit the exact same error forever. Mark the machine as irrecoverably failed and stop
-		// reconciling in all these cases.
-		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable) ||
-			hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+		// Mark the machine as irrecoverably failed and stop reconciling.
+		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable) {
 			msg := fmt.Sprintf(
 				"Server creation failed with an irrecoverable error: %s. If the requested resources (server type or location) become available again, delete the Machine to trigger a new creation attempt.",
 				err.Error(),
 			)
-			if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
-				msg = fmt.Sprintf(
-					"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
-						"Delete the conflicting HCloud server, or delete this Machine to trigger a new creation attempt.",
-					s.scope.Name(), err.Error(),
-				)
-			}
 			v1beta1conditions.MarkFalse(
 				s.scope.HCloudMachine,
 				infrav1.ServerCreateSucceededCondition,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -314,6 +314,39 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
+	// A server with matching labels can already exist here even though ProviderID is unset:
+	// a previous reconcile may have created the HCloud server successfully but lost the
+	// update that would have persisted ProviderID/BootState (e.g. an API server conflict or a
+	// controller restart between CreateServer and Close()). Without this check we would retry
+	// CreateServer with the same deterministic name forever and fail every time with a
+	// name-uniqueness error.
+	existingServer, err := s.findServerByLabels(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("findServerByLabels: %w", err)
+	}
+	if existingServer != nil {
+		s.scope.Info("found existing HCloud server with matching labels, adopting it instead of creating a duplicate",
+			"serverID", existingServer.ID, "serverName", existingServer.Name)
+		updateHCloudMachineStatusFromServer(hm, existingServer)
+		s.scope.SetProviderID(existingServer.ID)
+		v1beta1conditions.MarkTrue(hm, infrav1.ServerCreateSucceededCondition)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:   infrav1.HCloudMachineServerCreatedV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
+		})
+		if hm.Spec.ImageURL != "" {
+			s.setBootState(infrav1.HCloudBootStateInitializing)
+			// The create action ID for this server is unknown since we did not create it
+			// ourselves. Treat it as already finished so handleBootStateInitializing does not
+			// wait on an action ID it will never see.
+			hm.Status.ExternalIDs.ActionIDCreateServer = actionDone
+		} else {
+			s.setBootState(infrav1.HCloudBootStateBootingToRealOS)
+		}
+		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+	}
+
 	// The imageURL flow installs the image via SSH in the rescue system, so it needs a valid
 	// SSH private key. Check that before creating the server, so that no server gets created
 	// when the key is misconfigured. Other failures could also mean a network failure while
@@ -2236,6 +2269,19 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	}
 
 	// server has not been found via id - try to find the server based on its labels
+	server, err = s.findServerByLabels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if server != nil {
+		s.scope.Info("DeprecationWarning finding Server by labels is no longer needed. We plan to remove that feature and rename findServer to getServer")
+	}
+	return server, nil
+}
+
+// findServerByLabels searches for a server matching this HCloudMachine's labels, without
+// relying on ProviderID. It returns server and error as nil when no server matches.
+func (s *Service) findServerByLabels(ctx context.Context) (*hcloud.Server, error) {
 	opts := hcloud.ServerListOpts{}
 
 	opts.LabelSelector = utils.LabelsToLabelSelector(s.createLabels())
@@ -2254,8 +2300,6 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	if len(servers) == 0 {
 		return nil, nil
 	}
-
-	s.scope.Info("DeprecationWarning finding Server by labels is no longer needed. We plan to remove that feature and rename findServer to getServer", "err", err)
 
 	return servers[0], nil
 }

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1837,7 +1837,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 			// concrete fix instead of the raw uniqueness error.
 			msg = fmt.Sprintf(
 				"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
-					"Check for a dangling HCloud server with this name and delete it, or delete this Machine so its replacement is created with a new name.",
+					"Delete the conflicting HCloud server, or delete this Machine to get a replacement with a new name (deleting the Machine object leaves the original server behind as a dangling server). ",
 				hm.Name, err.Error())
 		}
 		s.scope.Error(nil, msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -351,12 +351,12 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			return reconcile.Result{}, nil
 		}
 
-		// A uniqueness_error that createServer's own recovery (adopting the existing server) could
-		// not resolve means a server with this name already exists but is not this machine's. Unlike
-		// invalid_input/resource_unavailable, this can clear from the outside when the conflicting
-		// server is deleted. Nothing watches HCloud, so we requeue on a slow interval to retry the
-		// create, otherwise deleting the conflicting server would never trigger a new attempt.
-		// createServer already set ServerCreateSucceededCondition to false, so we only requeue here.
+		// createServer hit a uniqueness_error that adoption (taking over an existing server) could
+		// not resolve. Unlike invalid_input/resource_unavailable, this can clear from the outside:
+		// the conflicting server may be deleted, or this Machine may be replaced with a new name.
+		// Nothing watches HCloud, so we requeue on a slow interval to retry, otherwise such a change
+		// would never trigger a new attempt. createServer already set ServerCreateSucceededCondition
+		// to false, so we only requeue here.
 		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
 			return reconcile.Result{RequeueAfter: 10 * time.Minute}, nil
 		}
@@ -1837,7 +1837,7 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 			// concrete fix instead of the raw uniqueness error.
 			msg = fmt.Sprintf(
 				"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
-					"Delete the conflicting HCloud server, or delete this Machine to trigger a new creation attempt.",
+					"Delete the conflicting HCloud server, or delete this Machine so its replacement is created with a new name.",
 				hm.Name, err.Error())
 		}
 		s.scope.Error(nil, msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -354,12 +354,23 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 
 		// Terminal errors like invalid_input (e.g. unsupported location for server type)
 		// or resource_unavailable (e.g. server location disabled) will never succeed on retry.
-		// Mark the machine as irrecoverably failed and stop reconciling.
-		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable) {
+		// A uniqueness_error that createServer's own recovery (adopting the existing server)
+		// could not resolve is equally terminal: retrying CreateServer with the same name will
+		// hit the exact same error forever. Mark the machine as irrecoverably failed and stop
+		// reconciling in all these cases.
+		if hcloud.IsError(err, hcloud.ErrorCodeInvalidInput) || hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable) ||
+			hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
 			msg := fmt.Sprintf(
 				"Server creation failed with an irrecoverable error: %s. If the requested resources (server type or location) become available again, delete the Machine to trigger a new creation attempt.",
 				err.Error(),
 			)
+			if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+				msg = fmt.Sprintf(
+					"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
+						"Delete the conflicting HCloud server, or delete this Machine to trigger a new creation attempt.",
+					s.scope.Name(), err.Error(),
+				)
+			}
 			v1beta1conditions.MarkFalse(
 				s.scope.HCloudMachine,
 				infrav1.ServerCreateSucceededCondition,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -314,39 +314,6 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	// A server with this exact name can already exist here even though ProviderID is unset:
-	// a previous reconcile may have created the HCloud server successfully but lost the
-	// update that would have persisted ProviderID/BootState (e.g. an API server conflict or a
-	// controller restart between CreateServer and Close()). Without this check we would retry
-	// CreateServer with the same deterministic name forever and fail every time with a
-	// name-uniqueness error.
-	existingServer, err := s.findServerByName(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("findServerByName: %w", err)
-	}
-	if existingServer != nil {
-		s.scope.Info("found existing HCloud server with matching name, adopting it instead of creating a duplicate",
-			"serverID", existingServer.ID, "serverName", existingServer.Name)
-		updateHCloudMachineStatusFromServer(hm, existingServer)
-		s.scope.SetProviderID(existingServer.ID)
-		v1beta1conditions.MarkTrue(hm, infrav1.ServerCreateSucceededCondition)
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:   infrav1.HCloudMachineServerCreatedV1Beta2Condition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
-		})
-		if hm.Spec.ImageURL != "" {
-			s.setBootState(infrav1.HCloudBootStateInitializing)
-			// The create action ID for this server is unknown since we did not create it
-			// ourselves. Treat it as already finished so handleBootStateInitializing does not
-			// wait on an action ID it will never see.
-			hm.Status.ExternalIDs.ActionIDCreateServer = actionDone
-		} else {
-			s.setBootState(infrav1.HCloudBootStateBootingToRealOS)
-		}
-		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
-	}
-
 	// The imageURL flow installs the image via SSH in the rescue system, so it needs a valid
 	// SSH private key. Check that before creating the server, so that no server gets created
 	// when the key is misconfigured. Other failures could also mean a network failure while
@@ -1834,6 +1801,26 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 		if hcloudutil.HandleRateLimitExceededV1Beta1(hm, err, "CreateServer") {
 			// RateLimit was reached. Condition and Event got already created.
 			return hcloud.ServerCreateResult{}, fmt.Errorf("%s: %w", msg, err)
+		}
+
+		// A server with this exact name already exists. This happens if a previous reconcile
+		// created the HCloud server successfully but lost the update that would have persisted
+		// ProviderID/BootState (e.g. an API server conflict or a controller restart between
+		// CreateServer and Close()). Adopt the existing server instead of failing forever with
+		// the same uniqueness error on every retry.
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			if existingServer, findErr := s.findServerByName(ctx); findErr == nil && existingServer != nil {
+				s.scope.Info("server already exists after a uniqueness error, adopting it instead of failing",
+					"serverID", existingServer.ID, "serverName", existingServer.Name)
+				hm.Status.SSHKeys = caphSSHKeys
+				v1beta1conditions.MarkTrue(hm, infrav1.ServerCreateSucceededCondition)
+				v1beta2conditions.Set(hm, metav1.Condition{
+					Type:   infrav1.HCloudMachineServerCreatedV1Beta2Condition,
+					Status: metav1.ConditionTrue,
+					Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
+				})
+				return hcloud.ServerCreateResult{Server: existingServer, Action: &hcloud.Action{ID: actionDone}}, nil
+			}
 		}
 
 		msg = fmt.Sprintf("%s: %s", msg, err.Error())

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -356,26 +356,8 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		// invalid_input/resource_unavailable, this can clear from the outside when the conflicting
 		// server is deleted. Nothing watches HCloud, so we requeue on a slow interval to retry the
 		// create, otherwise deleting the conflicting server would never trigger a new attempt.
+		// createServer already set ServerCreateSucceededCondition to false, so we only requeue here.
 		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
-			msg := fmt.Sprintf(
-				"a server named %q already exists and could not be adopted, retrying: %s. "+
-					"Delete the conflicting HCloud server, or delete this Machine to create a new one.",
-				s.scope.Name(), err.Error(),
-			)
-			v1beta1conditions.MarkFalse(
-				s.scope.HCloudMachine,
-				infrav1.ServerCreateSucceededCondition,
-				infrav1.ServerCreateFailedReason,
-				clusterv1beta1.ConditionSeverityWarning,
-				"%s",
-				msg,
-			)
-			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-				Type:    infrav1.HCloudMachineServerCreatedV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineServerCreationFailedV1Beta2Reason,
-				Message: msg,
-			})
 			return reconcile.Result{RequeueAfter: 10 * time.Minute}, nil
 		}
 
@@ -1850,6 +1832,14 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 		}
 
 		msg = fmt.Sprintf("%s: %s", msg, err.Error())
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			// The name is taken and we could not adopt the existing server. Give the operator the
+			// concrete fix instead of the raw uniqueness error.
+			msg = fmt.Sprintf(
+				"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
+					"Delete the conflicting HCloud server, or delete this Machine to trigger a new creation attempt.",
+				hm.Name, err.Error())
+		}
 		s.scope.Error(nil, msg)
 		// No condition was set yet. Set a general condition to false.
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerCreateSucceededCondition,

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -314,18 +314,18 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	// A server with matching labels can already exist here even though ProviderID is unset:
+	// A server with this exact name can already exist here even though ProviderID is unset:
 	// a previous reconcile may have created the HCloud server successfully but lost the
 	// update that would have persisted ProviderID/BootState (e.g. an API server conflict or a
 	// controller restart between CreateServer and Close()). Without this check we would retry
 	// CreateServer with the same deterministic name forever and fail every time with a
 	// name-uniqueness error.
-	existingServer, err := s.findServerByLabels(ctx)
+	existingServer, err := s.findServerByName(ctx)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("findServerByLabels: %w", err)
+		return reconcile.Result{}, fmt.Errorf("findServerByName: %w", err)
 	}
 	if existingServer != nil {
-		s.scope.Info("found existing HCloud server with matching labels, adopting it instead of creating a duplicate",
+		s.scope.Info("found existing HCloud server with matching name, adopting it instead of creating a duplicate",
 			"serverID", existingServer.ID, "serverName", existingServer.Name)
 		updateHCloudMachineStatusFromServer(hm, existingServer)
 		s.scope.SetProviderID(existingServer.ID)
@@ -2268,23 +2268,21 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 		}
 	}
 
-	// server has not been found via id - try to find the server based on its labels
-	server, err = s.findServerByLabels(ctx)
+	// server has not been found via id - try to find the server based on its name
+	server, err = s.findServerByName(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if server != nil {
-		s.scope.Info("DeprecationWarning finding Server by labels is no longer needed. We plan to remove that feature and rename findServer to getServer")
+		s.scope.Info("DeprecationWarning finding Server by name is no longer needed. We plan to remove that feature and rename findServer to getServer")
 	}
 	return server, nil
 }
 
-// findServerByLabels searches for a server matching this HCloudMachine's labels, without
-// relying on ProviderID. It returns server and error as nil when no server matches.
-func (s *Service) findServerByLabels(ctx context.Context) (*hcloud.Server, error) {
-	opts := hcloud.ServerListOpts{}
-
-	opts.LabelSelector = utils.LabelsToLabelSelector(s.createLabels())
+// findServerByName searches for a server with this HCloudMachine's name, without relying on
+// ProviderID. It returns server and error as nil when no server matches.
+func (s *Service) findServerByName(ctx context.Context) (*hcloud.Server, error) {
+	opts := hcloud.ServerListOpts{Name: s.scope.Name()}
 
 	servers, err := s.scope.HCloudClient.ListServers(ctx, opts)
 	if err != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1809,7 +1809,10 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 		// CreateServer and Close()). Adopt the existing server instead of failing forever with
 		// the same uniqueness error on every retry.
 		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
-			if existingServer, findErr := s.findServerByName(ctx); findErr == nil && existingServer != nil {
+			existingServer, findErr := s.findServerByName(ctx)
+			if findErr != nil {
+				s.scope.Error(findErr, "failed to look up existing server after a uniqueness error on CreateServer")
+			} else if existingServer != nil {
 				s.scope.Info("server already exists after a uniqueness error, adopting it instead of failing",
 					"serverID", existingServer.ID, "serverName", existingServer.Name)
 				hm.Status.SSHKeys = caphSSHKeys
@@ -1819,6 +1822,8 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 					Status: metav1.ConditionTrue,
 					Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
 				})
+				record.Eventf(hm, "AdoptedExistingServer", "Adopted existing server %s (ID %d) after a uniqueness error on create",
+					existingServer.Name, existingServer.ID)
 				return hcloud.ServerCreateResult{Server: existingServer, Action: &hcloud.Action{ID: actionDone}}, nil
 			}
 		}

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -2255,21 +2255,10 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 		}
 	}
 
-	// server has not been found via id - try to find the server based on its name
-	server, err = s.findServerByName(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if server != nil {
-		s.scope.Info("DeprecationWarning finding Server by name is no longer needed. We plan to remove that feature and rename findServer to getServer")
-	}
-	return server, nil
-}
+	// server has not been found via id - try to find the server based on its labels
+	opts := hcloud.ServerListOpts{}
 
-// findServerByName searches for a server with this HCloudMachine's name, without relying on
-// ProviderID. It returns server and error as nil when no server matches.
-func (s *Service) findServerByName(ctx context.Context) (*hcloud.Server, error) {
-	opts := hcloud.ServerListOpts{Name: s.scope.Name()}
+	opts.LabelSelector = utils.LabelsToLabelSelector(s.createLabels())
 
 	servers, err := s.scope.HCloudClient.ListServers(ctx, opts)
 	if err != nil {
@@ -2280,6 +2269,28 @@ func (s *Service) findServerByName(ctx context.Context) (*hcloud.Server, error) 
 		err := fmt.Errorf("found %d servers with name %s", len(servers), s.scope.Name())
 		record.Warn(s.scope.HCloudMachine, "MultipleInstances", err.Error())
 		return nil, err
+	}
+
+	if len(servers) == 0 {
+		return nil, nil
+	}
+
+	s.scope.Info("DeprecationWarning finding Server by labels is no longer needed. We plan to remove that feature and rename findServer to getServer", "err", err)
+
+	return servers[0], nil
+}
+
+// findServerByName searches for a server with this HCloudMachine's exact name. Used to recover
+// from a uniqueness error on CreateServer, where relying on ProviderID isn't possible yet.
+// It returns server and error as nil when no server matches.
+func (s *Service) findServerByName(ctx context.Context) (*hcloud.Server, error) {
+	servers, err := s.scope.HCloudClient.ListServers(ctx, hcloud.ServerListOpts{Name: s.scope.Name()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	if len(servers) > 1 {
+		return nil, fmt.Errorf("found %d servers with name %s", len(servers), s.scope.Name())
 	}
 
 	if len(servers) == 0 {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -239,7 +239,10 @@ var _ = Describe("handleBootStateUnset", func() {
 	})
 
 	It("marks SSHPrivateKeyAvailableCondition false and requeues when SSH private key secret ref name is empty", func() {
-		service := newTestService(hcloudMachine, mocks.NewClient(GinkgoT()))
+		hcloudClient := mocks.NewClient(GinkgoT())
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
+
+		service := newTestService(hcloudMachine, hcloudClient)
 		service.scope.HetznerCluster = &infrav1.HetznerCluster{
 			Spec: infrav1.HetznerClusterSpec{
 				SSHKeys: infrav1.HetznerSSHKeys{
@@ -1229,6 +1232,8 @@ var _ = Describe("Reconcile", func() {
 			Action: &hcloud.Action{ID: 998877},
 		}, nil)
 
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
+
 		By("calling reconcile")
 		_, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
@@ -1251,6 +1256,41 @@ var _ = Describe("Reconcile", func() {
 
 		By("ensuring the bootstate has transitioned to BootStateOperatingSystemRunning once the server's status changes to running")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
+	})
+
+	It("adopts an existing server with matching labels instead of creating a duplicate", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		By("simulating a server that a previous reconcile already created, but whose ProviderID never got persisted")
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return([]*hcloud.Server{
+			{
+				ID:     42,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusRunning,
+			},
+		}, nil)
+
+		By("calling reconcile — CreateServer must not be called")
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueImmediately}))
+
+		By("ensuring the existing server was adopted instead of creating a duplicate")
+		hcloudClient.AssertNotCalled(GinkgoT(), "CreateServer", mock.Anything, mock.Anything)
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
+		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
 	})
 
 	It("transitions to BootStateOperatingSystemRunning (imageURL)", func() {
@@ -1311,6 +1351,8 @@ var _ = Describe("Reconcile", func() {
 			},
 			Action: &hcloud.Action{ID: 998877},
 		}, nil)
+
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("calling reconcile")
 		_, err := service.Reconcile(ctx)
@@ -1699,6 +1741,8 @@ var _ = Describe("Reconcile", func() {
 
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
 
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
+
 		By("ensuring that the mock hcloud client return unauthorized error on GetServerType")
 		// GetServerType is the first API call to HCloud while creating a server.
 		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
@@ -1745,6 +1789,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("ensuring that the mock hcloud client returns no server type")
 		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(nil, nil).Once()
@@ -1882,6 +1928,8 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Spec.ImageName = ""
 		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
 		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-nonexistent.sh"
+
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("calling reconcile — CreateServer must not be called")
 		res, err := service.Reconcile(ctx)

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1320,9 +1320,10 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
 		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
 		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudMachineServerCreatedV1Beta2Reason)).To(BeTrue())
 	})
 
-	It("marks the machine as irrecoverably failed if a uniqueness error on CreateServer cannot be resolved by adoption", func() {
+	It("requeues to retry when a uniqueness error on CreateServer cannot be resolved by adoption", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1374,15 +1375,15 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{}, nil)
 
 		By("calling reconcile")
-		_, err = service.Reconcile(ctx)
-
-		By("ensuring reconcile does not return an error, so the machine does not get retried forever")
+		result, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
 
-		By("ensuring the machine is marked as irrecoverably failed instead of being retried forever")
+		By("ensuring the machine requeues to retry instead of being marked irrecoverable")
+		Expect(result.RequeueAfter).To(Equal(10 * time.Minute))
 		Expect(v1beta1conditions.IsFalse(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
 		Expect(v1beta1conditions.GetReason(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
-			To(Equal(infrav1.ServerCreateFailedIrrecoverableErrorReason))
+			To(Equal(infrav1.ServerCreateFailedReason))
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineServerCreationFailedV1Beta2Reason)).To(BeTrue())
 	})
 
 	It("recovers from a uniqueness error on CreateServer by adopting the existing server (imageURL)", func() {
@@ -1457,6 +1458,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreateServer).To(Equal(int64(actionDone)))
 		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
 		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudMachineServerCreatedV1Beta2Reason)).To(BeTrue())
 
 		By("reconciling again: handleBootStateInitializing must not wait on a create action, since ActionIDCreateServer is already actionDone")
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1258,7 +1258,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
 	})
 
-	It("adopts an existing server with matching labels instead of creating a duplicate", func() {
+	It("adopts an existing server with a matching name instead of creating a duplicate", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1274,7 +1274,7 @@ var _ = Describe("Reconcile", func() {
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
 
 		By("simulating a server that a previous reconcile already created, but whose ProviderID never got persisted")
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return([]*hcloud.Server{
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{
 			{
 				ID:     42,
 				Name:   "my-machine",

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1384,6 +1384,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(v1beta1conditions.GetReason(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
 			To(Equal(infrav1.ServerCreateFailedReason))
 		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineServerCreationFailedV1Beta2Reason)).To(BeTrue())
+		Expect(v1beta1conditions.GetMessage(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
+			To(ContainSubstring("could not be adopted"))
 	})
 
 	It("recovers from a uniqueness error on CreateServer by adopting the existing server (imageURL)", func() {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -240,7 +240,6 @@ var _ = Describe("handleBootStateUnset", func() {
 
 	It("marks SSHPrivateKeyAvailableCondition false and requeues when SSH private key secret ref name is empty", func() {
 		hcloudClient := mocks.NewClient(GinkgoT())
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		service := newTestService(hcloudMachine, hcloudClient)
 		service.scope.HetznerCluster = &infrav1.HetznerCluster{
@@ -1232,8 +1231,6 @@ var _ = Describe("Reconcile", func() {
 			Action: &hcloud.Action{ID: 998877},
 		}, nil)
 
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
-
 		By("calling reconcile")
 		_, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
@@ -1258,7 +1255,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
 	})
 
-	It("adopts an existing server with a matching name instead of creating a duplicate", func() {
+	It("recovers from a uniqueness error on CreateServer by adopting the existing server", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1273,7 +1270,40 @@ var _ = Describe("Reconcile", func() {
 
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
 
-		By("simulating a server that a previous reconcile already created, but whose ProviderID never got persisted")
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a previous reconcile that created the server but never persisted ProviderID")
+		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
 		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{
 			{
 				ID:     42,
@@ -1282,15 +1312,14 @@ var _ = Describe("Reconcile", func() {
 			},
 		}, nil)
 
-		By("calling reconcile — CreateServer must not be called")
-		res, err := service.Reconcile(ctx)
+		By("calling reconcile")
+		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
-		Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueImmediately}))
 
-		By("ensuring the existing server was adopted instead of creating a duplicate")
-		hcloudClient.AssertNotCalled(GinkgoT(), "CreateServer", mock.Anything, mock.Anything)
+		By("ensuring the existing server was adopted instead of failing forever")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
 		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
+		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
 	})
 
 	It("transitions to BootStateOperatingSystemRunning (imageURL)", func() {
@@ -1351,8 +1380,6 @@ var _ = Describe("Reconcile", func() {
 			},
 			Action: &hcloud.Action{ID: 998877},
 		}, nil)
-
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("calling reconcile")
 		_, err := service.Reconcile(ctx)
@@ -1741,8 +1768,6 @@ var _ = Describe("Reconcile", func() {
 
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
 
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
-
 		By("ensuring that the mock hcloud client return unauthorized error on GetServerType")
 		// GetServerType is the first API call to HCloud while creating a server.
 		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
@@ -1789,8 +1814,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).To(BeNil())
 
 		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
-
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("ensuring that the mock hcloud client returns no server type")
 		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(nil, nil).Once()
@@ -1928,8 +1951,6 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Spec.ImageName = ""
 		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
 		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-nonexistent.sh"
-
-		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
 		By("calling reconcile — CreateServer must not be called")
 		res, err := service.Reconcile(ctx)

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -239,9 +239,7 @@ var _ = Describe("handleBootStateUnset", func() {
 	})
 
 	It("marks SSHPrivateKeyAvailableCondition false and requeues when SSH private key secret ref name is empty", func() {
-		hcloudClient := mocks.NewClient(GinkgoT())
-
-		service := newTestService(hcloudMachine, hcloudClient)
+		service := newTestService(hcloudMachine, mocks.NewClient(GinkgoT()))
 		service.scope.HetznerCluster = &infrav1.HetznerCluster{
 			Spec: infrav1.HetznerClusterSpec{
 				SSHKeys: infrav1.HetznerSSHKeys{

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1320,6 +1320,97 @@ var _ = Describe("Reconcile", func() {
 		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
 	})
 
+	It("recovers from a uniqueness error on CreateServer by adopting the existing server (imageURL)", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+		service.scope.HCloudMachine.Spec.ImageName = ""
+		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
+		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-test.sh"
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a previous reconcile that created the server but never persisted ProviderID")
+		hcloudClient.On("CreateServer", mock.Anything, mock.MatchedBy(func(opts hcloud.ServerCreateOpts) bool {
+			// an imageURL machine must be created powered off, so its first boot goes into the rescue system
+			return opts.StartAfterCreate != nil && !*opts.StartAfterCreate
+		})).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{
+			{
+				ID:     42,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusOff,
+			},
+		}, nil)
+
+		By("calling reconcile")
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		By("ensuring the existing server was adopted, with the create action treated as already finished")
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreateServer).To(Equal(int64(actionDone)))
+		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
+		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+
+		By("reconciling again: handleBootStateInitializing must not wait on a create action, since ActionIDCreateServer is already actionDone")
+		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
+			ID:     42,
+			Name:   "my-machine",
+			Status: hcloud.ServerStatusOff,
+		}, nil).Once()
+		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(
+			hcloud.ServerEnableRescueResult{
+				Action: &hcloud.Action{
+					ID:     334455,
+					Status: hcloud.ActionStatusRunning,
+				},
+			}, nil).Once()
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
+	})
+
 	It("transitions to BootStateOperatingSystemRunning (imageURL)", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1320,6 +1320,69 @@ var _ = Describe("Reconcile", func() {
 		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
 	})
 
+	It("marks the machine as irrecoverably failed if a uniqueness error on CreateServer cannot be resolved by adoption", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a uniqueness error where the recovery lookup finds no matching server")
+		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{}, nil)
+
+		By("calling reconcile")
+		_, err = service.Reconcile(ctx)
+
+		By("ensuring reconcile does not return an error, so the machine does not get retried forever")
+		Expect(err).To(BeNil())
+
+		By("ensuring the machine is marked as irrecoverably failed instead of being retried forever")
+		Expect(v1beta1conditions.IsFalse(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(v1beta1conditions.GetReason(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
+			To(Equal(infrav1.ServerCreateFailedIrrecoverableErrorReason))
+	})
+
 	It("recovers from a uniqueness error on CreateServer by adopting the existing server (imageURL)", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{


### PR DESCRIPTION
## Summary
- The `createServer` function called the HCloud API's `CreateServer` without handling the case where a server with this exact name already exists. Since the server name is deterministic (`HCloudMachine.Name`), if a previous reconcile created the server successfully but lost the update that would have persisted `ProviderID`/`BootState` (e.g. an API server conflict or controller restart between `CreateServer` and `Close()`), every subsequent reconcile retried `CreateServer` with the same name and failed forever with `server name is already used (uniqueness_error)`.
- This is a regression from #1650 (Refactor Hcloud Provisioning, use Status.BootState), which gated the existing `findServer` lookup (which has a label-based fallback) behind `ProviderID != nil`, removing the safety net for the initial creation path. `release-1.0` forked before that refactor and is unaffected; `main` and branches based on it are affected.
- Fix: when `CreateServer` fails specifically with `hcloud.ErrorCodeUniquenessError`, look up the existing server by name (`hcloud.ServerListOpts{Name: ...}`, an exact-match filter) via a new standalone `findServerByName` helper, and adopt it instead of failing. This is handled entirely inside `createServer()` — no change needed to `handleBootStateUnset` or either creation flow (imageName/imageURL), since both already consume `createServer`'s return value the same way whether the server was just created or adopted.
- `findServer`'s existing label-based fallback is left untouched — the diff is a pure addition (0 lines removed from `server.go`).
- Matching the sibling create-failure/success paths in the same function, adoption both logs and emits a Kubernetes Event (`AdoptedExistingServer`); a failure in the recovery lookup itself is logged rather than silently discarded.

