### PR TITLE
✨ Add status.controlPlaneLoadBalancer.proxyProtocolEnabled (port #2173 to main)

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -257,6 +257,13 @@ type LoadBalancerStatus struct {
 	InternalIP string               `json:"internalIP,omitempty"`
 	Target     []LoadBalancerTarget `json:"targets,omitempty"`
 	Protected  bool                 `json:"protected,omitempty"`
+
+	// ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+	// has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+	// behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+	// protocol is in progress (see the field's docs for details).
+	// +optional
+	ProxyProtocolEnabled bool `json:"proxyProtocolEnabled,omitempty"`
 }
 
 // LoadBalancerTarget defines the target of a load balancer.

--- a/api/v1beta1/zz_generated.conversion.go
+++ b/api/v1beta1/zz_generated.conversion.go
@@ -2617,6 +2617,7 @@ func autoConvert_v1beta1_LoadBalancerStatus_To_v1beta2_LoadBalancerStatus(in *Lo
 	out.InternalIP = in.InternalIP
 	out.Target = *(*[]v1beta2.LoadBalancerTarget)(unsafe.Pointer(&in.Target))
 	out.Protected = in.Protected
+	out.ProxyProtocolEnabled = in.ProxyProtocolEnabled
 	return nil
 }
 
@@ -2632,6 +2633,7 @@ func autoConvert_v1beta2_LoadBalancerStatus_To_v1beta1_LoadBalancerStatus(in *v1
 	out.InternalIP = in.InternalIP
 	out.Target = *(*[]LoadBalancerTarget)(unsafe.Pointer(&in.Target))
 	out.Protected = in.Protected
+	out.ProxyProtocolEnabled = in.ProxyProtocolEnabled
 	return nil
 }
 

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -267,6 +267,13 @@ type LoadBalancerStatus struct {
 	// +listType=atomic
 	Target    []LoadBalancerTarget `json:"targets,omitempty"`
 	Protected bool                 `json:"protected,omitempty"`
+
+	// ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+	// has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+	// behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+	// protocol is in progress (see the field's docs for details).
+	// +optional
+	ProxyProtocolEnabled bool `json:"proxyProtocolEnabled,omitempty"`
 }
 
 // LoadBalancerTarget defines the target of a load balancer.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -460,6 +460,13 @@ spec:
                     type: string
                   protected:
                     type: boolean
+                  proxyProtocolEnabled:
+                    description: |-
+                      ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+                      has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+                      behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+                      protocol is in progress (see the field's docs for details).
+                    type: boolean
                   targets:
                     items:
                       description: LoadBalancerTarget defines the target of a load
@@ -1075,6 +1082,13 @@ spec:
                   ipv6:
                     type: string
                   protected:
+                    type: boolean
+                  proxyProtocolEnabled:
+                    description: |-
+                      ProxyProtocolEnabled reflects whether the kube-apiserver load balancer service currently
+                      has proxy protocol enabled, as observed on the actual HCloud load balancer. This can lag
+                      behind spec.controlPlaneLoadBalancer.enableProxyProtocol while the migration to proxy
+                      protocol is in progress (see the field's docs for details).
                     type: boolean
                   targets:
                     items:

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -90,7 +90,7 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 		}
 	}
 
-	s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = statusFromHCloudLB(lb, s.scope.HetznerCluster.Status.Network != nil, log)
+	s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = statusFromHCloudLB(lb, s.scope.HetznerCluster.Status.Network != nil, int(s.scope.HetznerCluster.Spec.ControlPlaneEndpoint.Port), log)
 
 	// check whether load balancer name, algorithm or type has been changed
 	if err := s.reconcileLBProperties(ctx, lb); err != nil {
@@ -366,6 +366,12 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 				return reconcile.Result{}, multierr
 			}
+		} else if listenPort == kubeAPIServicePort {
+			// Status.ControlPlaneLoadBalancer was snapshotted from the LB state fetched at the
+			// start of Reconcile, before this service was (re)created, so it still shows the old
+			// value. Update it now so callers observe the change in this reconcile instead of
+			// waiting for the next one (e.g. the next full resync, up to --sync-period later).
+			s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled = proxyProtocol
 		}
 	}
 	if requeueForProxyProtocol {
@@ -643,7 +649,7 @@ func (s *Service) ownExistingLoadBalancer(ctx context.Context) (*hcloud.LoadBala
 }
 
 // statusFromHCloudLB gets the information of the Hetzner load balancer and returns it in the status object.
-func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, log logr.Logger) *infrav2.LoadBalancerStatus {
+func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, kubeAPIServicePort int, log logr.Logger) *infrav2.LoadBalancerStatus {
 	var internalIP string
 	if hasNetwork && len(lb.PrivateNet) > 0 {
 		internalIP = lb.PrivateNet[0].IP.String()
@@ -669,12 +675,21 @@ func statusFromHCloudLB(lb *hcloud.LoadBalancer, hasNetwork bool, log logr.Logge
 		}
 	}
 
+	var proxyProtocolEnabled bool
+	for _, service := range lb.Services {
+		if service.ListenPort == kubeAPIServicePort {
+			proxyProtocolEnabled = service.Proxyprotocol
+			break
+		}
+	}
+
 	return &infrav2.LoadBalancerStatus{
-		ID:         lb.ID,
-		IPv4:       lb.PublicNet.IPv4.IP.String(),
-		IPv6:       lb.PublicNet.IPv6.IP.String(),
-		InternalIP: internalIP,
-		Target:     targetObjects,
-		Protected:  lb.Protection.Delete,
+		ID:                   lb.ID,
+		IPv4:                 lb.PublicNet.IPv4.IP.String(),
+		IPv6:                 lb.PublicNet.IPv6.IP.String(),
+		InternalIP:           internalIP,
+		Target:               targetObjects,
+		Protected:            lb.Protection.Delete,
+		ProxyProtocolEnabled: proxyProtocolEnabled,
 	}
 }

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Loadbalancer", func() {
 	Context("hcloud cluster has network attached", func() {
 		var sts *infrav2.LoadBalancerStatus
 		BeforeEach(func() {
-			sts = statusFromHCloudLB(lb, true, logr.Discard())
+			sts = statusFromHCloudLB(lb, true, 443, logr.Discard())
 		})
 
 		It("should have two targets", func() {
@@ -45,11 +45,14 @@ var _ = Describe("Loadbalancer", func() {
 		It("should be unprotected", func() {
 			Expect(sts.Protected).To(Equal(protected))
 		})
+		It("should have proxy protocol disabled", func() {
+			Expect(sts.ProxyProtocolEnabled).To(BeFalse())
+		})
 	})
 	Context("hcloud cluster has no network attached", func() {
 		var sts *infrav2.LoadBalancerStatus
 		BeforeEach(func() {
-			sts = statusFromHCloudLB(lb, false, logr.Discard())
+			sts = statusFromHCloudLB(lb, false, 443, logr.Discard())
 		})
 
 		It("should have two targets", func() {
@@ -64,6 +67,21 @@ var _ = Describe("Loadbalancer", func() {
 		})
 		It("should be unprotected", func() {
 			Expect(sts.Protected).To(Equal(protected))
+		})
+	})
+	Context("proxy protocol detection", func() {
+		It("reports enabled when the kube-API service has proxy protocol on", func() {
+			lbWithProxyProtocol := &hcloud.LoadBalancer{
+				Services: []hcloud.LoadBalancerService{
+					{ListenPort: 6443, Proxyprotocol: true},
+				},
+			}
+			sts := statusFromHCloudLB(lbWithProxyProtocol, false, 6443, logr.Discard())
+			Expect(sts.ProxyProtocolEnabled).To(BeTrue())
+		})
+		It("reports disabled when the kube-API port has no matching service", func() {
+			sts := statusFromHCloudLB(lb, false, 6443, logr.Discard())
+			Expect(sts.ProxyProtocolEnabled).To(BeFalse())
 		})
 	})
 })

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -54,6 +54,11 @@ func newTestHetznerCluster() *infrav2.HetznerCluster {
 			},
 			ControlPlaneEndpoint: infrav2.APIEndpoint{Port: testKubeAPIListenPort},
 		},
+		Status: infrav2.HetznerClusterStatus{
+			// reconcileServices is always called after Reconcile has already populated this
+			// from statusFromHCloudLB, so mirror that invariant here.
+			ControlPlaneLoadBalancer: &infrav2.LoadBalancerStatus{},
+		},
 	}
 }
 
@@ -109,6 +114,25 @@ func TestReconcileServices_NewCluster_EnableProxyProtocol_AddsServiceWithProxyPr
 	_, err := svc.reconcileServices(context.Background(), hcloudLB)
 	require.NoError(t, err)
 	require.True(t, *capturedOpts.Proxyprotocol)
+	mockClient.AssertExpectations(t)
+}
+
+// TestReconcileServices_EnableProxyProtocol_UpdatesStatusInSameReconcile verifies that
+// status.controlPlaneLoadBalancer.proxyProtocolEnabled is set as soon as the kube-API service is
+// (re)created with proxy protocol, instead of waiting for the next reconcile to pick it up.
+func TestReconcileServices_EnableProxyProtocol_UpdatesStatusInSameReconcile(t *testing.T) {
+	hetznerCluster := newTestHetznerCluster()
+	hetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol = true
+
+	mockClient := &mocks.Client{}
+	svc := newTestService(t, hetznerCluster, mockClient)
+	hcloudLB := &hcloud.LoadBalancer{}
+
+	mockClient.On("AddServiceToLoadBalancer", mock.Anything, hcloudLB, mock.Anything).Return(nil)
+
+	_, err := svc.reconcileServices(context.Background(), hcloudLB)
+	require.NoError(t, err)
+	require.True(t, hetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled)
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

Port of #2173 (merged to `release-1.1`) to `main`.

- Adds `status.controlPlaneLoadBalancer.proxyProtocolEnabled` (bool) to `HetznerCluster`
- Reflects whether the kube-apiserver load balancer service currently has proxy protocol enabled, as observed on the actual HCloud load balancer service
- Follow-up to #2113, which added `spec.controlPlaneLoadBalancer.enableProxyProtocol`. Since enabling proxy protocol on existing clusters is a gated migration (waiting for all control-plane nodes to carry an annotation before the LB service is recreated), the spec field alone doesn't tell you whether it has actually taken effect yet — this status field does.
- Updates the new status field in the same reconcile that actually enables proxy protocol on the LB, instead of only on the next one. Without this, `status.controlPlaneLoadBalancer` is a snapshot taken from the LB state fetched at the *start* of `Reconcile`, before `reconcileServices` (re)creates the kube-API service with proxy protocol on. Since a status-only change doesn't requeue the object, the field could stay stale until some unrelated event happened to trigger another reconcile, or until the next periodic full resync.

### Porting notes

`main` has already gone through the v1beta2 migration (#2079 and friends), so the field was added to `api/v1beta2/types.go` (the version the controller actually operates on) instead of `api/v1beta1/types.go` as on `release-1.1`. The corresponding `api/v1beta1` field and generated conversion code were added/regenerated too, since `main` serves both CRD versions with a conversion webhook. `ControlPlaneEndpoint` is a value type (not a pointer) in v1beta2, so the nil-check helper from the `release-1.1` version isn't needed here.

Tests were adapted to this branch's existing `reconcile_services_test.go` (table-style tests with `testify`/mocks) rather than re-adding the ginkgo-based test from the `release-1.1` commit.
