### PR TITLE
Reduce hcloud GetServer calls during machine provisioning

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -408,8 +408,6 @@ const (
 	HCloudMachineEnablingRescueActionFailedV1Beta2Reason = "EnablingRescueActionFailed"
 	// HCloudMachineEnablingRescueActionDoneV1Beta2Reason indicates the rescue enable action is done.
 	HCloudMachineEnablingRescueActionDoneV1Beta2Reason = "EnablingRescueActionDone"
-	// HCloudMachineRescueNotEnabledYetV1Beta2Reason indicates the rescue system is not enabled yet.
-	HCloudMachineRescueNotEnabledYetV1Beta2Reason = "RescueNotEnabledYet"
 
 	// HCloudMachineGettingSSHPrivateKeyFailedV1Beta2Reason indicates getting the SSH private key failed.
 	HCloudMachineGettingSSHPrivateKeyFailedV1Beta2Reason = "GettingSSHPrivateKeyFailed"
@@ -424,8 +422,6 @@ const (
 	HCloudMachineBootingToRescueV1Beta2Reason = "BootingToRescue"
 	// HCloudMachineBootingToRescueTimedOutV1Beta2Reason indicates booting to rescue mode timed out.
 	HCloudMachineBootingToRescueTimedOutV1Beta2Reason = "BootingToRescueTimedOut"
-	// HCloudMachineWaitForRescueEnabledToBeFalseV1Beta2Reason indicates waiting for rescue enabled to become false.
-	HCloudMachineWaitForRescueEnabledToBeFalseV1Beta2Reason = "WaitingForRescueEnabledToBeFalse"
 
 	// HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason indicates the image URL command is not accessible.
 	HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason = "ImageURLCommandNotAccessible"

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -455,8 +455,6 @@ const (
 	HCloudMachineEnablingRescueActionFailedReason = "EnablingRescueActionFailed"
 	// HCloudMachineEnablingRescueActionDoneReason indicates the rescue enable action is done.
 	HCloudMachineEnablingRescueActionDoneReason = "EnablingRescueActionDone"
-	// HCloudMachineRescueNotEnabledYetReason indicates the rescue system is not enabled yet.
-	HCloudMachineRescueNotEnabledYetReason = "RescueNotEnabledYet"
 
 	// HCloudMachineGettingSSHPrivateKeyFailedReason indicates getting the SSH private key failed.
 	HCloudMachineGettingSSHPrivateKeyFailedReason = "GettingSSHPrivateKeyFailed"
@@ -471,8 +469,6 @@ const (
 	HCloudMachineBootingToRescueReason = "BootingToRescue"
 	// HCloudMachineBootingToRescueTimedOutReason indicates booting to rescue mode timed out.
 	HCloudMachineBootingToRescueTimedOutReason = "BootingToRescueTimedOut"
-	// HCloudMachineWaitForRescueEnabledToBeFalseReason indicates waiting for rescue enabled to become false.
-	HCloudMachineWaitForRescueEnabledToBeFalseReason = "WaitingForRescueEnabledToBeFalse"
 
 	// HCloudMachineImageURLCommandNotAccessibleReason indicates the image URL command is not accessible.
 	HCloudMachineImageURLCommandNotAccessibleReason = "ImageURLCommandNotAccessible"

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -284,6 +284,9 @@ func (c *realClient) RebootServer(ctx context.Context, server *hcloud.Server) er
 
 func (c *realClient) PowerOnServer(ctx context.Context, server *hcloud.Server) error {
 	_, _, err := c.client.Server.Poweron(ctx, server)
+	if err != nil && strings.Contains(err.Error(), errStringUnauthorized) {
+		return fmt.Errorf("%w: %w", ErrUnauthorized, err)
+	}
 	return err
 }
 
@@ -337,6 +340,9 @@ func (c *realClient) AddServerToPlacementGroup(ctx context.Context, server *hclo
 func (c *realClient) EnableRescueSystem(ctx context.Context, server *hcloud.Server, rescueOpts *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
 	result, _, err := c.client.Server.EnableRescue(ctx, server, *rescueOpts)
 	if err != nil {
+		if strings.Contains(err.Error(), errStringUnauthorized) {
+			return result, fmt.Errorf("%w: EnableRescue failed for %d: %w", ErrUnauthorized, server.ID, err)
+		}
 		return result, fmt.Errorf("EnableRescue failed for %d: %w", server.ID, err)
 	}
 	return result, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -144,7 +144,17 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	var server *hcloud.Server
 
-	if s.scope.HCloudMachine.Spec.ProviderID != nil {
+	// Only fetch the live server for the states that actually need it (an "IsCreated" check,
+	// a server.Status transition, or the network/LB attachment reconcile). The remaining states
+	// (Initializing, EnablingRescue, BootingToRescue, RunningImageCommand) drive their progress
+	// via GetAction polling and/or SSH, so skipping the fetch there avoids an hcloud API call on
+	// every reconcile while we wait (see issue #2163).
+	bootState := s.scope.HCloudMachine.Status.BootState
+	needsLiveServer := bootState == infrav1.HCloudBootStateUnset ||
+		bootState == infrav1.HCloudBootStateBootingToRealOS ||
+		bootState == infrav1.HCloudBootStateOperatingSystemRunning
+
+	if s.scope.HCloudMachine.Spec.ProviderID != nil && needsLiveServer {
 		server, err = s.findServer(ctx)
 		if err != nil {
 			// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
@@ -221,23 +231,23 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 		"bootState", s.scope.HCloudMachine.Status.BootState,
 		"sinceBootStateChanged", sinceBootStateChanged)
 
-	switch s.scope.HCloudMachine.Status.BootState {
+	switch bootState {
 	case infrav1.HCloudBootStateUnset:
 		return s.handleBootStateUnset(ctx)
 	case infrav1.HCloudBootStateInitializing:
-		return s.handleBootStateInitializing(ctx, server)
+		return s.handleBootStateInitializing(ctx)
 	case infrav1.HCloudBootStateEnablingRescue:
-		return s.handleBootStateEnablingRescue(ctx, server)
+		return s.handleBootStateEnablingRescue(ctx)
 	case infrav1.HCloudBootStateBootingToRescue:
-		return s.handleBootStateBootingToRescue(ctx, server)
+		return s.handleBootStateBootingToRescue(ctx)
 	case infrav1.HCloudBootStateRunningImageCommand:
-		return s.handleBootStateRunningImageCommand(ctx, server)
+		return s.handleBootStateRunningImageCommand(ctx)
 	case infrav1.HCloudBootStateBootingToRealOS:
 		return s.handleBootingToRealOS(ctx, server)
 	case infrav1.HCloudBootStateOperatingSystemRunning:
 		return s.handleOperatingSystemRunning(ctx, server)
 	default:
-		return reconcile.Result{}, fmt.Errorf("unknown BootState: %s", s.scope.HCloudMachine.Status.BootState)
+		return reconcile.Result{}, fmt.Errorf("unknown BootState: %s", bootState)
 	}
 }
 
@@ -441,7 +451,7 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 }
 
 // handleBootStateInitializing is for provisioning with imageURL and image-url-command.
-func (s *Service) handleBootStateInitializing(ctx context.Context, server *hcloud.Server) (res reconcile.Result, reterr error) {
+func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcile.Result, reterr error) {
 	hm := s.scope.HCloudMachine
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
@@ -483,8 +493,6 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 		})
 		return reconcile.Result{}, nil
 	}
-
-	updateHCloudMachineStatusFromServer(hm, server)
 
 	// ActionIDCreateServer gets stored by createServerFromImageURL before the boot state becomes
 	// Initializing. This guard catches it early if that behavior ever changes.
@@ -599,7 +607,11 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 		Type:    hcloud.ServerRescueTypeLinux64,
 		SSHKeys: hcloudSSHKeys,
 	}
-	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, server, rescueOpts)
+	serverStub, err := s.serverStubFromProviderID()
+	if err != nil {
+		return res, fmt.Errorf("serverStubFromProviderID failed: %w", err)
+	}
+	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, serverStub, rescueOpts)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
@@ -637,7 +649,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context, server *hclou
 }
 
 // handleBootStateEnablingRescue is for provisioning with imageURL and image-url-command.
-func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcloud.Server) (reconcile.Result, error) {
+func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.Result, error) {
 	hm := s.scope.HCloudMachine
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
@@ -678,8 +690,6 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		})
 		return reconcile.Result{}, nil
 	}
-
-	updateHCloudMachineStatusFromServer(hm, server)
 
 	// ActionIDEnableRescueSystem gets stored by handleBootStateInitializing before the boot
 	// state becomes EnablingRescue. This guard catches it early if that behavior ever changes.
@@ -794,25 +804,17 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	if !server.RescueEnabled {
-		msg := "rescue system is not enabled yet? Requeue"
-		s.scope.Error(nil, msg)
-		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"RescueNotEnabledYet", clusterv1beta1.ConditionSeverityWarning,
-			"%s", msg)
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineRescueNotEnabledYetV1Beta2Reason,
-			Message: msg,
-		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	// The enable_rescue action (checked above) already reports success, which is the
+	// authoritative signal that the rescue system is enabled - no live GetServer call needed
+	// to double-check via server.RescueEnabled.
+	//
+	// The server was created with StartAfterCreate=false and has never been started, so
+	// powering it on boots it directly into the rescue system.
+	serverStub, err := s.serverStubFromProviderID()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("serverStubFromProviderID failed: %w", err)
 	}
-
-	// Now we know that the rescue-system was enabled. The server was created with
-	// StartAfterCreate=false and has never been started, so powering it on boots it
-	// directly into the rescue system.
-	if err := s.scope.HCloudClient.PowerOnServer(ctx, server); err != nil {
+	if err := s.scope.HCloudClient.PowerOnServer(ctx, serverStub); err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
 			// interval is enough
@@ -840,13 +842,14 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context, server *hcl
 		Reason:  infrav1.HCloudMachineBootingToRescueV1Beta2Reason,
 		Message: "power on to rescue started",
 	})
-	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	// The next state (BootingToRescue) polls purely via SSH, with no hcloud API cost, so
+	// requeue immediately instead of waiting.
+	return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 }
 
 // handleBootStateBootingToRescue is for provisioning with imageURL and image-url-command.
-func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hcloud.Server) (reconcile.Result, error) {
+func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile.Result, error) {
 	hm := s.scope.HCloudMachine
-	updateHCloudMachineStatusFromServer(hm, server)
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
 	if durationOfState > 6*time.Minute {
@@ -888,24 +891,10 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		return reconcile.Result{}, nil
 	}
 
-	if server.RescueEnabled {
-		// RescueEnabled is true until the server completes its reboot into the rescue system.
-		// Once the server has booted into rescue, Hetzner clears this flag automatically.
-		// We wait here until that happens before attempting to SSH.
-		msg := "Server has not yet rebooted into rescue system"
-		s.scope.Info(msg)
-		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-			"WaitingForRebootIntoRescue", clusterv1beta1.ConditionSeverityInfo,
-			"%s", msg)
-		v1beta2conditions.Set(hm, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineWaitForRescueEnabledToBeFalseV1Beta2Reason,
-			Message: msg,
-		})
-		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
+	// The server is freshly created and was never started before this boot cycle, so there is no
+	// prior OS it could mistakenly reach over SSH. Attempt SSH directly instead of first checking
+	// server.RescueEnabled via a live GetServer call - ECONNREFUSED below already covers "server
+	// has not yet rebooted into rescue system".
 	sshClient, err := s.getSSHClient(ctx)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (waiting for rescue running): %w", err)
@@ -927,7 +916,8 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 				Reason:  infrav1.HCloudMachineRetryingSSHConnectionV1Beta2Reason,
 				Message: msg,
 			})
-			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+			// Pure SSH retry, no hcloud API cost, so requeue immediately.
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
 		err = fmt.Errorf("get hostname failed: %w", err)
 		s.scope.Error(err, "")
@@ -1036,13 +1026,14 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 		Message: "custom provisioner running",
 	})
 	s.setBootState(infrav1.HCloudBootStateRunningImageCommand)
-	return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
+	// The next state (RunningImageCommand) polls purely via SSH, with no hcloud API cost, so
+	// requeue immediately instead of waiting.
+	return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 }
 
 // handleBootStateRunningImageCommand is for provisioning with imageURL and image-url-command.
-func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server *hcloud.Server) (res reconcile.Result, err error) {
+func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
-	updateHCloudMachineStatusFromServer(hm, server)
 
 	hcloudSSHClient, err := s.getSSHClient(ctx)
 	if err != nil {
@@ -1102,7 +1093,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {
 			s.scope.Error(err, "failed to read output.json")
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			// Pure SSH retry, no hcloud API cost, so requeue immediately.
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
 		msg := "custom provisioner running"
 
@@ -1112,7 +1104,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			output, err := imageurlcommand.Parse(outputJSON)
 			if err != nil {
 				s.scope.Error(err, "failed to parse image URL command output")
-				return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+				return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 			}
 
 			if output.Message != "" {
@@ -1128,7 +1120,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 			Reason:  infrav1.HCloudMachineCustomProvisionerRunningV1Beta2Reason,
 			Message: msg,
 		})
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 
 	case sshclient.ImageURLCommandStateFinishedSuccessfully:
 		// IMAGE_URL_DONE was found in the stdout.
@@ -1137,7 +1129,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {
 			s.scope.Error(err, "failed to read output.json")
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
 
 		s.scope.Info("CustomProvisionerOutputJSON", "outputJSON", outputJSON)
@@ -1172,7 +1164,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context, server
 		outputJSON, err := sshClient.ReadOutputJSON(ctx)
 		if err != nil {
 			s.scope.Error(err, "failed to read output.json")
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
 
 		msg := "custom provisioner failed"
@@ -2182,6 +2174,17 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 	)
 
 	return nil
+}
+
+// serverStubFromProviderID builds a minimal *hcloud.Server carrying only the ID parsed from
+// Spec.ProviderID. It is used for hcloud API calls (e.g. actions on a server) that only ever read
+// server.ID off the passed struct, so no live GetServer fetch is needed to obtain it.
+func (s *Service) serverStubFromProviderID() (*hcloud.Server, error) {
+	id, err := s.scope.ServerIDFromProviderID()
+	if err != nil {
+		return nil, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
+	}
+	return &hcloud.Server{ID: id}, nil
 }
 
 // findServer attempts to locate the HCloud server for the underlying HCloudMachine.

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -170,85 +170,6 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	}
 }
 
-// getLiveServer fetches the live hcloud server. It is only called by the two states
-// (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
-// network/LB attachment reconcile. The remaining states (Unset, Initializing, EnablingRescue,
-// BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
-// they never call this and avoid an hcloud API call on every reconcile while they wait.
-//
-// Unless it returns a live server together with an empty res and a nil err, the caller must return
-// (res, err) immediately. Some stop-paths (invalid token, rate limit, deleted server) deliberately
-// return an empty res and a nil err, so a nil server is a stop signal in its own right.
-func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error) {
-	server, err = s.findServer(ctx)
-	if err != nil {
-		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
-		// As there is no point retrying with invalid credentials.
-		if errors.Is(err, hcloudclient.ErrUnauthorized) {
-			v1beta1conditions.MarkFalse(
-				s.scope.HCloudMachine,
-				infrav1.HCloudTokenAvailableCondition,
-				infrav1.HCloudCredentialsInvalidReason,
-				clusterv1beta1.ConditionSeverityError,
-				"wrong hcloud token",
-			)
-			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-				Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-				Message: "wrong hcloud token",
-			})
-
-			return nil, reconcile.Result{}, nil
-		}
-
-		if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
-			if !s.scope.HCloudMachine.Status.Ready {
-				hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
-				return nil, reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-			}
-			return nil, reconcile.Result{}, nil
-		}
-
-		return nil, reconcile.Result{}, fmt.Errorf("findServer: %w", err)
-	}
-
-	v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
-	v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-		Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
-		Status: metav1.ConditionTrue,
-		Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
-	})
-
-	// findServer returns nil for both server and error if the server was not found.
-	if server == nil {
-		// The server no longer exists in HCloud, it was deleted.
-		// We set MachineError. CAPI will delete machine.
-		msg := fmt.Sprintf("hcloud server (%q) no longer available. Setting MachineError.",
-			*s.scope.HCloudMachine.Spec.ProviderID)
-
-		s.scope.Error(errors.New(msg), msg)
-
-		if err := s.scope.SetErrorAndRemediate(ctx, msg); err != nil {
-			return nil, reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err)
-		}
-		record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
-		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
-			"NoHCloudServerFound", clusterv1beta1.ConditionSeverityWarning,
-			"%s", msg)
-		v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-			Type:    infrav1.HCloudMachineServerAvailableV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.HCloudMachineServerNotFoundV1Beta2Reason,
-			Message: msg,
-		})
-		// no need to requeue.
-		return nil, reconcile.Result{}, nil
-	}
-
-	return server, reconcile.Result{}, nil
-}
-
 // handleBootStateUnset is first state for both ways (imageName/snapshot and imageURL).
 func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, error) {
 	hm := s.scope.HCloudMachine
@@ -519,20 +440,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcil
 	if hm.Status.ExternalIDs.ActionIDCreateServer != actionDone {
 		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDCreateServer)
 		if err != nil {
-			if errors.Is(err, hcloudclient.ErrUnauthorized) {
-				v1beta1conditions.MarkFalse(
-					hm,
-					infrav1.HCloudTokenAvailableCondition,
-					infrav1.HCloudCredentialsInvalidReason,
-					clusterv1beta1.ConditionSeverityError,
-					"wrong hcloud token",
-				)
-				v1beta2conditions.Set(hm, metav1.Condition{
-					Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-					Message: "wrong hcloud token",
-				})
+			if handleUnauthorized(hm, err) {
 				return reconcile.Result{}, nil
 			}
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
@@ -554,6 +462,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcil
 			})
 			return reconcile.Result{}, err
 		}
+		markHCloudTokenAvailable(hm)
 
 		if action.Finished.IsZero() {
 			// not finished yet.
@@ -605,12 +514,17 @@ func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcil
 		Type:    hcloud.ServerRescueTypeLinux64,
 		SSHKeys: hcloudSSHKeys,
 	}
+
 	serverID, err := s.scope.ServerIDFromProviderID()
 	if err != nil {
 		return res, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
 	}
+
 	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, &hcloud.Server{ID: serverID}, rescueOpts)
 	if err != nil {
+		if handleUnauthorized(hm, err) {
+			return reconcile.Result{}, nil
+		}
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
 			// interval is enough
@@ -627,6 +541,7 @@ func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcil
 		}
 		return res, handleRateLimit(hm, err, "EnableRescueSystem", "failed to enable rescue system")
 	}
+	markHCloudTokenAvailable(hm)
 
 	// The API of hetzner is async. We get an Action-ID as result. We need to wait until the action
 	// is done. After that we can power the server on, so that it boots into the rescue system.
@@ -712,20 +627,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 	if hm.Status.ExternalIDs.ActionIDEnableRescueSystem != actionDone {
 		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDEnableRescueSystem)
 		if err != nil {
-			if errors.Is(err, hcloudclient.ErrUnauthorized) {
-				v1beta1conditions.MarkFalse(
-					hm,
-					infrav1.HCloudTokenAvailableCondition,
-					infrav1.HCloudCredentialsInvalidReason,
-					clusterv1beta1.ConditionSeverityError,
-					"wrong hcloud token",
-				)
-				v1beta2conditions.Set(hm, metav1.Condition{
-					Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-					Message: "wrong hcloud token",
-				})
+			if handleUnauthorized(hm, err) {
 				return reconcile.Result{}, nil
 			}
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
@@ -747,6 +649,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 			})
 			return reconcile.Result{}, err
 		}
+		markHCloudTokenAvailable(hm)
 
 		if action.Finished.IsZero() {
 			// not finished yet.
@@ -809,6 +712,9 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 	// The server was created with StartAfterCreate=false and has never been started, so
 	// powering it on boots it directly into the rescue system.
 	if err := s.scope.HCloudClient.PowerOnServer(ctx, &hcloud.Server{ID: serverID}); err != nil {
+		if handleUnauthorized(hm, err) {
+			return reconcile.Result{}, nil
+		}
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
 			// interval is enough
@@ -825,6 +731,7 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 		}
 		return reconcile.Result{}, handleRateLimit(hm, err, "PowerOnServer", "failed to power on server")
 	}
+	markHCloudTokenAvailable(hm)
 
 	s.setBootState(infrav1.HCloudBootStateBootingToRescue)
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
@@ -1399,6 +1306,97 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconci
 		Reason: infrav1.HCloudMachineServerAvailableV1Beta2Reason,
 	})
 	return reconcile.Result{}, nil
+}
+
+// getLiveServer fetches the live hcloud server. It is only called by the two states
+// (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
+// network/LB attachment reconcile. The remaining states (Unset, Initializing, EnablingRescue,
+// BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
+// they never call this and avoid an hcloud API call on every reconcile while they wait.
+//
+// Unless it returns a live server together with an empty res and a nil err, the caller must return
+// (res, err) immediately. Some stop-paths (invalid token, rate limit, deleted server) deliberately
+// return an empty res and a nil err, so a nil server is a stop signal in its own right.
+func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error) {
+	server, err = s.findServer(ctx)
+	if err != nil {
+		if handleUnauthorized(s.scope.HCloudMachine, err) {
+			return nil, reconcile.Result{}, nil
+		}
+
+		if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+			if !s.scope.HCloudMachine.Status.Ready {
+				hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
+				return nil, reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			return nil, reconcile.Result{}, nil
+		}
+
+		return nil, reconcile.Result{}, fmt.Errorf("findServer: %w", err)
+	}
+	markHCloudTokenAvailable(s.scope.HCloudMachine)
+
+	// findServer returns nil for both server and error if the server was not found.
+	if server == nil {
+		// The server no longer exists in HCloud, it was deleted.
+		// We set MachineError. CAPI will delete machine.
+		msg := fmt.Sprintf("hcloud server (%q) no longer available. Setting MachineError.",
+			*s.scope.HCloudMachine.Spec.ProviderID)
+
+		s.scope.Error(errors.New(msg), msg)
+
+		if err := s.scope.SetErrorAndRemediate(ctx, msg); err != nil {
+			return nil, reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err)
+		}
+		record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
+		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+			"NoHCloudServerFound", clusterv1beta1.ConditionSeverityWarning,
+			"%s", msg)
+		v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineServerNotFoundV1Beta2Reason,
+			Message: msg,
+		})
+		// no need to requeue.
+		return nil, reconcile.Result{}, nil
+	}
+
+	return server, reconcile.Result{}, nil
+}
+
+// markHCloudTokenAvailable marks the HCloudTokenAvailableCondition as true. Call it after an
+// hcloud API call succeeds, so the condition reflects the outcome of the most recent call.
+func markHCloudTokenAvailable(hm *infrav1.HCloudMachine) {
+	v1beta1conditions.MarkTrue(hm, infrav1.HCloudTokenAvailableCondition)
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
+		Status: metav1.ConditionTrue,
+		Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
+	})
+}
+
+// handleUnauthorized marks the HCloudTokenAvailableCondition as false if err is the "wrong
+// hcloud token" error, and reports whether the caller should stop reconciling instead of
+// retrying - there is no point retrying with invalid credentials.
+func handleUnauthorized(hm *infrav1.HCloudMachine, err error) bool {
+	if !errors.Is(err, hcloudclient.ErrUnauthorized) {
+		return false
+	}
+	v1beta1conditions.MarkFalse(
+		hm,
+		infrav1.HCloudTokenAvailableCondition,
+		infrav1.HCloudCredentialsInvalidReason,
+		clusterv1beta1.ConditionSeverityError,
+		"wrong hcloud token",
+	)
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
+		Message: "wrong hcloud token",
+	})
+	return true
 }
 
 // implements setting rate limit on hcloudmachine.

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -176,7 +176,9 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 // BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
 // they never call this and avoid an hcloud API call on every reconcile while they wait.
 //
-// If server is nil, the caller must return (res, err) immediately.
+// Unless it returns a live server together with an empty res and a nil err, the caller must return
+// (res, err) immediately. Some stop-paths (invalid token, rate limit, deleted server) deliberately
+// return an empty res and a nil err, so a nil server is a stop signal in its own right.
 func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error) {
 	server, err = s.findServer(ctx)
 	if err != nil {
@@ -1205,7 +1207,7 @@ func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Resu
 	hm := s.scope.HCloudMachine
 
 	server, res, err := s.getLiveServer(ctx)
-	if server == nil {
+	if server == nil || err != nil || !res.IsZero() {
 		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)
@@ -1305,7 +1307,7 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconci
 	hm := s.scope.HCloudMachine
 
 	server, res, err := s.getLiveServer(ctx)
-	if server == nil {
+	if server == nil || err != nil || !res.IsZero() {
 		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -176,8 +176,8 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 // BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
 // they never call this and avoid an hcloud API call on every reconcile while they wait.
 //
-// If done is true, the caller must return (res, err) immediately. Otherwise server is non-nil.
-func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error, done bool) {
+// If server is nil, the caller must return (res, err) immediately.
+func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error) {
 	server, err = s.findServer(ctx)
 	if err != nil {
 		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
@@ -197,18 +197,18 @@ func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res
 				Message: "wrong hcloud token",
 			})
 
-			return nil, reconcile.Result{}, nil, true
+			return nil, reconcile.Result{}, nil
 		}
 
 		if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 			if !s.scope.HCloudMachine.Status.Ready {
 				hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
-				return nil, reconcile.Result{RequeueAfter: 30 * time.Second}, nil, true
+				return nil, reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 			}
-			return nil, reconcile.Result{}, nil, true
+			return nil, reconcile.Result{}, nil
 		}
 
-		return nil, reconcile.Result{}, fmt.Errorf("findServer: %w", err), true
+		return nil, reconcile.Result{}, fmt.Errorf("findServer: %w", err)
 	}
 
 	v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
@@ -228,7 +228,7 @@ func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res
 		s.scope.Error(errors.New(msg), msg)
 
 		if err := s.scope.SetErrorAndRemediate(ctx, msg); err != nil {
-			return nil, reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err), true
+			return nil, reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err)
 		}
 		record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
 		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
@@ -241,10 +241,10 @@ func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res
 			Message: msg,
 		})
 		// no need to requeue.
-		return nil, reconcile.Result{}, nil, true
+		return nil, reconcile.Result{}, nil
 	}
 
-	return server, reconcile.Result{}, nil, false
+	return server, reconcile.Result{}, nil
 }
 
 // handleBootStateUnset is first state for both ways (imageName/snapshot and imageURL).
@@ -1204,8 +1204,8 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	server, res, err, done := s.getLiveServer(ctx)
-	if done {
+	server, res, err := s.getLiveServer(ctx)
+	if server == nil {
 		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)
@@ -1304,8 +1304,8 @@ func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Resu
 func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	server, res, err, done := s.getLiveServer(ctx)
-	if done {
+	server, res, err := s.getLiveServer(ctx)
+	if server == nil {
 		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -141,92 +141,13 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.BootstrapReadyCondition)
 
-	var server *hcloud.Server
-
-	// Only fetch the live server for the states that actually need it (a server.Status
-	// transition, or the network/LB attachment reconcile). The remaining states (Unset,
-	// Initializing, EnablingRescue, BootingToRescue, RunningImageCommand) drive their progress
-	// via GetAction polling and/or SSH, so skipping the fetch there avoids an hcloud API call on
-	// every reconcile while we wait (see issue #2163).
-	bootState := s.scope.HCloudMachine.Status.BootState
-	needsLiveServer := bootState == infrav1.HCloudBootStateBootingToRealOS ||
-		bootState == infrav1.HCloudBootStateOperatingSystemRunning
-
-	if s.scope.HCloudMachine.Spec.ProviderID != nil && needsLiveServer {
-		server, err = s.findServer(ctx)
-		if err != nil {
-			// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
-			// As there is no point retrying with invalid credentials.
-			if errors.Is(err, hcloudclient.ErrUnauthorized) {
-				v1beta1conditions.MarkFalse(
-					s.scope.HCloudMachine,
-					infrav1.HCloudTokenAvailableCondition,
-					infrav1.HCloudCredentialsInvalidReason,
-					clusterv1beta1.ConditionSeverityError,
-					"wrong hcloud token",
-				)
-				v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-					Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-					Message: "wrong hcloud token",
-				})
-
-				return reconcile.Result{}, nil
-			}
-
-			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
-				if !s.scope.HCloudMachine.Status.Ready {
-					hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
-					return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-				}
-				return reconcile.Result{}, nil
-			}
-
-			return reconcile.Result{}, fmt.Errorf("findServer: %w", err)
-		}
-
-		v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
-		v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-			Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
-		})
-
-		// findServer returns nil for both server and error if the server was not found.
-		if server == nil {
-			// The server no longer exists in HCloud, it was deleted.
-			// We set MachineError. CAPI will delete machine.
-			msg := fmt.Sprintf("hcloud server (%q) no longer available. Setting MachineError.",
-				*s.scope.HCloudMachine.Spec.ProviderID)
-
-			s.scope.Error(errors.New(msg), msg)
-
-			err := s.scope.SetErrorAndRemediate(ctx, msg)
-			if err != nil {
-				return reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err)
-			}
-			record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
-			v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
-				"NoHCloudServerFound", clusterv1beta1.ConditionSeverityWarning,
-				"%s", msg)
-			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-				Type:    infrav1.HCloudMachineServerAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudMachineServerNotFoundV1Beta2Reason,
-				Message: msg,
-			})
-			// no need to requeue.
-			return reconcile.Result{}, nil
-		}
-	}
-
 	sinceBootStateChanged := time.Duration(0)
 	if !s.scope.HCloudMachine.Status.BootStateSince.IsZero() {
 		sinceBootStateChanged = time.Since(s.scope.HCloudMachine.Status.BootStateSince.Time).Round(time.Millisecond)
 	}
+	bootState := s.scope.HCloudMachine.Status.BootState
 	s.scope.V(1).Info("Reconciling BootState",
-		"bootState", s.scope.HCloudMachine.Status.BootState,
+		"bootState", bootState,
 		"sinceBootStateChanged", sinceBootStateChanged)
 
 	switch bootState {
@@ -241,12 +162,99 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	case infrav1.HCloudBootStateRunningImageCommand:
 		return s.handleBootStateRunningImageCommand(ctx)
 	case infrav1.HCloudBootStateBootingToRealOS:
-		return s.handleBootingToRealOS(ctx, server)
+		return s.handleBootingToRealOS(ctx)
 	case infrav1.HCloudBootStateOperatingSystemRunning:
-		return s.handleOperatingSystemRunning(ctx, server)
+		return s.handleOperatingSystemRunning(ctx)
 	default:
 		return reconcile.Result{}, fmt.Errorf("unknown BootState: %s", bootState)
 	}
+}
+
+// resultOrError carries the (result, error) pair getLiveServer wants its caller to return
+// immediately. Bundling them into one pointer (nil = keep going) makes it impossible for a caller
+// to observe a non-nil error without also seeing the signal to stop, unlike a separate `done
+// bool` alongside `err`.
+type resultOrError struct {
+	res reconcile.Result
+	err error
+}
+
+// getLiveServer fetches the live hcloud server. It is only called by the two states
+// (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
+// network/LB attachment reconcile. The remaining states (Unset, Initializing, EnablingRescue,
+// BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
+// they never call this and avoid an hcloud API call on every reconcile while they wait.
+//
+// If the returned *resultOrError is non-nil, the caller must return (its res, its err)
+// immediately. Otherwise server is non-nil and there is nothing to return early.
+func (s *Service) getLiveServer(ctx context.Context) (*hcloud.Server, *resultOrError) {
+	server, err := s.findServer(ctx)
+	if err != nil {
+		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
+		// As there is no point retrying with invalid credentials.
+		if errors.Is(err, hcloudclient.ErrUnauthorized) {
+			v1beta1conditions.MarkFalse(
+				s.scope.HCloudMachine,
+				infrav1.HCloudTokenAvailableCondition,
+				infrav1.HCloudCredentialsInvalidReason,
+				clusterv1beta1.ConditionSeverityError,
+				"wrong hcloud token",
+			)
+			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
+				Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
+				Message: "wrong hcloud token",
+			})
+
+			return nil, &resultOrError{}
+		}
+
+		if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+			if !s.scope.HCloudMachine.Status.Ready {
+				hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
+				return nil, &resultOrError{res: reconcile.Result{RequeueAfter: 30 * time.Second}}
+			}
+			return nil, &resultOrError{}
+		}
+
+		return nil, &resultOrError{err: fmt.Errorf("findServer: %w", err)}
+	}
+
+	v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
+	v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
+		Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
+		Status: metav1.ConditionTrue,
+		Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
+	})
+
+	// findServer returns nil for both server and error if the server was not found.
+	if server == nil {
+		// The server no longer exists in HCloud, it was deleted.
+		// We set MachineError. CAPI will delete machine.
+		msg := fmt.Sprintf("hcloud server (%q) no longer available. Setting MachineError.",
+			*s.scope.HCloudMachine.Spec.ProviderID)
+
+		s.scope.Error(errors.New(msg), msg)
+
+		if err := s.scope.SetErrorAndRemediate(ctx, msg); err != nil {
+			return nil, &resultOrError{err: fmt.Errorf("SetErrorAndRemediate failed: %w", err)}
+		}
+		record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
+		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
+			"NoHCloudServerFound", clusterv1beta1.ConditionSeverityWarning,
+			"%s", msg)
+		v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerAvailableV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineServerNotFoundV1Beta2Reason,
+			Message: msg,
+		})
+		// no need to requeue.
+		return nil, &resultOrError{}
+	}
+
+	return server, nil
 }
 
 // handleBootStateUnset is first state for both ways (imageName/snapshot and imageURL).
@@ -1201,8 +1209,13 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 }
 
 // handleBootingToRealOS is used for both ways (imageName/snapshot and imageURL).
-func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Server) (res reconcile.Result, err error) {
+func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
+
+	server, resultOrError := s.getLiveServer(ctx)
+	if resultOrError != nil {
+		return resultOrError.res, resultOrError.err
+	}
 	updateHCloudMachineStatusFromServer(hm, server)
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
@@ -1296,8 +1309,13 @@ func (s *Service) handleBootingToRealOS(ctx context.Context, server *hcloud.Serv
 }
 
 // handleOperatingSystemRunning is the final state. It is used for both ways (imageName/snapshot and imageURL).
-func (s *Service) handleOperatingSystemRunning(ctx context.Context, server *hcloud.Server) (res reconcile.Result, err error) {
+func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
+
+	server, resultOrError := s.getLiveServer(ctx)
+	if resultOrError != nil {
+		return resultOrError.res, resultOrError.err
+	}
 	updateHCloudMachineStatusFromServer(hm, server)
 
 	// Clean up old Status fields

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1310,9 +1310,10 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconci
 
 // getLiveServer fetches the live hcloud server. It is only called by the two states
 // (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
-// network/LB attachment reconcile. The remaining states (Unset, Initializing, EnablingRescue,
-// BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
-// they never call this and avoid an hcloud API call on every reconcile while they wait.
+// network/LB attachment reconcile. Unset does not call this because the server does not exist
+// yet. Initializing, EnablingRescue, BootingToRescue and RunningImageCommand drive their progress
+// via GetAction polling and/or SSH, so they never call this and avoid an hcloud API call on every
+// reconcile while they wait.
 //
 // Unless it returns a live server together with an empty res and a nil err, the caller must return
 // (res, err) immediately. Some stop-paths (invalid token, rate limit, deleted server) deliberately
@@ -1435,26 +1436,13 @@ func (s *Service) Delete(ctx context.Context) (reconcile.Result, error) {
 	if err != nil {
 		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
 		// As there is no point retrying with invalid credentials.
-		if errors.Is(err, hcloudclient.ErrUnauthorized) {
-			v1beta1conditions.MarkFalse(
-				s.scope.HCloudMachine,
-				infrav1.HCloudTokenAvailableCondition,
-				infrav1.HCloudCredentialsInvalidReason,
-				clusterv1beta1.ConditionSeverityError,
-				"wrong hcloud token",
-			)
-			v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-				Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-				Message: "wrong hcloud token",
-			})
-
+		if handleUnauthorized(s.scope.HCloudMachine, err) {
 			return reconcile.Result{}, nil
 		}
 
 		return reconcile.Result{}, handleRateLimit(s.scope.HCloudMachine, err, "findServer", "failed to find server for deletion")
 	}
+	markHCloudTokenAvailable(s.scope.HCloudMachine)
 
 	// if no server has been found, then nothing can be deleted
 	if server == nil {
@@ -2190,34 +2178,12 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	serverID, err := s.scope.ServerIDFromProviderID()
 	if err == nil {
 		server, err = s.scope.HCloudClient.GetServer(ctx, serverID)
+		// findServer stays a plain fetch. Its callers (getLiveServer, Delete) set the
+		// HCloudTokenAvailable condition from the result; GetServer already wraps a wrong-token
+		// error with ErrUnauthorized so they can detect it.
 		if err != nil {
-			// If it is an unauthorized error i.e. wrong HCloudToken, set HCloudCredentialsInvalid condition.
-			if errors.Is(err, hcloudclient.ErrUnauthorized) {
-				v1beta1conditions.MarkFalse(
-					s.scope.HCloudMachine,
-					infrav1.HCloudTokenAvailableCondition,
-					infrav1.HCloudCredentialsInvalidReason,
-					clusterv1beta1.ConditionSeverityError,
-					"wrong hcloud token",
-				)
-				v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-					Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
-					Status:  metav1.ConditionFalse,
-					Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
-					Message: "wrong hcloud token",
-				})
-				return nil, err
-			}
-
 			return nil, fmt.Errorf("failed to get server %d: %w", serverID, err)
 		}
-
-		v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
-		v1beta2conditions.Set(s.scope.HCloudMachine, metav1.Condition{
-			Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
-			Status: metav1.ConditionTrue,
-			Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
-		})
 
 		// if server has been found, return it
 		if server != nil {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -2178,9 +2178,6 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	serverID, err := s.scope.ServerIDFromProviderID()
 	if err == nil {
 		server, err = s.scope.HCloudClient.GetServer(ctx, serverID)
-		// findServer stays a plain fetch. Its callers (getLiveServer, Delete) set the
-		// HCloudTokenAvailable condition from the result; GetServer already wraps a wrong-token
-		// error with ErrUnauthorized so they can detect it.
 		if err != nil {
 			return nil, fmt.Errorf("failed to get server %d: %w", serverID, err)
 		}

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -804,10 +804,6 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	// The enable_rescue action (checked above) already reports success, which is the
-	// authoritative signal that the rescue system is enabled - no live GetServer call needed
-	// to double-check via server.RescueEnabled.
-	//
 	// The server was created with StartAfterCreate=false and has never been started, so
 	// powering it on boots it directly into the rescue system.
 	serverStub, err := s.serverStubFromProviderID()

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -170,25 +170,15 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 	}
 }
 
-// resultOrError carries the (result, error) pair getLiveServer wants its caller to return
-// immediately. Bundling them into one pointer (nil = keep going) makes it impossible for a caller
-// to observe a non-nil error without also seeing the signal to stop, unlike a separate `done
-// bool` alongside `err`.
-type resultOrError struct {
-	res reconcile.Result
-	err error
-}
-
 // getLiveServer fetches the live hcloud server. It is only called by the two states
 // (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
 // network/LB attachment reconcile. The remaining states (Unset, Initializing, EnablingRescue,
 // BootingToRescue, RunningImageCommand) drive their progress via GetAction polling and/or SSH, so
 // they never call this and avoid an hcloud API call on every reconcile while they wait.
 //
-// If the returned *resultOrError is non-nil, the caller must return (its res, its err)
-// immediately. Otherwise server is non-nil and there is nothing to return early.
-func (s *Service) getLiveServer(ctx context.Context) (*hcloud.Server, *resultOrError) {
-	server, err := s.findServer(ctx)
+// If done is true, the caller must return (res, err) immediately. Otherwise server is non-nil.
+func (s *Service) getLiveServer(ctx context.Context) (server *hcloud.Server, res reconcile.Result, err error, done bool) {
+	server, err = s.findServer(ctx)
 	if err != nil {
 		// If it is an unauthorized error i.e. wrong HCloudToken do not return an error.
 		// As there is no point retrying with invalid credentials.
@@ -207,18 +197,18 @@ func (s *Service) getLiveServer(ctx context.Context) (*hcloud.Server, *resultOrE
 				Message: "wrong hcloud token",
 			})
 
-			return nil, &resultOrError{}
+			return nil, reconcile.Result{}, nil, true
 		}
 
 		if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 			if !s.scope.HCloudMachine.Status.Ready {
 				hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudMachine, err, "findServer")
-				return nil, &resultOrError{res: reconcile.Result{RequeueAfter: 30 * time.Second}}
+				return nil, reconcile.Result{RequeueAfter: 30 * time.Second}, nil, true
 			}
-			return nil, &resultOrError{}
+			return nil, reconcile.Result{}, nil, true
 		}
 
-		return nil, &resultOrError{err: fmt.Errorf("findServer: %w", err)}
+		return nil, reconcile.Result{}, fmt.Errorf("findServer: %w", err), true
 	}
 
 	v1beta1conditions.MarkTrue(s.scope.HCloudMachine, infrav1.HCloudTokenAvailableCondition)
@@ -238,7 +228,7 @@ func (s *Service) getLiveServer(ctx context.Context) (*hcloud.Server, *resultOrE
 		s.scope.Error(errors.New(msg), msg)
 
 		if err := s.scope.SetErrorAndRemediate(ctx, msg); err != nil {
-			return nil, &resultOrError{err: fmt.Errorf("SetErrorAndRemediate failed: %w", err)}
+			return nil, reconcile.Result{}, fmt.Errorf("SetErrorAndRemediate failed: %w", err), true
 		}
 		record.Warn(s.scope.HCloudMachine, "NoHCloudServerFound", msg)
 		v1beta1conditions.MarkFalse(s.scope.HCloudMachine, infrav1.ServerAvailableCondition,
@@ -251,10 +241,10 @@ func (s *Service) getLiveServer(ctx context.Context) (*hcloud.Server, *resultOrE
 			Message: msg,
 		})
 		// no need to requeue.
-		return nil, &resultOrError{}
+		return nil, reconcile.Result{}, nil, true
 	}
 
-	return server, nil
+	return server, reconcile.Result{}, nil, false
 }
 
 // handleBootStateUnset is first state for both ways (imageName/snapshot and imageURL).
@@ -613,11 +603,11 @@ func (s *Service) handleBootStateInitializing(ctx context.Context) (res reconcil
 		Type:    hcloud.ServerRescueTypeLinux64,
 		SSHKeys: hcloudSSHKeys,
 	}
-	serverStub, err := s.serverStubFromProviderID()
+	serverID, err := s.scope.ServerIDFromProviderID()
 	if err != nil {
-		return res, fmt.Errorf("serverStubFromProviderID failed: %w", err)
+		return res, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
 	}
-	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, serverStub, rescueOpts)
+	result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, &hcloud.Server{ID: serverID}, rescueOpts)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
@@ -810,13 +800,13 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
+	serverID, err := s.scope.ServerIDFromProviderID()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
+	}
 	// The server was created with StartAfterCreate=false and has never been started, so
 	// powering it on boots it directly into the rescue system.
-	serverStub, err := s.serverStubFromProviderID()
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("serverStubFromProviderID failed: %w", err)
-	}
-	if err := s.scope.HCloudClient.PowerOnServer(ctx, serverStub); err != nil {
+	if err := s.scope.HCloudClient.PowerOnServer(ctx, &hcloud.Server{ID: serverID}); err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
 			// a fresh server is locked only for a short time after create, so a short retry
 			// interval is enough
@@ -844,9 +834,10 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 		Reason:  infrav1.HCloudMachineBootingToRescueV1Beta2Reason,
 		Message: "power on to rescue started",
 	})
-	// The next state (BootingToRescue) polls purely via SSH, with no hcloud API cost, so
-	// requeue immediately instead of waiting.
-	return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+	// The next state (BootingToRescue) polls via SSH, which costs no hcloud API calls, but
+	// powering on is not instant, so wait a bit before the first attempt instead of retrying
+	// immediately.
+	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
 // handleBootStateBootingToRescue is for provisioning with imageURL and image-url-command.
@@ -1028,9 +1019,10 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 		Message: "custom provisioner running",
 	})
 	s.setBootState(infrav1.HCloudBootStateRunningImageCommand)
-	// The next state (RunningImageCommand) polls purely via SSH, with no hcloud API cost, so
-	// requeue immediately instead of waiting.
-	return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+	// The next state (RunningImageCommand) polls via SSH, which costs no hcloud API calls, but
+	// the custom provisioner needs time to run, so wait a bit before the first attempt instead
+	// of retrying immediately.
+	return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
 }
 
 // handleBootStateRunningImageCommand is for provisioning with imageURL and image-url-command.
@@ -1212,9 +1204,9 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	server, resultOrError := s.getLiveServer(ctx)
-	if resultOrError != nil {
-		return resultOrError.res, resultOrError.err
+	server, res, err, done := s.getLiveServer(ctx)
+	if done {
+		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)
 
@@ -1312,9 +1304,9 @@ func (s *Service) handleBootingToRealOS(ctx context.Context) (res reconcile.Resu
 func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	server, resultOrError := s.getLiveServer(ctx)
-	if resultOrError != nil {
-		return resultOrError.res, resultOrError.err
+	server, res, err, done := s.getLiveServer(ctx)
+	if done {
+		return res, err
 	}
 	updateHCloudMachineStatusFromServer(hm, server)
 
@@ -2183,17 +2175,6 @@ func (s *Service) deleteServerOfLoadBalancer(ctx context.Context, server *hcloud
 	)
 
 	return nil
-}
-
-// serverStubFromProviderID builds a minimal *hcloud.Server carrying only the ID parsed from
-// Spec.ProviderID. It is used for hcloud API calls (e.g. actions on a server) that only ever read
-// server.ID off the passed struct, so no live GetServer fetch is needed to obtain it.
-func (s *Service) serverStubFromProviderID() (*hcloud.Server, error) {
-	id, err := s.scope.ServerIDFromProviderID()
-	if err != nil {
-		return nil, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
-	}
-	return &hcloud.Server{ID: id}, nil
 }
 
 // findServer attempts to locate the HCloud server for the underlying HCloudMachine.

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -144,14 +144,13 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 
 	var server *hcloud.Server
 
-	// Only fetch the live server for the states that actually need it (an "IsCreated" check,
-	// a server.Status transition, or the network/LB attachment reconcile). The remaining states
-	// (Initializing, EnablingRescue, BootingToRescue, RunningImageCommand) drive their progress
+	// Only fetch the live server for the states that actually need it (a server.Status
+	// transition, or the network/LB attachment reconcile). The remaining states (Unset,
+	// Initializing, EnablingRescue, BootingToRescue, RunningImageCommand) drive their progress
 	// via GetAction polling and/or SSH, so skipping the fetch there avoids an hcloud API call on
 	// every reconcile while we wait (see issue #2163).
 	bootState := s.scope.HCloudMachine.Status.BootState
-	needsLiveServer := bootState == infrav1.HCloudBootStateUnset ||
-		bootState == infrav1.HCloudBootStateBootingToRealOS ||
+	needsLiveServer := bootState == infrav1.HCloudBootStateBootingToRealOS ||
 		bootState == infrav1.HCloudBootStateOperatingSystemRunning
 
 	if s.scope.HCloudMachine.Spec.ProviderID != nil && needsLiveServer {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -520,6 +520,36 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 
+	It("marks HCloudTokenAvailable true when GetAction succeeds", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDEnableRescueSystem: 123456,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetAction", mock.Anything, int64(123456)).Return(&hcloud.Action{
+			ID:      123456,
+			Status:  hcloud.ActionStatusRunning,
+			Started: time.Now(),
+		}, nil).Once()
+
+		res, err := service.handleBootStateEnablingRescue(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+		Expect(v1beta1conditions.IsTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudTokenAvailableV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudTokenAvailableV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
 	It("routes GetAction rate-limit errors through handleRateLimit", func() {
 		hcloudMachine := &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -581,6 +611,37 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
 		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "PowerOnServerFailed")).To(BeTrue())
 		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachinePoweringOnServerFailedV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudMachine.Status.BootState).ToNot(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("sets HCloudTokenAvailable to false when PowerOnServer returns unauthorized", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.HCloudMachineSpec{
+				ProviderID: ptr.To("hcloud://1"),
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDEnableRescueSystem: actionDone,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(
+			fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
+
+		res, err := service.handleBootStateEnablingRescue(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudTokenAvailableV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudTokenInvalidV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudMachine.Status.BootState).ToNot(Equal(infrav1.HCloudBootStateBootingToRescue))
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
@@ -670,6 +731,123 @@ var _ = Describe("handleBootStateInitializing", func() {
 		Expect(err.Error()).To(ContainSubstring("GetAction failed"))
 		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "GettingServerCreationStatusFailed")).To(BeTrue())
 		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionUnknown, infrav1.HCloudMachineGettingServerCreationStatusFailedV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("marks HCloudTokenAvailable true when GetAction succeeds", func() {
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.Now(),
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDCreateServer: 998877,
+				},
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(&hcloud.Action{
+			ID:      998877,
+			Status:  hcloud.ActionStatusRunning,
+			Started: time.Now(),
+		}, nil).Once()
+
+		res, err := service.handleBootStateInitializing(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+		Expect(v1beta1conditions.IsTrue(hcloudMachine, infrav1.HCloudTokenAvailableCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudTokenAvailableV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudTokenAvailableV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("sets HCloudTokenAvailable to false when EnableRescueSystem returns unauthorized", func() {
+		hcloudClient := mocks.NewClient(GinkgoT())
+		machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
+			Client:    testEnv.GetClient(),
+			APIReader: testEnv.GetAPIReader(),
+
+			HCloudClient: hcloudClient,
+			Logger:       GinkgoLogr,
+
+			Cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clustername",
+					Namespace: "default",
+				},
+			},
+
+			HetznerCluster: &infrav1.HetznerCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "clustername",
+					Namespace: "default",
+				},
+				Spec: infrav1.HetznerClusterSpec{
+					HetznerSecret: infrav1.HetznerSecretRef{
+						Name: "secretname",
+						Key: infrav1.HetznerSecretKeyRef{
+							SSHKey: "hcloud-ssh-key-name",
+						},
+					},
+				},
+			},
+
+			HCloudMachine: &infrav1.HCloudMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-machine",
+					Namespace: "default",
+				},
+				Spec: infrav1.HCloudMachineSpec{
+					ProviderID: ptr.To("hcloud://1"),
+				},
+				Status: infrav1.HCloudMachineStatus{
+					BootStateSince: metav1.Now(),
+					ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+						ActionIDCreateServer: actionDone,
+					},
+				},
+			},
+
+			HetznerSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secretname",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"hcloud-ssh-key-name": []byte("sshKey1"),
+				},
+			},
+			Machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-machine",
+					Namespace: "default",
+				},
+			},
+			SSHClientFactory: testEnv.HCloudSSHClientFactory,
+		})
+		Expect(err).To(BeNil())
+
+		service := &Service{scope: machineScope}
+		hcloudMachine := service.scope.HCloudMachine
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:   1,
+				Name: "sshKey1",
+			},
+		}, nil).Once()
+		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(
+			hcloud.ServerEnableRescueResult{}, fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
+
+		res, err := service.handleBootStateInitializing(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudTokenAvailableV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudTokenInvalidV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 })

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1959,7 +1959,7 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 	)
 
 	BeforeEach(func() {
-		client := fakehcloudclient.NewHCloudClientFactory().NewClient("")
+		client := mocks.NewClient(GinkgoT())
 		server = newTestServer()
 
 		hcloudMachine = &infrav1.HCloudMachine{
@@ -1974,6 +1974,8 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 		}
 
 		service = newTestService(hcloudMachine, client)
+		service.scope.SetProviderID(server.ID)
+		client.On("GetServer", mock.Anything, server.ID).Return(server, nil)
 
 		// Mark capi Machine as control plane so the load balancer branch runs.
 		service.scope.Machine.Labels = map[string]string{
@@ -2007,7 +2009,7 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 			},
 		}
 
-		res, err := service.handleOperatingSystemRunning(context.Background(), server)
+		res, err := service.handleOperatingSystemRunning(context.Background())
 		Expect(err).To(Succeed())
 		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
 
@@ -2017,7 +2019,7 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 
 	It("sets Ready and ServerAvailableCondition when reconcileLoadBalancerAttachment returns an empty Result", func() {
 		// No load balancer → reconcileLoadBalancerAttachment returns an empty Result.
-		res, err := service.handleOperatingSystemRunning(context.Background(), server)
+		res, err := service.handleOperatingSystemRunning(context.Background())
 		Expect(err).To(Succeed())
 		Expect(res).To(Equal(reconcile.Result{}))
 

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1622,7 +1622,7 @@ var _ = Describe("Reconcile", func() {
 			}
 		}
 		GinkgoWriter.Printf("GetServer was called %d times during provisioning (imageURL)\n", getServerCalls)
-		Expect(getServerCalls).To(BeNumerically("<=", 1), "GetServer should not be called more than 1 time during imageURL provisioning (see issue #2163)")
+		Expect(getServerCalls).To(BeNumerically("<=", 1), "GetServer should not be called more than 1 time during imageURL provisioning")
 	})
 
 	It("ignores status in output.json when IMAGE_URL_DONE in stdout", func() {
@@ -1635,9 +1635,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1674,9 +1674,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1715,9 +1715,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1746,9 +1746,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1776,9 +1776,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1806,9 +1806,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1836,9 +1836,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// RunningImageCommand no longer fetches the live server (see issue #2163), so
-		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
-		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in RunningImageCommand, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}
@@ -1878,9 +1878,9 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateBootingToRescue
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		// BootingToRescue no longer fetches the live server or checks server.RescueEnabled
-		// (see issue #2163): it goes straight to SSH, so Status.Addresses (needed by
-		// getSSHClient) has to be set directly here.
+		// This state connects to the server over SSH, and getSSHClient reads the target IP from
+		// Status.Addresses. The full provisioning flow fills that in at server creation; this test
+		// starts in BootingToRescue, so it sets Status.Addresses directly.
 		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
 			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
 		}

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1149,7 +1149,12 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.On("GetServer", mock.Anything, int64(1234567)).Return(nil, nil)
 		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
 
-		By("calling reconcile")
+		By("reconciling once: the pre-BootState migration path sets BootingToRealOS without calling GetServer")
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
+
+		By("reconciling again: BootingToRealOS calls GetServer, which reports the server as gone")
 		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
 
@@ -1819,11 +1824,16 @@ var _ = Describe("Reconcile", func() {
 		By("setting the ProviderID on the HCloudMachine")
 		service.scope.HCloudMachine.Spec.ProviderID = ptr.To("hcloud://1234567")
 
+		By("reconciling once: the pre-BootState migration path sets BootingToRealOS without calling GetServer")
+		_, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
+
 		By("ensuring that the mock hcloud client return unauthorized error on GetServer")
 		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
 
 		By("calling reconcile")
-		_, err := service.Reconcile(ctx)
+		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
 
 		By("ensuring condition HCloudCredentialsInvalid is set")

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"syscall"
 	"testing"
 	"time"
 
@@ -510,10 +511,7 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		service := newTestService(hcloudMachine, hcloudClient)
 		hcloudClient.On("GetAction", mock.Anything, int64(123456)).Return(nil, fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
 
-		res, err := service.handleBootStateEnablingRescue(context.Background(), &hcloud.Server{
-			ID:     1,
-			Status: hcloud.ServerStatusRunning,
-		})
+		res, err := service.handleBootStateEnablingRescue(context.Background())
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{}))
@@ -543,10 +541,7 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		}
 		hcloudClient.On("GetAction", mock.Anything, int64(123456)).Return(nil, rateLimitErr).Once()
 
-		res, err := service.handleBootStateEnablingRescue(context.Background(), &hcloud.Server{
-			ID:     1,
-			Status: hcloud.ServerStatusRunning,
-		})
+		res, err := service.handleBootStateEnablingRescue(context.Background())
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
@@ -563,6 +558,9 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 				Name:      "my-machine",
 				Namespace: "default",
 			},
+			Spec: infrav1.HCloudMachineSpec{
+				ProviderID: ptr.To("hcloud://1"),
+			},
 			Status: infrav1.HCloudMachineStatus{
 				BootStateSince: metav1.Now(),
 				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
@@ -577,11 +575,7 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 			Message: "server is locked",
 		}).Once()
 
-		res, err := service.handleBootStateEnablingRescue(context.Background(), &hcloud.Server{
-			ID:            1,
-			RescueEnabled: true,
-			Status:        hcloud.ServerStatusOff,
-		})
+		res, err := service.handleBootStateEnablingRescue(context.Background())
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
@@ -617,10 +611,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 			ErrorMessage: "server creation failed",
 		}, nil).Once()
 
-		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
-			ID:     1,
-			Status: hcloud.ServerStatusOff,
-		})
+		res, err := service.handleBootStateInitializing(context.Background())
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{}))
@@ -644,10 +635,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 		hcloudClient := mocks.NewClient(GinkgoT())
 		service := newTestService(hcloudMachine, hcloudClient)
 
-		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
-			ID:     1,
-			Status: hcloud.ServerStatusOff,
-		})
+		res, err := service.handleBootStateInitializing(context.Background())
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{}))
@@ -675,10 +663,7 @@ var _ = Describe("handleBootStateInitializing", func() {
 		service := newTestService(hcloudMachine, hcloudClient)
 		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(nil, fmt.Errorf("hcloud is down")).Once()
 
-		res, err := service.handleBootStateInitializing(context.Background(), &hcloud.Server{
-			ID:     1,
-			Status: hcloud.ServerStatusOff,
-		})
+		res, err := service.handleBootStateInitializing(context.Background())
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
@@ -1324,11 +1309,6 @@ var _ = Describe("Reconcile", func() {
 
 		By("reconciling again: server create action not finished yet")
 		startTime := time.Now()
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:     1,
-			Name:   "my-machine",
-			Status: hcloud.ServerStatusOff,
-		}, nil).Once()
 		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(
 			&hcloud.Action{
 				ID:      998877,
@@ -1343,11 +1323,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
 
 		By("reconciling again: server create action finished, rescue system gets enabled")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:     1,
-			Name:   "my-machine",
-			Status: hcloud.ServerStatusOff,
-		}, nil).Once()
 		hcloudClient.On("GetAction", mock.Anything, int64(998877)).Return(
 			&hcloud.Action{
 				ID:       998877,
@@ -1378,12 +1353,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
 		By("reconcile again: enable rescue action finished ---------------------------")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:            1,
-			Name:          "my-machine",
-			RescueEnabled: true,
-			Status:        hcloud.ServerStatusOff,
-		}, nil).Once()
 		hcloudClient.On("GetAction", mock.Anything, int64(334455)).Return(
 			&hcloud.Action{
 				ID:           334455,
@@ -1405,12 +1374,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
 		By("reconcile again: server gets powered on ---------------------------------")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:            1,
-			Name:          "my-machine",
-			RescueEnabled: true,
-			Status:        hcloud.ServerStatusOff,
-		}, nil).Once()
 		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(nil).Once()
 		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
@@ -1420,11 +1383,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
 
 		By("reconcile again --------------------------------------------------------")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:     1,
-			Name:   "hcloudmachinenameWithRescueEnabled",
-			Status: hcloud.ServerStatusRunning,
-		}, nil).Once()
 		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: "rescue",
 			StdErr: "",
@@ -1452,12 +1410,6 @@ var _ = Describe("Reconcile", func() {
 			StdOut: "ok",
 			StdErr: "",
 		})
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
-			ID:            1,
-			Name:          "hcloudmachinenameWithRescueEnabled",
-			RescueEnabled: true,
-			Status:        hcloud.ServerStatusRunning,
-		}, nil).Once()
 		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
@@ -1477,6 +1429,15 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
 		By("ensuring the bootstate has transitioned to OperatingSystemRunning")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
+
+		getServerCalls := 0
+		for _, call := range hcloudClient.Calls {
+			if call.Method == "GetServer" {
+				getServerCalls++
+			}
+		}
+		GinkgoWriter.Printf("GetServer was called %d times during provisioning (imageURL)\n", getServerCalls)
+		Expect(getServerCalls).To(BeNumerically("<=", 1), "GetServer should not be called more than 1 time during imageURL provisioning (see issue #2163)")
 	})
 
 	It("ignores status in output.json when IMAGE_URL_DONE in stdout", func() {
@@ -1489,8 +1450,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command finished but output.json reports failure")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFinishedSuccessfully, "logfile", nil)
@@ -1524,8 +1489,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command still running, output.json has a progress message")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
@@ -1534,7 +1503,7 @@ var _ = Describe("Reconcile", func() {
 		By("reconciling")
 		result, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
-		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+		Expect(result.RequeueAfter).To(Equal(requeueImmediately))
 
 		By("ensuring the machine stays in RunningImageCommand")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
@@ -1561,8 +1530,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command still running, output.json not written yet")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
@@ -1588,8 +1561,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command running, but reading output.json fails")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
@@ -1598,7 +1575,7 @@ var _ = Describe("Reconcile", func() {
 		By("reconciling")
 		result, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
-		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+		Expect(result.RequeueAfter).To(Equal(requeueImmediately))
 
 		By("ensuring the machine stays in RunningImageCommand")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
@@ -1614,8 +1591,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command running, output.json is malformed JSON")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateRunning, "", nil)
@@ -1624,7 +1605,7 @@ var _ = Describe("Reconcile", func() {
 		By("reconciling")
 		result, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())
-		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+		Expect(result.RequeueAfter).To(Equal(requeueImmediately))
 
 		By("ensuring the machine stays in RunningImageCommand")
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
@@ -1640,8 +1621,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command failed, output.json is malformed JSON")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFailed, "some logs", nil)
@@ -1666,8 +1651,12 @@ var _ = Describe("Reconcile", func() {
 		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateRunningImageCommand
 		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
 
-		By("mocking GetServer to return server 42 (which has IP 1.2.3.4)")
-		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(newTestServer(), nil).Once()
+		// RunningImageCommand no longer fetches the live server (see issue #2163), so
+		// Status.Addresses (needed by getSSHClient) has to be set directly, mirroring what
+		// updateHCloudMachineStatusFromServer would have set from newTestServer() (IP 1.2.3.4).
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
 
 		By("mocking SSH: command failed, output.json has a message")
 		testEnv.HCloudSSHClient.On("StateOfImageURLCommand", mock.Anything).Return(sshclient.ImageURLCommandStateFailed, "some logs", nil)
@@ -1682,6 +1671,60 @@ var _ = Describe("Reconcile", func() {
 		c := v1beta1conditions.Get(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition)
 		Expect(c).ToNot(BeNil())
 		Expect(c.Message).To(Equal("disk full"))
+	})
+
+	It("never calls GetServer while waiting for SSH in BootingToRescue, including after an ECONNREFUSED retry", func() {
+		By("setting bootstrap data ready and machine in BootingToRescue state")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+		service.scope.HCloudMachine.Spec.ImageName = ""
+		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
+		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-test.sh"
+		service.scope.HCloudMachine.Spec.ProviderID = ptr.To("hcloud://42")
+		service.scope.HCloudMachine.Status.BootState = infrav1.HCloudBootStateBootingToRescue
+		service.scope.HCloudMachine.Status.BootStateSince = metav1.Now()
+
+		// BootingToRescue no longer fetches the live server or checks server.RescueEnabled
+		// (see issue #2163): it goes straight to SSH, so Status.Addresses (needed by
+		// getSSHClient) has to be set directly here.
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
+
+		By("mocking SSH: connection refused, server has not rebooted into rescue yet")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			Err: syscall.ECONNREFUSED,
+		}).Once()
+
+		By("reconciling: still waiting for the reboot into rescue")
+		result, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(result.RequeueAfter).To(Equal(requeueImmediately))
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
+
+		By("mocking SSH: rescue system now reachable")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			StdOut: "rescue",
+		})
+		startImageURLCommandMock := testEnv.HCloudSSHClient.On("StartImageURLCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "my-machine", []string{"sda"}).Return(0, "", nil)
+
+		By("reconciling again: rescue system reachable, custom provisioner starts")
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
+		startImageURLCommandMock.Parent.AssertNumberOfCalls(GinkgoT(), "StartImageURLCommand", 1)
+
+		By("ensuring GetServer was never called")
+		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
 	})
 
 	It("sets condition HCloudCredentialsInvalid when HCloud API returns 'unauthorized' error while creating a server", func() {


### PR DESCRIPTION
## Summary
- `Reconcile()` fetched the live hcloud server unconditionally at the top of every call, even for `BootState`s (`Initializing`, `EnablingRescue`, `BootingToRescue`, `RunningImageCommand`) that only need `GetAction` polling or SSH to make progress.
- Skips the `GetServer` fetch for those four states, and drops the now-redundant `server.RescueEnabled` re-checks — the `enable_rescue` action result is already the authoritative signal, so `BootingToRescue` goes straight to SSH (an `ECONNREFUSED` retry already covered "not rebooted yet").
- The two remaining hcloud calls that only needed `server.ID` (`EnableRescueSystem`, `PowerOnServer`) now use a `server_id`-only stub built from `Spec.ProviderID`, avoiding a live fetch just to get an ID we already know.
- Tightens `RequeueAfter` to immediate for the states that are now hcloud-API-free (pure SSH), so provisioning can proceed as fast as SSH allows instead of waiting on a fixed interval. States that still poll `GetAction`/`GetServer` keep their existing interval, since tightening those would multiply hcloud API calls instead of reducing them.
- Net effect: `GetServer` calls during a full imageURL provisioning run drop from 7 to 1 (only the `BootingToRealOS` poll remains, since `server.Status` has no SSH substitute).

Relates to #2163
