### PR TITLE
🐛 Fix HetznerBareMetalHost spec.status.hetznerClusterRef Required value error

### DIFF
--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -258,8 +258,8 @@ type ControllerGeneratedStatus struct {
 	// HetznerClusterRef is the name of the HetznerCluster object which is
 	// needed as some necessary information is stored there, e.g. the hrobot password.
 	// It is empty until the host is claimed by a HetznerBareMetalMachine.
-	// +kubebuilder:default:=""
-	HetznerClusterRef string `json:"hetznerClusterRef"`
+	// +optional
+	HetznerClusterRef string `json:"hetznerClusterRef,omitempty"`
 
 	// UserData holds the reference to the Secret containing the user
 	// data to be passed to the host before it boots.

--- a/api/v1beta1/hetznerbaremetalhost_types.go
+++ b/api/v1beta1/hetznerbaremetalhost_types.go
@@ -257,6 +257,8 @@ type HetznerBareMetalHostSpec struct {
 type ControllerGeneratedStatus struct {
 	// HetznerClusterRef is the name of the HetznerCluster object which is
 	// needed as some necessary information is stored there, e.g. the hrobot password.
+	// It is empty until the host is claimed by a HetznerBareMetalMachine.
+	// +kubebuilder:default:=""
 	HetznerClusterRef string `json:"hetznerClusterRef"`
 
 	// UserData holds the reference to the Secret containing the user

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -336,9 +336,11 @@ spec:
                         type: array
                     type: object
                   hetznerClusterRef:
+                    default: ""
                     description: |-
                       HetznerClusterRef is the name of the HetznerCluster object which is
                       needed as some necessary information is stored there, e.g. the hrobot password.
+                      It is empty until the host is claimed by a HetznerBareMetalMachine.
                     type: string
                   installImage:
                     description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerbaremetalhosts.yaml
@@ -336,7 +336,6 @@ spec:
                         type: array
                     type: object
                   hetznerClusterRef:
-                    default: ""
                     description: |-
                       HetznerClusterRef is the name of the HetznerCluster object which is
                       needed as some necessary information is stored there, e.g. the hrobot password.
@@ -765,7 +764,6 @@ spec:
                     type: object
                 required:
                 - errorCount
-                - hetznerClusterRef
                 type: object
             required:
             - serverID

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -333,6 +334,46 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 			Eventually(func() bool {
 				return apierrors.IsNotFound(testEnv.Get(ctx, key, host))
 			}, timeout, time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("Fresh, unclaimed host (as created by a user, before any machine claims it)", func() {
+		It("persists status without hitting the spec.status.hetznerClusterRef required-field validation error", func() {
+			// Unlike the other hosts in this suite (created via helpers.BareMetalHost + the typed
+			// client, which always marshals HetznerClusterRef as "" since the field lacks
+			// omitempty), this one is created the way a real user creates it: via an unstructured
+			// object carrying only what a plain YAML manifest would contain. That means no
+			// "status" key under spec at all, matching how kubectl/GitOps actually submits a new
+			// HetznerBareMetalHost. HetznerClusterRef is only set once a HetznerBareMetalMachine
+			// claims the host (see setHostSpec), so for a fresh, unclaimed host spec.status starts
+			// out completely absent from the stored object - not merely present-with-empty-string.
+			freshHostName := utils.GenerateName(nil, "fresh-host")
+			freshHost := &unstructured.Unstructured{}
+			freshHost.SetGroupVersionKind(infrav1.GroupVersion.WithKind("HetznerBareMetalHost"))
+			freshHost.SetName(freshHostName)
+			freshHost.SetNamespace(testNs.Name)
+			Expect(unstructured.SetNestedField(freshHost.Object, int64(987654321), "spec", "serverID")).To(Succeed())
+			Expect(testEnv.Create(ctx, freshHost)).To(Succeed())
+			defer func() {
+				Expect(testEnv.Cleanup(ctx, freshHost)).To(Succeed())
+			}()
+
+			freshKey := client.ObjectKey{Namespace: testNs.Name, Name: freshHostName}
+
+			// The very first status patch the reconciler ever issues for this host (adding
+			// the finalizer together with the initial v1beta2 Ready condition) introduces
+			// spec.status for the first time. Before the fix, that patch never included
+			// hetznerClusterRef (unchanged, so omitted from the merge patch), and the API
+			// server rejected the result because spec.status did not exist yet and
+			// hetznerClusterRef had no default. That made this Eventually block time out
+			// forever instead of observing the v1beta2 conditions appear.
+			typedHost := &infrav1.HetznerBareMetalHost{}
+			Eventually(func() []metav1.Condition {
+				if err := testEnv.Get(ctx, freshKey, typedHost); err != nil {
+					return nil
+				}
+				return typedHost.GetV1Beta2Conditions()
+			}, timeout).ShouldNot(BeEmpty())
 		})
 	})
 

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -340,9 +340,9 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 	Context("Fresh, unclaimed host (as created by a user, before any machine claims it)", func() {
 		It("persists status without hitting the spec.status.hetznerClusterRef required-field validation error", func() {
 			// Unlike the other hosts in this suite (created via helpers.BareMetalHost + the typed
-			// client, which always marshals HetznerClusterRef as "" since the field lacks
-			// omitempty), this one is created the way a real user creates it: via an unstructured
-			// object carrying only what a plain YAML manifest would contain. That means no
+			// client, which always marshals a spec.status object, empty or not), this one is
+			// created the way a real user creates it: via an unstructured object carrying only
+			// what a plain YAML manifest would contain. That means no
 			// "status" key under spec at all, matching how kubectl/GitOps actually submits a new
 			// HetznerBareMetalHost. HetznerClusterRef is only set once a HetznerBareMetalMachine
 			// claims the host (see setHostSpec), so for a fresh, unclaimed host spec.status starts
@@ -365,8 +365,8 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 			// spec.status for the first time. Before the fix, that patch never included
 			// hetznerClusterRef (unchanged, so omitted from the merge patch), and the API
 			// server rejected the result because spec.status did not exist yet and
-			// hetznerClusterRef had no default. That made this Eventually block time out
-			// forever instead of observing the v1beta2 conditions appear.
+			// hetznerClusterRef was a required field. That made this Eventually block time
+			// out forever instead of observing the v1beta2 conditions appear.
 			typedHost := &infrav1.HetznerBareMetalHost{}
 			Eventually(func() []metav1.Condition {
 				if err := testEnv.Get(ctx, freshKey, typedHost); err != nil {


### PR DESCRIPTION
## Summary

A freshly created, unclaimed `HetznerBareMetalHost` (created the way a real user/GitOps manifest would — `spec.status` absent entirely, only `spec.serverID` set) fails its very first reconcile with:

```
HetznerBareMetalHost.infrastructure.cluster.x-k8s.io "bm-8" is invalid: spec.status.hetznerClusterRef: Required value
```

- `HetznerClusterRef` is only ever set once a `HetznerBareMetalMachine` claims the host ([setHostSpec](pkg/services/baremetal/baremetal/baremetal.go)). Until then it stays `""`, and — for a host created via a plain manifest — `spec.status` is absent from etcd entirely (not merely present-with-empty-string).
- The reconciler's deferred patch ([controllers/hetznerbaremetalhost_controller.go](controllers/hetznerbaremetalhost_controller.go)) unconditionally adds the finalizer and the initial v1beta2 `Ready` condition on the very first reconcile, in one merge patch. Since `hetznerClusterRef` doesn't change (still `""` before/after), it's omitted from the computed merge patch.
- The API server merges that patch into the (previously absent) `spec.status`, producing an object where `errorCount` gets its default (`0`) applied, but `hetznerClusterRef` — which had no default — stays absent, so the CRD's `required` constraint on `spec.status.hetznerClusterRef` rejects it.
- The host then retries the exact same failing patch forever (until, if ever, a machine claims it and sets `hetznerClusterRef` in the same patch as everything else).

Confirmed on a live cluster: an unclaimed host sat in this failure loop continuously; `kubectl patch --type=merge` reproduces the exact error against an unmodified checkout.

## Fix

Give `HetznerClusterRef` a `+kubebuilder:default:=""`, mirroring the existing `+kubebuilder:default:=0` already used for `ErrorCount` in the same struct. This lets the API server fill in the empty default whenever the field is omitted from a partial status patch, exactly like `ErrorCount` already does.
