### PR TITLE
✨ Add status.controlPlaneLoadBalancer.proxyProtocolEnabled

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -257,6 +257,13 @@ type LoadBalancerStatus struct {
 	InternalIP string               `json:"internalIP,omitempty"`
 	Target     []LoadBalancerTarget `json:"targets,omitempty"`
 	Protected  bool                 `json:"protected,omitempty"`
+
+	// ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+	// has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+	// behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+	// protocol is in progress (see the field's docs for details).
+	// +optional
+	ProxyProtocolEnabled bool `json:"proxyProtocolEnabled,omitempty"`
 }
 
 // LoadBalancerTarget defines the target of a load balancer.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -454,6 +454,13 @@ spec:
                     type: string
                   protected:
                     type: boolean
+                  proxyProtocolEnabled:
+                    description: |-
+                      ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+                      has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+                      behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+                      protocol is in progress (see the field's docs for details).
+                    type: boolean
                   targets:
                     items:
                       description: LoadBalancerTarget defines the target of a load

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -117,7 +117,7 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 		}
 	}
 
-	s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = statusFromHCloudLB(lb, s.scope.HetznerCluster.Status.Network != nil, log)
+	s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = statusFromHCloudLB(lb, s.scope.HetznerCluster.Status.Network != nil, kubeAPIServicePortFromSpec(s.scope.HetznerCluster), log)
 
 	// check whether load balancer name, algorithm or type has been changed
 	if err := s.reconcileLBProperties(ctx, lb); err != nil {
@@ -300,11 +300,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 		existingServicesByPort[service.ListenPort] = service
 	}
 
-	// ControlPlaneEndpoint is a pointer in v1beta1; zero-value port means unknown.
-	var kubeAPIServicePort int
-	if s.scope.HetznerCluster.Spec.ControlPlaneEndpoint != nil {
-		kubeAPIServicePort = int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port)
-	}
+	kubeAPIServicePort := kubeAPIServicePortFromSpec(s.scope.HetznerCluster)
 
 	for _, serviceInSpec := range extraServicesSpec {
 		wantServiceListenPorts = append(wantServiceListenPorts, serviceInSpec.ListenPort)
@@ -678,8 +674,17 @@ func (s *Service) ownExistingLoadBalancer(ctx context.Context) (*hcloud.LoadBala
 	return lb, nil
 }
 
+// kubeAPIServicePortFromSpec returns the listen port of the kube-apiserver load balancer service.
+// ControlPlaneEndpoint is a pointer in v1beta1; a returned 0 means the port is not known yet.
+func kubeAPIServicePortFromSpec(hc *infrav1.HetznerCluster) int {
+	if hc.Spec.ControlPlaneEndpoint == nil {
+		return 0
+	}
+	return int(hc.Spec.ControlPlaneEndpoint.Port)
+}
+
 // statusFromHCloudLB gets the information of the Hetzner load balancer and returns it in the status object.
-func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, log logr.Logger) *infrav1.LoadBalancerStatus {
+func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, kubeAPIServicePort int, log logr.Logger) *infrav1.LoadBalancerStatus {
 	var internalIP string
 	if hasNetwork && len(lb.PrivateNet) > 0 {
 		internalIP = lb.PrivateNet[0].IP.String()
@@ -705,12 +710,21 @@ func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, log logr.Logge
 		}
 	}
 
+	var proxyProtocolEnabled bool
+	for _, service := range lb.Services {
+		if service.ListenPort == kubeAPIServicePort {
+			proxyProtocolEnabled = service.Proxyprotocol
+			break
+		}
+	}
+
 	return &infrav1.LoadBalancerStatus{
-		ID:         lb.ID,
-		IPv4:       lb.PublicNet.IPv4.IP.String(),
-		IPv6:       lb.PublicNet.IPv6.IP.String(),
-		InternalIP: internalIP,
-		Target:     targetObjects,
-		Protected:  lb.Protection.Delete,
+		ID:                   lb.ID,
+		IPv4:                 lb.PublicNet.IPv4.IP.String(),
+		IPv6:                 lb.PublicNet.IPv6.IP.String(),
+		InternalIP:           internalIP,
+		Target:               targetObjects,
+		Protected:            lb.Protection.Delete,
+		ProxyProtocolEnabled: proxyProtocolEnabled,
 	}
 }

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -393,6 +393,12 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 				return reconcile.Result{}, multierr
 			}
+		} else if listenPort == kubeAPIServicePort {
+			// Status.ControlPlaneLoadBalancer was snapshotted from the LB state fetched at the
+			// start of Reconcile, before this service was (re)created, so it still shows the old
+			// value. Update it now so callers observe the change in this reconcile instead of
+			// waiting for the next one (e.g. the next full resync, up to --sync-period later).
+			s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled = proxyProtocol
 		}
 	}
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loadbalancer
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-logr/logr"
@@ -26,6 +27,8 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
+	fakeclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/fake"
 )
 
 var _ = Describe("Loadbalancer", func() {
@@ -86,6 +89,39 @@ var _ = Describe("Loadbalancer", func() {
 			sts := statusFromHCloudLB(lb, false, 6443, logr.Discard())
 			Expect(sts.ProxyProtocolEnabled).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("reconcileServices", func() {
+	It("sets status.controlPlaneLoadBalancer.proxyProtocolEnabled as soon as the kube-API service is created with proxy protocol, without waiting for the next reconcile", func() {
+		hcloudClient := fakeclient.NewHCloudClientFactory().NewClient("")
+		createdLB, err := hcloudClient.CreateLoadBalancer(context.Background(), hcloud.LoadBalancerCreateOpts{
+			Name:      "test-lb",
+			Algorithm: &hcloud.LoadBalancerAlgorithm{Type: hcloud.LoadBalancerAlgorithmTypeRoundRobin},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		hetznerCluster := &infrav1.HetznerCluster{
+			Spec: infrav1.HetznerClusterSpec{
+				ControlPlaneEndpoint: &clusterv1beta1.APIEndpoint{Port: 6443},
+				ControlPlaneLoadBalancer: infrav1.LoadBalancerSpec{
+					Enabled:             true,
+					EnableProxyProtocol: true,
+					Port:                6443,
+				},
+			},
+			Status: infrav1.HetznerClusterStatus{
+				// Simulates the snapshot taken from the LB state at the start of Reconcile,
+				// before the kube-API service (and thus proxy protocol) existed on the LB.
+				ControlPlaneLoadBalancer: &infrav1.LoadBalancerStatus{},
+			},
+		}
+
+		svc := &Service{&scope.ClusterScope{HetznerCluster: hetznerCluster, HCloudClient: hcloudClient}}
+
+		_, err = svc.reconcileServices(context.Background(), createdLB)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled).To(BeTrue())
 	})
 })
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Loadbalancer", func() {
 	Context("hcloud cluster has network attached", func() {
 		var sts *infrav1.LoadBalancerStatus
 		BeforeEach(func() {
-			sts = statusFromHCloudLB(lb, true, logr.Discard())
+			sts = statusFromHCloudLB(lb, true, 443, logr.Discard())
 		})
 
 		It("should have two targets", func() {
@@ -48,11 +48,14 @@ var _ = Describe("Loadbalancer", func() {
 		It("should be unprotected", func() {
 			Expect(sts.Protected).To(Equal(protected))
 		})
+		It("should have proxy protocol disabled", func() {
+			Expect(sts.ProxyProtocolEnabled).To(BeFalse())
+		})
 	})
 	Context("hcloud cluster has no network attached", func() {
 		var sts *infrav1.LoadBalancerStatus
 		BeforeEach(func() {
-			sts = statusFromHCloudLB(lb, false, logr.Discard())
+			sts = statusFromHCloudLB(lb, false, 443, logr.Discard())
 		})
 
 		It("should have two targets", func() {
@@ -67,6 +70,21 @@ var _ = Describe("Loadbalancer", func() {
 		})
 		It("should be unprotected", func() {
 			Expect(sts.Protected).To(Equal(protected))
+		})
+	})
+	Context("proxy protocol detection", func() {
+		It("reports enabled when the kube-API service has proxy protocol on", func() {
+			lbWithProxyProtocol := &hcloud.LoadBalancer{
+				Services: []hcloud.LoadBalancerService{
+					{ListenPort: 6443, Proxyprotocol: true},
+				},
+			}
+			sts := statusFromHCloudLB(lbWithProxyProtocol, false, 6443, logr.Discard())
+			Expect(sts.ProxyProtocolEnabled).To(BeTrue())
+		})
+		It("reports disabled when the kube-API port has no matching service", func() {
+			sts := statusFromHCloudLB(lb, false, 6443, logr.Discard())
+			Expect(sts.ProxyProtocolEnabled).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Adds `status.controlPlaneLoadBalancer.proxyProtocolEnabled` (bool) to `HetznerCluster`
- Reflects whether the kube-apiserver load balancer service currently has proxy protocol enabled, as observed on the actual HCloud load balancer service
- Follow-up to #2113 / its release-1.1 backport (#2132), which added `spec.controlPlaneLoadBalancer.enableProxyProtocol`. Since enabling proxy protocol on existing clusters is a gated migration (waiting for all control-plane nodes to carry an annotation before the LB service is recreated), the spec field alone doesn't tell you whether it has actually taken effect yet — this status field does.
- Updates the new status field in the same reconcile that actually enables proxy protocol on the LB, instead of only on the next one. Without this, `status.controlPlaneLoadBalancer` is a snapshot taken from the LB state fetched at the *start* of `Reconcile`, before `reconcileServices` (re)creates the kube-API service with proxy protocol on. Since a status-only change is filtered out by `IgnoreInsignificantHetznerClusterStatusUpdates` (it doesn't requeue the object), the field could stay stale until some unrelated event happened to trigger another reconcile, or until the next periodic full resync (`--sync-period`, e.g. up to 30m on some deployments) — even though proxy protocol was already live on HCloud.
