### PR TITLE
:seedling: fix flaky test via RWMutex (backport #2036)

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -77,7 +77,13 @@ func TestControllers(t *testing.T) {
 }
 
 type ControllerResetter struct {
-	debug                                 bool
+	debug bool
+	// reconcileGate ensures no Reconcile is running while mock clients are being replaced between tests.
+	// Each Reconcile call holds it as a read lock (via ReconcileGate); test setup holds it as a write
+	// lock. Because a write lock waits for all read lock holders to finish, mock setup can only proceed
+	// once all in-flight reconciles from the previous test have completed.
+	reconcileGate                         *sync.RWMutex
+	baremetalSSHClientFactory             *mocks.SSHFactory
 	HetznerClusterReconciler              *HetznerClusterReconciler
 	HCloudMachineReconciler               *HCloudMachineReconciler
 	HCloudMachineTemplateReconciler       *HCloudMachineTemplateReconciler
@@ -88,6 +94,8 @@ type ControllerResetter struct {
 }
 
 func NewControllerResetter(
+	reconcileGate *sync.RWMutex,
+	sshFactory *mocks.SSHFactory,
 	hetznerClusterReconciler *HetznerClusterReconciler,
 	hcloudMachineReconciler *HCloudMachineReconciler,
 	hcloudMachineTemplateReconciler *HCloudMachineTemplateReconciler,
@@ -97,6 +105,8 @@ func NewControllerResetter(
 	hetznerBareMetalRemediationReconciler *HetznerBareMetalRemediationReconciler,
 ) *ControllerResetter {
 	return &ControllerResetter{
+		reconcileGate:                         reconcileGate,
+		baremetalSSHClientFactory:             sshFactory,
 		HetznerClusterReconciler:              hetznerClusterReconciler,
 		HCloudMachineReconciler:               hcloudMachineReconciler,
 		HCloudMachineTemplateReconciler:       hcloudMachineTemplateReconciler,
@@ -112,7 +122,13 @@ var _ helpers.Resetter = &ControllerResetter{}
 
 // ResetAndInitNamespace implements Resetter.ResetAndInitNamespace(). Documentation is on the
 // interface.
-func (r *ControllerResetter) ResetAndInitNamespace(namespace string, testEnv *helpers.TestEnvironment, t FullGinkgoTInterface) {
+func (r *ControllerResetter) ResetAndInitNamespace(namespace string, testEnv *helpers.TestEnvironment, t FullGinkgoTInterface) func() {
+	// Acquire the write lock. This blocks until all in-flight Reconcile calls (which hold
+	// the read lock) finish, so no reconcile from the previous test is running when we
+	// swap the mock clients. The returned func releases it once all On() expectations
+	// have been registered by the caller's BeforeEach (via defer).
+	r.reconcileGate.Lock()
+
 	rescueSSHClient := &sshmock.Client{}
 	// Register Testify helpers so failed expectations are reported against this test instance.
 	rescueSSHClient.Test(t)
@@ -132,12 +148,9 @@ func (r *ControllerResetter) ResetAndInitNamespace(namespace string, testEnv *he
 	hcloudClientFactory := fakehcloudclient.NewHCloudClientFactory()
 
 	robotClientFactory := mocks.NewRobotFactory(robotClient)
-	baremetalSSHClientFactory := mocks.NewSSHFactory(rescueSSHClient,
-		osSSHClientAfterInstallImage, osSSHClientAfterCloudInit)
 
 	// Reset clients used by the test code
-	testEnv.BaremetalSSHClientFactory = mocks.NewSSHFactory(rescueSSHClient,
-		osSSHClientAfterInstallImage, osSSHClientAfterCloudInit)
+	testEnv.BaremetalSSHClientFactory = r.baremetalSSHClientFactory
 	testEnv.HCloudSSHClientFactory = mockedsshclient.NewSSHFactory(hcloudSSHClient)
 	testEnv.RescueSSHClient = rescueSSHClient
 	testEnv.OSSSHClientAfterInstallImage = osSSHClientAfterInstallImage
@@ -151,14 +164,12 @@ func (r *ControllerResetter) ResetAndInitNamespace(namespace string, testEnv *he
 	r.HetznerClusterReconciler.Namespace = namespace
 
 	r.HCloudMachineReconciler.HCloudClientFactory = hcloudClientFactory
-	r.HCloudMachineReconciler.SSHClientFactory = baremetalSSHClientFactory
 	r.HCloudMachineReconciler.Namespace = namespace
 
 	r.HCloudMachineTemplateReconciler.HCloudClientFactory = hcloudClientFactory
 	r.HCloudMachineTemplateReconciler.Namespace = namespace
 
 	r.HetznerBareMetalHostReconciler.RobotClientFactory = robotClientFactory
-	r.HetznerBareMetalHostReconciler.SSHClientFactory = baremetalSSHClientFactory
 	r.HetznerBareMetalHostReconciler.Namespace = namespace
 	r.HetznerBareMetalHostReconciler.WorkloadClusterClientFactory = newFakeWorkloadClusterClientFactory()
 
@@ -172,6 +183,11 @@ func (r *ControllerResetter) ResetAndInitNamespace(namespace string, testEnv *he
 
 	if r.debug {
 		testEnv.GetLogger().Info("Starting test: ===> ===> ===> ===> ===> ===> ===> " + t.Name())
+	}
+
+	return func() {
+		r.baremetalSSHClientFactory.SetClients(rescueSSHClient, osSSHClientAfterInstallImage, osSSHClientAfterCloudInit)
+		r.reconcileGate.Unlock()
 	}
 }
 
@@ -256,7 +272,20 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(hetznerBareMetalRemediationReconciler.SetupWithManager(ctx, testEnv, controller.Options{})).To(Succeed())
 
-	testEnv.Resetter = NewControllerResetter(hetznerClusterReconciler, hcloudMachineReconciler,
+	// One factory shared across resets so in-flight goroutines always hold a valid pointer.
+	sshFactory := &mocks.SSHFactory{}
+	hcloudMachineReconciler.SSHClientFactory = sshFactory
+	hetznerBareMetalHostReconciler.SSHClientFactory = sshFactory
+
+	// reconcileGate is shared by the two reconcilers and the resetter: reconcilers hold a read lock
+	// for the duration of each Reconcile call; the resetter holds the write lock while swapping mock
+	// clients between tests, which blocks until all in-flight reconciles finish.
+	reconcileGate := &sync.RWMutex{}
+	hetznerBareMetalHostReconciler.ReconcileGate = reconcileGate
+	hcloudMachineReconciler.ReconcileGate = reconcileGate
+
+	testEnv.Resetter = NewControllerResetter(
+		reconcileGate, sshFactory, hetznerClusterReconciler, hcloudMachineReconciler,
 		hcloudMachineTemplateReconciler, hetznerBareMetalHostReconciler,
 		hetznerBareMetalMachineReconciler, hcloudRemediationReconciler,
 		hetznerBareMetalRemediationReconciler)

--- a/controllers/hcloudmachine_controller.go
+++ b/controllers/hcloudmachine_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -70,6 +71,12 @@ type HCloudMachineReconciler struct {
 
 	// Reconcile only this namespace. Only needed for testing
 	Namespace string
+
+	// ReconcileGate, when non-nil, is held as a read lock for the full duration of each Reconcile
+	// call. Between tests, the test setup holds it as a write lock while swapping mock clients.
+	// A write lock can only be acquired once all read lock holders (in-flight reconciles) finish,
+	// so mock clients are never swapped while a Reconcile is running.
+	ReconcileGate *sync.RWMutex
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
@@ -81,6 +88,11 @@ type HCloudMachineReconciler struct {
 
 // Reconcile manages the lifecycle of an HCloud machine object.
 func (r *HCloudMachineReconciler) Reconcile(ctx context.Context, req reconcile.Request) (res reconcile.Result, reterr error) {
+	if r.ReconcileGate != nil {
+		r.ReconcileGate.RLock()
+		defer r.ReconcileGate.RUnlock()
+	}
+
 	log := ctrl.LoggerFrom(ctx)
 
 	if r.Namespace != "" && req.Namespace != r.Namespace {

--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -389,7 +389,9 @@ var _ = Describe("HCloudMachineReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 		hcloudClient = testEnv.HCloudClientFactory.NewClient("fake-token")
 
@@ -859,7 +861,9 @@ var _ = Describe("Hetzner secret", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerClusterName = utils.GenerateName(nil, "hetzner-cluster-test")
@@ -1060,7 +1064,9 @@ var _ = Describe("HCloudMachine validation", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hcloudMachine = &infrav1.HCloudMachine{

--- a/controllers/hcloudmachinetemplate_controller_test.go
+++ b/controllers/hcloudmachinetemplate_controller_test.go
@@ -40,7 +40,9 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerSecret = getDefaultHetznerSecret(testNs.Name)
@@ -338,7 +340,9 @@ var _ = Describe("HCloudMachineTemplateReconciler", func() {
 			)
 			BeforeEach(func() {
 				var err error
-				testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+				var finish func()
+				testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+				defer finish()
 				Expect(err).NotTo(HaveOccurred())
 
 				hcloudMachineTemplate = &infrav1.HCloudMachineTemplate{

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -62,7 +62,9 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerSecret = getDefaultHetznerSecret(testNs.Name)

--- a/controllers/hetznerbaremetalhost_controller.go
+++ b/controllers/hetznerbaremetalhost_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,6 +74,12 @@ type HetznerBareMetalHostReconciler struct {
 	Namespace string
 	// WorkloadClusterClientFactory overrides the default real factory. Intended for tests only.
 	WorkloadClusterClientFactory scope.WorkloadClusterClientFactory
+
+	// ReconcileGate, when non-nil, is held as a read lock for the full duration of each Reconcile
+	// call. Between tests, the test setup holds it as a write lock while swapping mock clients.
+	// A write lock can only be acquired once all read lock holders (in-flight reconciles) finish,
+	// so mock clients are never swapped while a Reconcile is running.
+	ReconcileGate *sync.RWMutex
 }
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=hetznerbaremetalhosts,verbs=get;list;watch;create;update;patch;delete
@@ -81,6 +88,11 @@ type HetznerBareMetalHostReconciler struct {
 
 // Reconcile implements the reconcilement of HetznerBareMetalHost objects.
 func (r *HetznerBareMetalHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, reterr error) {
+	if r.ReconcileGate != nil {
+		r.ReconcileGate.RLock()
+		defer r.ReconcileGate.RUnlock()
+	}
+
 	log := ctrl.LoggerFrom(ctx)
 
 	if r.Namespace != "" && req.Namespace != r.Namespace {

--- a/controllers/hetznerbaremetalhost_controller_test.go
+++ b/controllers/hetznerbaremetalhost_controller_test.go
@@ -174,7 +174,9 @@ var _ = Describe("HetznerBareMetalHostReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalhost-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalhost-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerClusterName = utils.GenerateName(nil, "hetzner-cluster-test")
@@ -705,7 +707,9 @@ var _ = Describe("HetznerBareMetalHostReconciler - missing secrets", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalmachine-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalmachine-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerClusterName = utils.GenerateName(nil, "hetzner-cluster-test")

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -82,7 +82,9 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalmachine-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "baremetalmachine-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		machineName = utils.GenerateName(nil, "machine")
@@ -1035,7 +1037,9 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 			)
 			BeforeEach(func() {
 				var err error
-				testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+				var finish func()
+				testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+				defer finish()
 				Expect(err).NotTo(HaveOccurred())
 
 				hbmmt = &infrav1.HetznerBareMetalMachineTemplate{

--- a/controllers/hetznerbaremetalremediation_controller_test.go
+++ b/controllers/hetznerbaremetalremediation_controller_test.go
@@ -70,7 +70,9 @@ var _ = Describe("HetznerBareMetalRemediationReconciler", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachinetemplate-reconciler")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		machineName = utils.GenerateName(nil, "machine")

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -578,7 +578,9 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 			hcloudClient       hcloudclient.Client
 		)
 		BeforeEach(func() {
-			testNs, err = testEnv.ResetAndCreateNamespace(ctx, "cluster-tests")
+			var finish func()
+			testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "cluster-tests")
+			defer finish()
 			Expect(err).NotTo(HaveOccurred())
 			hcloudClient = testEnv.HCloudClientFactory.NewClient("fake-token")
 
@@ -1332,7 +1334,9 @@ var _ = Describe("Hetzner secret", func() {
 
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hetzner-secret")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hetzner-secret")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 
 		hetznerClusterName = utils.GenerateName(nil, "hetzner-cluster-test")
@@ -1430,7 +1434,9 @@ var _ = Describe("HetznerCluster validation", func() {
 	)
 	BeforeEach(func() {
 		var err error
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-validation")
+		defer finish()
 		Expect(err).NotTo(HaveOccurred())
 	})
 	AfterEach(func() {

--- a/pkg/services/baremetal/client/mocks/factory.go
+++ b/pkg/services/baremetal/client/mocks/factory.go
@@ -18,36 +18,61 @@ limitations under the License.
 package mocks
 
 import (
+	"sync"
+
 	robotmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/robot"
 	sshmock "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/mocks/ssh"
 	robotclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/robot"
 	sshclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/client/ssh"
 )
 
-type sshFactory struct {
+// SSHFactory is a test SSH client factory whose mock clients can be hot-swapped between
+// tests via SetClients without replacing the factory pointer on the reconciler. A
+// sync.RWMutex ensures that concurrent NewClient calls (from in-flight reconcile
+// goroutines) and SetClients calls (from the test reset path) never race.
+type SSHFactory struct {
+	mu                        sync.RWMutex
 	rescueClient              *sshmock.Client
 	osClientAfterInstallImage *sshmock.Client
 	osClientAfterCloudInit    *sshmock.Client
 }
 
-// NewSSHFactory creates a new factory for SSH clients.
+var _ sshclient.Factory = &SSHFactory{}
+
+// NewSSHFactory creates a new SSHFactory primed with the given clients.
 func NewSSHFactory(
 	rescueClient *sshmock.Client,
 	osClientAfterInstallImage *sshmock.Client,
 	osClientAfterCloudInit *sshmock.Client,
-) sshclient.Factory {
-	return &sshFactory{
-		rescueClient:              rescueClient,
-		osClientAfterInstallImage: osClientAfterInstallImage,
-		osClientAfterCloudInit:    osClientAfterCloudInit,
-	}
+) *SSHFactory {
+	f := &SSHFactory{}
+	f.SetClients(rescueClient, osClientAfterInstallImage, osClientAfterCloudInit)
+	return f
 }
 
-var _ = sshclient.Factory(&sshFactory{})
+// SetClients atomically replaces the mock clients returned by NewClient (defined below). The
+// finish() func returned by ResetAndInitNamespace calls this after all On() expectations are
+// registered, so any goroutine that calls NewClient after this returns sees a fully-configured
+// mock. f.mu guards only the SSHFactory fields against data races between SetClients and
+// NewClient; the ReconcileGate in the reconcilers is what prevents Reconcile from running
+// while mocks are being swapped between tests.
+func (f *SSHFactory) SetClients(
+	rescue *sshmock.Client,
+	osAfterInstallImage *sshmock.Client,
+	osAfterCloudInit *sshmock.Client,
+) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rescueClient = rescue
+	f.osClientAfterInstallImage = osAfterInstallImage
+	f.osClientAfterCloudInit = osAfterCloudInit
+}
 
-// NewClient implements the NewClient function of the SSHFactory interface.
-func (f *sshFactory) NewClient(in sshclient.Input) sshclient.Client {
-	// return rescueClient when private key rescue-private-key is given. Otherwise give the os private key.
+// NewClient implements sshclient.Factory. f.mu.RLock allows multiple goroutines to call
+// NewClient concurrently while guarding the client fields against a concurrent SetClients write.
+func (f *SSHFactory) NewClient(in sshclient.Input) sshclient.Client {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if in.Port == 0 {
 		panic("no port specified for ssh client")
 	}

--- a/pkg/services/hcloud/server/server_suite_test.go
+++ b/pkg/services/hcloud/server/server_suite_test.go
@@ -217,7 +217,7 @@ var _ helpers.Resetter = &Resetter{}
 
 var hcloudImageURLCommandTempDir string
 
-func (r *Resetter) ResetAndInitNamespace(_ string, testEnv *helpers.TestEnvironment, t FullGinkgoTInterface) {
+func (r *Resetter) ResetAndInitNamespace(_ string, testEnv *helpers.TestEnvironment, t FullGinkgoTInterface) func() {
 	rescueSSHClient := &sshmock.Client{}
 	// Register Testify helpers so failed expectations are reported against this test instance.
 
@@ -227,6 +227,7 @@ func (r *Resetter) ResetAndInitNamespace(_ string, testEnv *helpers.TestEnvironm
 	testEnv.HCloudSSHClient = &sshmock.Client{}
 	testEnv.HCloudSSHClient.Test(t)
 	testEnv.HCloudSSHClientFactory = mockedsshclient.NewSSHFactory(testEnv.HCloudSSHClient)
+	return func() {}
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -974,7 +974,9 @@ var _ = Describe("Reconcile", func() {
 
 	BeforeEach(func() {
 		hcloudClient = mocks.NewClient(GinkgoT())
-		testNs, err = testEnv.ResetAndCreateNamespace(ctx, "server-reconcile")
+		var finish func()
+		testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "server-reconcile")
+		defer finish()
 		Expect(err).To(BeNil())
 
 		clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -117,7 +117,19 @@ type Resetter interface {
 	// testEnv: the TestEnvironment which should be resetted.
 	//
 	// t: g.GinkgoT()
-	ResetAndInitNamespace(namespace string, testEnv *TestEnvironment, t g.FullGinkgoTInterface)
+	//
+	// The returned func must be deferred by the caller immediately after ResetAndCreateNamespace
+	// returns. It calls SetClients with the fully configured mocks and releases the reconcile gate
+	// (write lock), and is safe to call multiple times (subsequent calls are no-ops). Example:
+	//
+	//  BeforeEach(func() {
+	//      var err error
+	//      var finish func()
+	//      testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-reconciler")
+	//      defer finish()
+	//      // ... register On() mock expectations here ...
+	//  })
+	ResetAndInitNamespace(namespace string, testEnv *TestEnvironment, t g.FullGinkgoTInterface) func()
 }
 
 // TestEnvironment encapsulates a Kubernetes local test environment.
@@ -274,8 +286,24 @@ func (t *TestEnvironment) Cleanup(ctx context.Context, objs ...client.Object) er
 	return kerrors.NewAggregate(errs)
 }
 
-// ResetAndCreateNamespace creates a namespace.
-func (t *TestEnvironment) ResetAndCreateNamespace(ctx context.Context, generateName string) (*corev1.Namespace, error) {
+// ResetAndCreateNamespace creates a namespace and initializes fresh mock clients for the next test.
+//
+// The second return value is a finish func that the caller MUST defer immediately:
+//
+//	BeforeEach(func() {
+//	    var err error
+//	    var finish func()
+//	    testNs, finish, err = testEnv.ResetAndCreateNamespace(ctx, "hcloudmachine-reconciler")
+//	    defer finish()
+//	    // ... register On() mock expectations here ...
+//	})
+//
+// Between this call and finish(), the reconcile gate is held as a write lock, blocking new
+// Reconcile calls. The caller uses this window to register On() mock expectations. finish()
+// then installs the configured mocks (via SetClients) and releases the gate so reconciles can
+// proceed. Deferring — rather than calling directly — ensures finish() runs even if BeforeEach
+// panics mid-setup, which would otherwise leave the gate permanently locked.
+func (t *TestEnvironment) ResetAndCreateNamespace(ctx context.Context, generateName string) (*corev1.Namespace, func(), error) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", generateName),
@@ -285,14 +313,15 @@ func (t *TestEnvironment) ResetAndCreateNamespace(ctx context.Context, generateN
 		},
 	}
 	if err := t.Create(ctx, ns); err != nil {
-		return nil, err
+		return nil, func() {}, err
 	}
 
+	finish := func() {}
 	if t.Resetter != nil {
-		t.Resetter.ResetAndInitNamespace(ns.Name, t, g.GinkgoT())
+		finish = t.Resetter.ResetAndInitNamespace(ns.Name, t, g.GinkgoT())
 	}
 
-	return ns, nil
+	return ns, finish, nil
 }
 
 // CreateKubeconfigSecret generates a kubeconfig secret in a given capi cluster.


### PR DESCRIPTION
## Summary
Backport of #2036 to `release-1.1`.

Fixes a flaky `HetznerBareMetalRemediationReconciler` test caused by a race between `ResetAndInitNamespace` swapping in fresh mocks and in-flight reconcile goroutines from the previous test. Introduces a `ReconcileGate` RWMutex on the reconcilers that use mocked SSH/Robot clients so `ResetAndCreateNamespace` blocks until in-flight reconciles finish before swapping mocks.