### PR TITLE
🌱 Rename leftover imageurl condition reasons to custom provisioner

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -433,8 +433,6 @@ const (
 	HCloudMachineStartImageURLCommandFailedV1Beta2Reason = "StartImageURLCommandFailed"
 	// HCloudMachineStartImageURLCommandNonZeroExitCodeV1Beta2Reason indicates the image URL command returned a non-zero exit code.
 	HCloudMachineStartImageURLCommandNonZeroExitCodeV1Beta2Reason = "StartImageURLCommandNonZeroExitCode"
-	// HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason indicates the image URL command is running.
-	HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason = "HCloudImageURLCommandRunning"
 	// HCloudMachineRunningImageURLCommandTimedOutV1Beta2Reason indicates the running image command timed out.
 	HCloudMachineRunningImageURLCommandTimedOutV1Beta2Reason = "RunningImageURLCommandTimedOut"
 	// HCloudMachineImageURLCommandFailedV1Beta2Reason indicates the image command failed.

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1421,12 +1421,12 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 			}
 		}
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
-			"ImageURLCommandFailed", clusterv1beta1.ConditionSeverityWarning,
+			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)
 		v1beta2conditions.Set(host, metav1.Condition{
 			Type:    infrav1.HetznerBareMetalHostProvisionSucceededV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ImageURLCommandFailed",
+			Reason:  "CustomProvisionerFailed",
 			Message: msg,
 		})
 		return s.recordActionFailure(infrav1.FatalError, msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1027,12 +1027,12 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context, server *hc
 	}
 
 	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
-		"HCloudImageURLCommandRunning", clusterv1beta1.ConditionSeverityInfo,
+		"CustomProvisionerRunning", clusterv1beta1.ConditionSeverityInfo,
 		"custom provisioner running")
 	v1beta2conditions.Set(hm, metav1.Condition{
 		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 		Status:  metav1.ConditionFalse,
-		Reason:  infrav1.HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason,
+		Reason:  infrav1.HCloudMachineCustomProvisionerRunningV1Beta2Reason,
 		Message: "custom provisioner running",
 	})
 	s.setBootState(infrav1.HCloudBootStateRunningImageCommand)


### PR DESCRIPTION
## Summary
- Two `ServerProvisioned`/`ProvisionSucceeded` condition Reasons still said `ImageURLCommand...` while their Message already reads "custom provisioner running/failed" and sibling reasons for the same states use `CustomProvisionerRunning`/`CustomProvisionerFailed`.
- Renamed both to match: `pkg/services/hcloud/server/server.go` (`HCloudImageURLCommandRunning` → `CustomProvisionerRunning`) and `pkg/services/baremetal/host/host.go` (`ImageURLCommandFailed` → `CustomProvisionerFailed`).
- Removed the now-unused `HCloudMachineHCloudImageURLCommandRunningV1Beta2Reason` constant.
