### PR TITLE
:seedling: fix(hcloudmachine): reconcile on control-plane lb target changes (backport #1978)

### DIFF
--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,10 +34,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -403,6 +406,35 @@ func (r *HCloudMachineReconciler) HetznerClusterToHCloudMachines(_ context.Conte
 	}
 }
 
+// machineAPIServerPodHealthyConditionChanged reports whether the Machine's
+// KubeadmControlPlaneMachineAPIServerPodHealthyCondition status changed. reconcileLoadBalancerAttachment
+// (pkg/services/hcloud/server/server.go) uses conditions.IsTrue on this condition to decide whether to
+// attach the server to the load balancer. Without this check, a condition change alone would not trigger
+// a reconcile.
+func machineAPIServerPodHealthyConditionChanged(oldMachine, newMachine *clusterv1.Machine) bool {
+	return conditions.IsTrue(oldMachine, controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition) !=
+		conditions.IsTrue(newMachine, controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition)
+}
+
+// controlPlaneLoadBalancerTargetsChanged reports whether the load balancer's target list
+// changed. HCloudMachine reconciliation uses this list to decide whether a control-plane
+// server is already attached. Without this check, a target-list change alone would not
+// trigger a reconcile.
+func controlPlaneLoadBalancerTargetsChanged(oldCluster, newCluster *infrav1.HetznerCluster) bool {
+	var oldTargets []infrav1.LoadBalancerTarget
+	var newTargets []infrav1.LoadBalancerTarget
+
+	if oldCluster.Status.ControlPlaneLoadBalancer != nil {
+		oldTargets = oldCluster.Status.ControlPlaneLoadBalancer.Target
+	}
+
+	if newCluster.Status.ControlPlaneLoadBalancer != nil {
+		newTargets = newCluster.Status.ControlPlaneLoadBalancer.Target
+	}
+
+	return !slices.Equal(oldTargets, newTargets)
+}
+
 // HetznerSecretToHCloudMachines is a handler.ToRequestsFunc to be used to enqueue requests for reconciliation
 // of HCloudMachines when the referenced HetznerSecret changes (e.g. after a token rotation).
 func (r *HCloudMachineReconciler) HetznerSecretToHCloudMachines(_ context.Context) handler.MapFunc {
@@ -498,6 +530,11 @@ func IgnoreInsignificantHetznerClusterUpdates(logger logr.Logger) predicate.Func
 			oldCluster.ResourceVersion = ""
 			newCluster.ResourceVersion = ""
 
+			if controlPlaneLoadBalancerTargetsChanged(oldCluster, newCluster) {
+				log.V(1).Info("HetznerCluster -> HCloudMachine event for control plane load balancer target change")
+				return true
+			}
+
 			oldCluster.Status.Conditions = nil
 			newCluster.Status.Conditions = nil
 
@@ -565,6 +602,11 @@ func IgnoreInsignificantMachineStatusUpdates(logger logr.Logger) predicate.Funcs
 
 			oldMachine.ResourceVersion = ""
 			newMachine.ResourceVersion = ""
+
+			if machineAPIServerPodHealthyConditionChanged(oldMachine, newMachine) {
+				log.V(1).Info("Machine -> HCloudMachine event for load balancer related condition change")
+				return true
+			}
 
 			oldMachine.Status = clusterv1.MachineStatus{}
 			newMachine.Status = clusterv1.MachineStatus{}

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -32,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
@@ -216,6 +217,58 @@ func TestIgnoreInsignificantMachineStatusUpdates(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Changes in APIServerPodHealthy condition",
+			oldObj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "default",
+				},
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+			},
+			newObj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "default",
+				},
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Machine starts deletion (DeletionTimestamp set)",
+			oldObj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "default",
+				},
+				Status: clusterv1.MachineStatus{},
+			},
+			newObj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-machine",
+					Namespace:         "default",
+					DeletionTimestamp: ptr.To(metav1.Now()),
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Status: clusterv1.MachineStatus{},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -230,6 +283,82 @@ func TestIgnoreInsignificantMachineStatusUpdates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIgnoreInsignificantHetznerClusterUpdates_TargetChanges(t *testing.T) {
+	logger := klog.Background()
+	predicate := IgnoreInsignificantHetznerClusterUpdates(logger)
+
+	oldObj := &infrav1.HetznerCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Status: infrav1.HetznerClusterStatus{
+			ControlPlaneLoadBalancer: &infrav1.LoadBalancerStatus{
+				ID: 1,
+				Target: []infrav1.LoadBalancerTarget{
+					{
+						Type:     infrav1.LoadBalancerTargetTypeServer,
+						ServerID: 1,
+					},
+				},
+			},
+		},
+	}
+
+	newObj := oldObj.DeepCopy()
+	newObj.ResourceVersion = "2"
+	newObj.Status.ControlPlaneLoadBalancer.Target = []infrav1.LoadBalancerTarget{
+		{
+			Type:     infrav1.LoadBalancerTargetTypeServer,
+			ServerID: 1,
+		},
+		{
+			Type:     infrav1.LoadBalancerTargetTypeServer,
+			ServerID: 2,
+		},
+	}
+
+	updateEvent := event.UpdateEvent{
+		ObjectOld: oldObj,
+		ObjectNew: newObj,
+	}
+	if !predicate.Update(updateEvent) {
+		t.Errorf("expected control plane load balancer target change to trigger reconcile")
+	}
+
+	t.Run("unchanged targets", func(t *testing.T) {
+		unchangedObj := oldObj.DeepCopy()
+		unchangedObj.ResourceVersion = "2"
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: oldObj,
+			ObjectNew: unchangedObj,
+		}
+		if predicate.Update(updateEvent) {
+			t.Errorf("expected unchanged control plane load balancer targets to not trigger reconcile")
+		}
+	})
+
+	t.Run("nil ControlPlaneLoadBalancer", func(t *testing.T) {
+		oldNilLB := &infrav1.HetznerCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		}
+		newNilLB := oldNilLB.DeepCopy()
+		newNilLB.ResourceVersion = "2"
+
+		updateEvent := event.UpdateEvent{
+			ObjectOld: oldNilLB,
+			ObjectNew: newNilLB,
+		}
+		if predicate.Update(updateEvent) {
+			t.Errorf("expected nil control plane load balancer on both sides to not trigger reconcile")
+		}
+	})
 }
 
 func TestIgnoreInsignificantSecretUpdates(t *testing.T) {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -33,8 +33,7 @@ import (
 	"k8s.io/utils/ptr"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/record"
@@ -1534,11 +1533,8 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 		return reconcile.Result{}, nil
 	}
 
-	// remove server from load balancer if it's being deleted.
-	// s.scope.Machine is a CAPI core v1beta2 Machine, so its legacy conditions
-	// live at Status.Deprecated.V1Beta1.Conditions — use deprecatedv1beta1conditions,
-	// not v1beta1conditions. See .golangci.yaml for the full mapping.
-	if deprecatedv1beta1conditions.Has(s.scope.Machine, clusterv1.PreDrainDeleteHookSucceededV1Beta1Condition) {
+	// remove the server as soon as the Machine starts deleting.
+	if !s.scope.Machine.DeletionTimestamp.IsZero() {
 		if err := s.deleteServerOfLoadBalancer(ctx, server); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to delete server %s with ID %d from loadbalancer: %w", server.Name, server.ID, err)
 		}
@@ -1617,7 +1613,7 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 
 	apiServerPodHealthy := !s.scope.Cluster.Spec.ControlPlaneRef.IsDefined() ||
 		s.scope.Cluster.Spec.ControlPlaneRef.Kind != "KubeadmControlPlane" ||
-		deprecatedv1beta1conditions.IsTrue(s.scope.Machine, controlplanev1.MachineAPIServerPodHealthyV1Beta1Condition)
+		conditions.IsTrue(s.scope.Machine, controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition)
 
 	// we attach only nodes with kube-apiserver pod healthy to avoid downtime, skipped for the first node
 	if len(s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target) > 0 && !apiServerPodHealthy {


### PR DESCRIPTION
## Introduction

Backport of #1978 (still open on `main` at the time of this backport) to `release-1.1`.

`reconcileLoadBalancerAttachment()` (in the hcloud server service) decides whether a
control-plane node should be added to, or removed from, the Hetzner Load Balancer. To make
that decision it looks at two things:

* Two signals on the related Cluster API `Machine`:
  * `Machine.DeletionTimestamp` — set once a machine starts being deleted, i.e. it's safe to
    remove it from the LB.
  * `controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition` — set once a new
    control-plane node's kube-apiserver pod is healthy, i.e. it's safe to add it to the LB.
* `HetznerCluster.Status.ControlPlaneLoadBalancer.Target`, which HCloudMachine's own
  reconcile loop uses to know which servers are already attached.

The problem: both of these only ever change as part of a `Machine.Status`/`ObjectMeta` or
`HetznerCluster.Status` update. Before this PR:

* `IgnoreInsignificantMachineStatusUpdates()` treated **all** `Machine.Status`-only changes as
  insignificant, so it filtered out exactly the Condition transition above.
* `IgnoreInsignificantHetznerClusterUpdates()` did the same for
  `Status.ControlPlaneLoadBalancer.Target` changes.

In both cases the HCloudMachine controller was never triggered by the event that actually
matters for LB attachment. Verified `release-1.1` has the identical bug (same predicate code)
before applying this backport.

**Fix**: both predicates now explicitly check for changes to these signals and mark the event
as significant, so HCloudMachine reconciles immediately instead of waiting for an incidental
trigger.
