### PR TITLE
🌱 Do not emit image-url-command output.json as a Kubernetes event

### DIFF
--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -101,9 +101,9 @@ process is still running.
 
 The controller uses url.ParseRequestURI (Go function) to validate the imageURL.
 
-A Kubernetes event will be created in both (success, failure) cases containing the output (stdout
-and stderr) of the script. If the script takes longer than 20 minutes, the controller cancels the
-provisioning.
+The full output (stdout and stderr) of the script is written to the controller log. On failure or
+timeout CAPH also creates a Warning event, but with a short message only, never the full output. If
+the script takes longer than 20 minutes, the controller cancels the provisioning.
 
 ## Steps
 
@@ -114,17 +114,16 @@ provisioning.
   the file which will be in the corresponding condition, so that users can see the current state of
   the process. This is optional.
 * When the process has terminated, CAPH checks if IMAGE_URL_DONE is in the last line of the output.
-  If not, the process is considered to have failed. The machine gets deprovisioned. Two Events
-  (level=Warning) get created: One containing the output of the process, one containing the
-  output.json file (if it exists).
-* When IMAGE_URL_DONE was found, the process is considered to have succeeded. Two Events
-  (level=Info) get created: One containing the output of the process, one containing the output.json
-  file (if it exists).
+  If not, the process is considered to have failed. The machine gets deprovisioned. CAPH creates a
+  Warning event with a short message. The full output of the process and the output.json content (if
+  it exists) are written to the controller log.
+* When IMAGE_URL_DONE was found, the process is considered to have succeeded. The output of the
+  process and the output.json content (if it exists) are written to the controller log.
 
 ## output.json (optional)
 
 The command may write `/root/output.json` at any point during execution. The file is an option to
-give information from the node and to publish it as event. It's not about success or not.
+give information from the node and to write it to the controller log. It's not about success or not.
 
 CAPH reads only the `message` field from this file to update the provisioning condition on the
 machine (HCloudMachine or HetznerBareMetalHost). The `message` field is forwarded verbatim into the
@@ -146,15 +145,14 @@ Minimal example:
 {"message": "Downloading node image..."}
 ```
 
-Any other fields in the JSON are **ignored by CAPH** but are forwarded as-is via the Kubernetes
-event (see below). You can use them for your own structured debugging output.
+Any other fields in the JSON are **ignored by CAPH** but are written as-is to the controller log
+(see below). You can use them for your own structured debugging output.
 
-### Kubernetes event on completion
+### Controller log on completion
 
-When the command finishes (success or failure), CAPH emits a Kubernetes event with reason
-`CustomProvisionerOutputJSON` containing the **full JSON content** of the file. If the command
-failed, the event type is `Warning`; otherwise it is `Normal`. The content is also written to
-the controller log at key `outputJSON`.
+When the command finishes (success or failure), CAPH writes the **full JSON content** of the file
+to the controller log at key `outputJSON`. It is not exposed as a Kubernetes event, because the
+output can contain information that should not be shown to the cluster user.
 
 ## Measured durations for hcloud
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1314,7 +1314,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		msg := fmt.Sprintf("ImageURLCommand timed out after %s. Deleting machine",
 			duration.Round(time.Second).String())
 		s.scope.Error(nil, msg, "logFile", logFile)
-		record.Warn(s.scope.HetznerBareMetalHost, "ImageURLCommandTimedOut", logFile)
+		record.Warn(s.scope.HetznerBareMetalHost, "ImageURLCommandTimedOut", msg)
 
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
 			"ImageURLCommandTimedOut", clusterv1beta1.ConditionSeverityWarning,
@@ -1364,14 +1364,12 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.
 		s.scope.Info("CustomProvisionerOutput", "logFile", logFile)
-		record.Event(s.scope.HetznerBareMetalHost, "CustomProvisionerOutput", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {
 			s.scope.Error(err, "failed to read output.json")
 			return actionContinue{delay: 10 * time.Second}
 		}
-		record.Event(s.scope.HetznerBareMetalHost, "CustomProvisionerOutputJSON", outputJSON)
 		s.scope.Info("CustomProvisionerOutputJSON", "outputJSON", outputJSON)
 
 		// Update name in robot API
@@ -1398,7 +1396,6 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 		return actionComplete{}
 
 	case sshclient.ImageURLCommandStateFailed:
-		record.Warn(s.scope.HetznerBareMetalHost, "InstallImageNotSuccessful", logFile)
 		s.scope.Error(nil, "custom provisioner failed", "logFile", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
@@ -1414,12 +1411,12 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 				s.scope.Error(err, "failed to parse output.json", "outputJSON", outputJSON)
 				return actionError{err: fmt.Errorf("failed to parse: %w", err)}
 			}
-			record.Warn(s.scope.HetznerBareMetalHost, "CustomProvisionerOutputJSON", outputJSON)
 			s.scope.Error(nil, "CustomProvisionerOutputJSON", "outputJSON", outputJSON)
 			if output.Message != "" {
 				msg = output.Message
 			}
 		}
+		record.Warn(s.scope.HetznerBareMetalHost, "InstallImageNotSuccessful", msg)
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
 			"ImageURLCommandFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1083,7 +1083,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		record.Warn(hm, "ImageURLCommandFailed", logFile)
+		record.Warn(hm, "ImageURLCommandFailed", v1beta2Msg)
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			v1beta1Reason, clusterv1beta1.ConditionSeverityWarning,
 			"%s", v1beta1Msg)
@@ -1133,7 +1133,6 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.
 		s.scope.Info("CustomProvisionerOutput", "logFile", logFile)
-		record.Event(hm, "CustomProvisionerOutput", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {
@@ -1141,7 +1140,6 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		record.Event(hm, "CustomProvisionerOutputJSON", outputJSON)
 		s.scope.Info("CustomProvisionerOutputJSON", "outputJSON", outputJSON)
 
 		// The image got installed. Now reboot in the real operating system.
@@ -1169,7 +1167,6 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 
 	case sshclient.ImageURLCommandStateFailed:
-		record.Warn(hm, "InstallImageNotSuccessful", logFile)
 		s.scope.Error(nil, "custom provisioner failed", "logFile", logFile)
 
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
@@ -1185,7 +1182,6 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 				s.scope.Error(err, "failed to parse output.json", "outputJSON", outputJSON)
 				return reconcile.Result{}, fmt.Errorf("failed to parse: %w", err)
 			}
-			record.Warn(hm, "CustomProvisionerOutputJSON", outputJSON)
 			s.scope.Error(nil, "CustomProvisionerOutputJSON", "outputJSON", outputJSON)
 			if output.Message != "" {
 				msg = output.Message
@@ -1197,6 +1193,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		record.Warn(hm, "InstallImageNotSuccessful", msg)
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)

--- a/pkg/services/imageurlcommand/imageurlcommand.go
+++ b/pkg/services/imageurlcommand/imageurlcommand.go
@@ -24,9 +24,9 @@ import (
 
 // Output is the format of /root/output.json written by the image-url-command binary. Written
 // continuously during execution; presence and content are optional from CAPH's perspective. On
-// completion (success or failure) CAPH emits the full JSON as a Kubernetes Event (reason
-// "CustomProvisionerOutputJSON") and logs it to the controller log. CAPH reads only the top level
-// field "message" to write it to the corresponding message of the corresponding condition.
+// completion (success or failure) CAPH writes the full JSON to the controller log at key
+// "outputJSON". CAPH reads only the top level field "message" to write it to the corresponding
+// message of the corresponding condition.
 type Output struct {
 	Message string `json:"message,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Stopped emitting image-url-command's output.json as a Kubernetes event

**Which issue(s) this PR fixes:**
Fixes #2168

**Special notes for your reviewer**:
None