### PR TITLE
🐛 Fix server creation getting stuck forever on name-uniqueness error (backport #2167)

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -351,6 +351,16 @@ func (s *Service) handleBootStateUnset(ctx context.Context) (reconcile.Result, e
 			return reconcile.Result{}, nil
 		}
 
+		// createServer hit a uniqueness_error that adoption (taking over an existing server) could
+		// not resolve. Unlike invalid_input/resource_unavailable, this can clear from the outside:
+		// the conflicting server may be deleted, or this Machine may be replaced with a new name.
+		// Nothing watches HCloud, so we requeue on a slow interval to retry, otherwise such a change
+		// would never trigger a new attempt. createServer already set ServerCreateSucceededCondition
+		// to false, so we only requeue here.
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			return reconcile.Result{RequeueAfter: 10 * time.Minute}, nil
+		}
+
 		// Terminal errors like invalid_input (e.g. unsupported location for server type)
 		// or resource_unavailable (e.g. server location disabled) will never succeed on retry.
 		// Mark the machine as irrecoverably failed and stop reconciling.
@@ -1846,7 +1856,40 @@ func (s *Service) createServer(ctx context.Context, userData []byte, image *hclo
 			return hcloud.ServerCreateResult{}, fmt.Errorf("%s: %w", msg, err)
 		}
 
+		// A server with this exact name already exists. This happens if a previous reconcile
+		// created the HCloud server successfully but lost the update that would have persisted
+		// ProviderID/BootState (e.g. an API server conflict or a controller restart between
+		// CreateServer and Close()). Adopt the existing server instead of failing forever with
+		// the same uniqueness error on every retry.
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			existingServer, findErr := s.findServerByName(ctx)
+			if findErr != nil {
+				s.scope.Error(findErr, "failed to look up existing server after a uniqueness error on CreateServer")
+			} else if existingServer != nil {
+				s.scope.Info("server already exists after a uniqueness error, adopting it instead of failing",
+					"serverID", existingServer.ID, "serverName", existingServer.Name)
+				hm.Status.SSHKeys = caphSSHKeys
+				v1beta1conditions.MarkTrue(hm, infrav1.ServerCreateSucceededCondition)
+				v1beta2conditions.Set(hm, metav1.Condition{
+					Type:   infrav1.HCloudMachineServerCreatedV1Beta2Condition,
+					Status: metav1.ConditionTrue,
+					Reason: infrav1.HCloudMachineServerCreatedV1Beta2Reason,
+				})
+				record.Eventf(hm, "AdoptedExistingServer", "Adopted existing server %s (ID %d) after a uniqueness error on create",
+					existingServer.Name, existingServer.ID)
+				return hcloud.ServerCreateResult{Server: existingServer, Action: &hcloud.Action{ID: actionDone}}, nil
+			}
+		}
+
 		msg = fmt.Sprintf("%s: %s", msg, err.Error())
+		if hcloud.IsError(err, hcloud.ErrorCodeUniquenessError) {
+			// The name is taken and we could not adopt the existing server. Give the operator the
+			// concrete fix instead of the raw uniqueness error.
+			msg = fmt.Sprintf(
+				"Server creation failed because a server named %q already exists and it could not be adopted automatically: %s. "+
+					"Delete the conflicting HCloud server, or delete this Machine to get a replacement with a new name (deleting the Machine object leaves the original server behind as a dangling server). ",
+				hm.Name, err.Error())
+		}
 		s.scope.Error(nil, msg)
 		// No condition was set yet. Set a general condition to false.
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerCreateSucceededCondition,
@@ -2299,6 +2342,26 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 	}
 
 	s.scope.Info("DeprecationWarning finding Server by labels is no longer needed. We plan to remove that feature and rename findServer to getServer", "err", err)
+
+	return servers[0], nil
+}
+
+// findServerByName searches for a server with this HCloudMachine's exact name. Used to recover
+// from a uniqueness error on CreateServer, where relying on ProviderID isn't possible yet.
+// It returns server and error as nil when no server matches.
+func (s *Service) findServerByName(ctx context.Context) (*hcloud.Server, error) {
+	servers, err := s.scope.HCloudClient.ListServers(ctx, hcloud.ServerListOpts{Name: s.scope.Name()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	if len(servers) > 1 {
+		return nil, fmt.Errorf("found %d servers with name %s", len(servers), s.scope.Name())
+	}
+
+	if len(servers) == 0 {
+		return nil, nil
+	}
 
 	return servers[0], nil
 }

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -1254,6 +1254,233 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateOperatingSystemRunning))
 	})
 
+	It("recovers from a uniqueness error on CreateServer by adopting the existing server", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a previous reconcile that created the server but never persisted ProviderID")
+		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{
+			{
+				ID:     42,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusRunning,
+			},
+		}, nil)
+
+		By("calling reconcile")
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		By("ensuring the existing server was adopted instead of failing forever")
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRealOS))
+		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
+		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudMachineServerCreatedV1Beta2Reason)).To(BeTrue())
+	})
+
+	It("requeues to retry when a uniqueness error on CreateServer cannot be resolved by adoption", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a uniqueness error where the recovery lookup finds no matching server")
+		hcloudClient.On("CreateServer", mock.Anything, mock.Anything).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{}, nil)
+
+		By("calling reconcile")
+		result, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		By("ensuring the machine requeues to retry instead of being marked irrecoverable")
+		Expect(result.RequeueAfter).To(Equal(10 * time.Minute))
+		Expect(v1beta1conditions.IsFalse(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(v1beta1conditions.GetReason(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
+			To(Equal(infrav1.ServerCreateFailedReason))
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineServerCreationFailedV1Beta2Reason)).To(BeTrue())
+		Expect(v1beta1conditions.GetMessage(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).
+			To(ContainSubstring("could not be adopted"))
+	})
+
+	It("recovers from a uniqueness error on CreateServer by adopting the existing server (imageURL)", func() {
+		By("setting the bootstrap data")
+		err = testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})
+		Expect(err).To(BeNil())
+		service.scope.HCloudMachine.Spec.ImageName = ""
+		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
+		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-test.sh"
+
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+
+		hcloudClient.On("GetServerType", mock.Anything, mock.Anything).Return(&hcloud.ServerType{
+			Architecture: hcloud.ArchitectureX86,
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: "caph-image-name==ubuntu-24.04",
+			},
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{
+			{
+				ID:   123456,
+				Name: "ubuntu",
+			},
+		}, nil)
+
+		hcloudClient.On("ListImages", mock.Anything, hcloud.ImageListOpts{
+			Name:         "ubuntu-24.04",
+			Architecture: []hcloud.Architecture{hcloud.ArchitectureX86},
+		}).Return([]*hcloud.Image{}, nil)
+
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+
+		By("simulating a previous reconcile that created the server but never persisted ProviderID")
+		hcloudClient.On("CreateServer", mock.Anything, mock.MatchedBy(func(opts hcloud.ServerCreateOpts) bool {
+			// an imageURL machine must be created powered off, so its first boot goes into the rescue system
+			return opts.StartAfterCreate != nil && !*opts.StartAfterCreate
+		})).Return(hcloud.ServerCreateResult{}, hcloud.Error{
+			Code:    hcloud.ErrorCodeUniquenessError,
+			Message: "server name is already used",
+		})
+		hcloudClient.On("ListServers", mock.Anything, hcloud.ServerListOpts{Name: "my-machine"}).Return([]*hcloud.Server{
+			{
+				ID:     42,
+				Name:   "my-machine",
+				Status: hcloud.ServerStatusOff,
+			},
+		}, nil)
+
+		By("calling reconcile")
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		By("ensuring the existing server was adopted, with the create action treated as already finished")
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateInitializing))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDCreateServer).To(Equal(int64(actionDone)))
+		Expect(*service.scope.HCloudMachine.Spec.ProviderID).To(Equal("hcloud://42"))
+		Expect(v1beta1conditions.IsTrue(service.scope.HCloudMachine, infrav1.ServerCreateSucceededCondition)).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerCreatedV1Beta2Condition, metav1.ConditionTrue, infrav1.HCloudMachineServerCreatedV1Beta2Reason)).To(BeTrue())
+
+		By("reconciling again: handleBootStateInitializing must not wait on a create action, since ActionIDCreateServer is already actionDone")
+		// On release-1.1 Reconcile fetches the live server at the top for every BootState, so the
+		// second reconcile looks the adopted server up by its provider ID.
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:     42,
+			Name:   "my-machine",
+			Status: hcloud.ServerStatusOff,
+		}, nil).Maybe()
+		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(
+			hcloud.ServerEnableRescueResult{
+				Action: &hcloud.Action{
+					ID:     334455,
+					Status: hcloud.ActionStatusRunning,
+				},
+			}, nil).Once()
+		_, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
+	})
+
 	It("transitions to BootStateOperatingSystemRunning (imageURL)", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes server creation getting stuck forever when a server with the same name already exists.

**Which issue(s) this PR fixes**:
None (backport of PR #2167).

**Special notes for your reviewer**:
Cherry-picked cleanly from main (cc76cff89), no conflicts. The imageURL recovery test got a GetServer mock for the second reconcile, since release-1.1 still fetches the server at the top of Reconcile (removed on main by #2171). Server unit tests pass.
