### PR TITLE
🐛 Determine proxy-protocol readiness from control-plane machines, not the workload cluster (port #2179 to main)

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -222,10 +222,12 @@ type LoadBalancerSpec struct {
 	// unexpected PROXY-protocol headers.
 	//
 	// For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-	// every control-plane node carries the annotation
-	// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-	// service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-	// nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+	// every control-plane machine carries the annotation
+	// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+	// service to proxy protocol in place. The annotation is set on the control-plane machine
+	// template, so a machine from an earlier template does not carry it and the check stays false
+	// until the rollout completes. This prevents backends still expecting plain TCP from receiving
+	// malformed PROXY-protocol headers.
 	//
 	// Enabling proxy protocol is a one-way operation — it is never turned back off.
 	// +optional

--- a/api/v1beta2/hetznercluster_types.go
+++ b/api/v1beta2/hetznercluster_types.go
@@ -47,10 +47,10 @@ const (
 
 	// ProxyProtocolForControlPlaneLoadBalancerAnnotation is used only when enabling proxy protocol
 	// on an EXISTING cluster (migration path). It must be present with value "true" on ALL
-	// control-plane nodes before CAPH recreates the LB service with proxy protocol enabled.
-	// The annotation is set by an external service (e.g. a node-configuration daemonset) once the
-	// node is ready to receive PROXY-protocol connections. CAPH reads this annotation — it never
-	// writes it.
+	// control-plane machines before CAPH switches the LB service to proxy protocol in place.
+	// The annotation is set on the control-plane machine template, so it is present exactly on
+	// the machines whose template expects proxy protocol; machines from an earlier template do not
+	// carry it. CAPH reads this annotation on the control-plane machines; it never writes it.
 	//
 	// For NEW clusters created with EnableProxyProtocol: true, this annotation is never read:
 	// the LB service is created with proxy protocol from the start, so no migration is needed.

--- a/api/v1beta2/types.go
+++ b/api/v1beta2/types.go
@@ -230,10 +230,12 @@ type LoadBalancerSpec struct {
 	// unexpected PROXY-protocol headers.
 	//
 	// For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-	// every control-plane node carries the annotation
-	// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-	// service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-	// nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+	// every control-plane machine carries the annotation
+	// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+	// service to proxy protocol in place. The annotation is set on the control-plane machine
+	// template, so a machine from an earlier template does not carry it and the check stays false
+	// until the rollout completes. This prevents backends still expecting plain TCP from receiving
+	// malformed PROXY-protocol headers.
 	//
 	// Enabling proxy protocol is a one-way operation — it is never turned back off.
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclusters.yaml
@@ -111,10 +111,12 @@ spec:
                       unexpected PROXY-protocol headers.
 
                       For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                      every control-plane node carries the annotation
-                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                      service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                      nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+                      every control-plane machine carries the annotation
+                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+                      service to proxy protocol in place. The annotation is set on the control-plane machine
+                      template, so a machine from an earlier template does not carry it and the check stays false
+                      until the rollout completes. This prevents backends still expecting plain TCP from receiving
+                      malformed PROXY-protocol headers.
 
                       Enabling proxy protocol is a one-way operation — it is never turned back off.
                     type: boolean
@@ -723,10 +725,12 @@ spec:
                       unexpected PROXY-protocol headers.
 
                       For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                      every control-plane node carries the annotation
-                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                      service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                      nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+                      every control-plane machine carries the annotation
+                      capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+                      service to proxy protocol in place. The annotation is set on the control-plane machine
+                      template, so a machine from an earlier template does not carry it and the check stays false
+                      until the rollout completes. This prevents backends still expecting plain TCP from receiving
+                      malformed PROXY-protocol headers.
 
                       Enabling proxy protocol is a one-way operation — it is never turned back off.
                     type: boolean

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hetznerclustertemplates.yaml
@@ -135,10 +135,12 @@ spec:
                               unexpected PROXY-protocol headers.
 
                               For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                              every control-plane node carries the annotation
-                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                              service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                              nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+                              every control-plane machine carries the annotation
+                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+                              service to proxy protocol in place. The annotation is set on the control-plane machine
+                              template, so a machine from an earlier template does not carry it and the check stays false
+                              until the rollout completes. This prevents backends still expecting plain TCP from receiving
+                              malformed PROXY-protocol headers.
 
                               Enabling proxy protocol is a one-way operation — it is never turned back off.
                             type: boolean
@@ -525,10 +527,12 @@ spec:
                               unexpected PROXY-protocol headers.
 
                               For existing clusters that want to enable proxy protocol after the fact, CAPH waits until
-                              every control-plane node carries the annotation
-                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" (set by an external
-                              service, never by CAPH) before recreating the LB service with proxy protocol. This prevents
-                              nodes still expecting plain TCP from receiving malformed PROXY-protocol headers.
+                              every control-plane machine carries the annotation
+                              capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true" before switching the LB
+                              service to proxy protocol in place. The annotation is set on the control-plane machine
+                              template, so a machine from an earlier template does not carry it and the check stays false
+                              until the rollout completes. This prevents backends still expecting plain TCP from receiving
+                              malformed PROXY-protocol headers.
 
                               Enabling proxy protocol is a one-way operation — it is never turned back off.
                             type: boolean

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -304,7 +304,7 @@ func (r *HetznerClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 
 func processControlPlaneEndpoint(hetznerCluster *infrav2.HetznerCluster) {
 	if hetznerCluster.Spec.ControlPlaneLoadBalancer.Enabled {
-		if hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4 != "<nil>" {
+		if hetznerCluster.Status.ControlPlaneLoadBalancer != nil && hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4 != "<nil>" {
 			defaultHost := hetznerCluster.Status.ControlPlaneLoadBalancer.IPv4
 			defaultPort := int32(hetznerCluster.Spec.ControlPlaneLoadBalancer.Port) //nolint:gosec // Validation for the port range (1 to 65535) is already done via kubebuilder.
 

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -1800,6 +1800,22 @@ func TestSetControlPlaneEndpoint(t *testing.T) {
 		}
 	})
 
+	t.Run("does not panic if load balancer is enabled but Status.ControlPlaneLoadBalancer itself is nil (load balancer not reconciled yet)", func(t *testing.T) {
+		hetznerCluster := &infrav2.HetznerCluster{
+			Spec: infrav2.HetznerClusterSpec{
+				ControlPlaneLoadBalancer: infrav2.LoadBalancerSpec{
+					Enabled: true,
+				},
+			},
+		}
+
+		processControlPlaneEndpoint(hetznerCluster)
+
+		if hetznerCluster.Spec.ControlPlaneEndpoint.Host != "" || hetznerCluster.Spec.ControlPlaneEndpoint.Port != 0 {
+			t.Fatalf("ControlPlaneEndpoint should not be set when the load balancer is not reconciled yet")
+		}
+	})
+
 	t.Run("return true if load balancer is enabled, IPv4 is not nil, and ControlPlaneEndpoint is nil. Values of ControlPlaneEndpoint.Host and ControlPlaneEndpoint.Port will get updated", func(t *testing.T) {
 		hetznerCluster := &infrav2.HetznerCluster{
 			Spec: infrav2.HetznerClusterSpec{

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -269,48 +268,42 @@ func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 	return err
 }
 
-// AllControlPlaneNodesReadyForProxyProtocol returns true when every control-plane node
-// in the workload cluster carries the annotation
-// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true".
-// Returns false (no error) when the workload cluster has no control-plane nodes yet.
-func (s *ClusterScope) AllControlPlaneNodesReadyForProxyProtocol(ctx context.Context) (bool, error) {
-	wlClientConfig, err := s.ClientConfig(ctx)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			s.V(1).Info("proxy protocol: kubeconfig secret not found, cluster not yet provisioned")
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to get workload cluster client config: %w", err)
+// AllControlPlaneMachinesAnnotatedForProxyProtocol returns true when the control plane is
+// fully rolled out to the machine template that expects PROXY protocol at the load
+// balancer. It lists the cluster's control-plane Machines in the management cluster (the
+// Cluster API Machine, so one list covers every control plane whatever its infrastructure)
+// and requires every one to carry the annotation
+// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which the
+// control-plane machine template sets and Cluster API propagates onto the Machine.
+//
+// Machines from an earlier template do not carry the annotation, so the check stays false
+// until the last of them is replaced. It returns false (no error) while the cluster has no
+// control-plane machines yet.
+func (s *ClusterScope) AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
+	machines := &clusterv1.MachineList{}
+	listOptions := []client.ListOption{
+		client.InNamespace(s.Namespace()),
+		client.MatchingLabels{
+			clusterv1.ClusterNameLabel:         s.Cluster.Name,
+			clusterv1.MachineControlPlaneLabel: "",
+		},
 	}
-	if err := IsControlPlaneReady(ctx, wlClientConfig); err != nil {
-		return false, fmt.Errorf("workload cluster control plane not ready: %w", err)
-	}
-
-	restConfig, err := wlClientConfig.ClientConfig()
-	if err != nil {
-		return false, fmt.Errorf("failed to get workload cluster rest config: %w", err)
-	}
-	wlClient, err := client.New(restConfig, client.Options{})
-	if err != nil {
-		return false, fmt.Errorf("failed to create workload cluster client: %w", err)
+	if err := s.Client.List(ctx, machines, listOptions...); err != nil {
+		return false, fmt.Errorf("failed to list control-plane Machines: %w", err)
 	}
 
-	nodeList := &corev1.NodeList{}
-	if err := wlClient.List(ctx, nodeList, client.MatchingLabels{clusterv1.NodeRoleLabelPrefix + "/control-plane": ""}); err != nil {
-		return false, fmt.Errorf("failed to list control-plane nodes in workload cluster: %w", err)
-	}
-
-	if len(nodeList.Items) == 0 {
-		s.V(1).Info("proxy protocol: no control-plane nodes found")
+	if len(machines.Items) == 0 {
+		s.V(1).Info("proxy protocol: no control-plane machines found yet")
 		return false, nil
 	}
-	for _, node := range nodeList.Items {
-		if node.Annotations[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
-			s.V(1).Info("proxy protocol: node missing annotation",
-				"node", node.Name,
-				"annotation", infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation)
+
+	for i := range machines.Items {
+		machine := &machines.Items[i]
+		if machine.GetAnnotations()[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: control-plane machine is missing the annotation", "machine", machine.GetName())
 			return false, nil
 		}
 	}
+
 	return true, nil
 }

--- a/pkg/scope/cluster_test.go
+++ b/pkg/scope/cluster_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
+)
+
+func controlPlaneObjectMeta(namespace, name, clusterName string, annotated bool) metav1.ObjectMeta {
+	annotations := map[string]string{}
+	if annotated {
+		annotations[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] = "true"
+	}
+
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels: map[string]string{
+			clusterv1.ClusterNameLabel:         clusterName,
+			clusterv1.MachineControlPlaneLabel: "",
+		},
+		Annotations: annotations,
+	}
+}
+
+func controlPlaneMachine(namespace, name, clusterName string, annotated bool) *clusterv1.Machine {
+	return &clusterv1.Machine{
+		ObjectMeta: controlPlaneObjectMeta(namespace, name, clusterName, annotated),
+	}
+}
+
+func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+	)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(infrav2.AddToScheme(scheme))
+
+	tests := []struct {
+		name     string
+		machines []client.Object
+		want     bool
+	}{
+		{
+			name:     "no control-plane machines yet",
+			machines: nil,
+			want:     false,
+		},
+		{
+			name: "all control planes annotated",
+			machines: []client.Object{
+				controlPlaneMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneMachine(namespace, "cp-2", clusterName, true),
+				controlPlaneMachine(namespace, "cp-3", clusterName, true),
+			},
+			want: true,
+		},
+		{
+			name: "one machine still from the old template misses the annotation",
+			machines: []client.Object{
+				controlPlaneMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneMachine(namespace, "cp-2", clusterName, false),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := append([]client.Object{}, tt.machines...)
+			// A worker machine of the same cluster (no control-plane label) must never
+			// affect the result.
+			objects = append(objects, &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker-1",
+					Namespace: namespace,
+					Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+				},
+			})
+
+			s := &ClusterScope{
+				Logger: klog.Background(),
+				Client: fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+				},
+				HetznerCluster: &infrav2.HetznerCluster{
+					ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+				},
+			}
+
+			got, err := s.AllControlPlaneMachinesAnnotatedForProxyProtocol(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -52,6 +52,7 @@ type Client interface {
 	AddIPTargetToLoadBalancer(context.Context, hcloud.LoadBalancerAddIPTargetOpts, *hcloud.LoadBalancer) error
 	DeleteIPTargetOfLoadBalancer(context.Context, *hcloud.LoadBalancer, net.IP) error
 	AddServiceToLoadBalancer(context.Context, *hcloud.LoadBalancer, hcloud.LoadBalancerAddServiceOpts) error
+	UpdateServiceOnLoadBalancer(context.Context, *hcloud.LoadBalancer, int, hcloud.LoadBalancerUpdateServiceOpts) error
 	DeleteServiceFromLoadBalancer(context.Context, *hcloud.LoadBalancer, int) error
 	ListImages(context.Context, hcloud.ImageListOpts) ([]*hcloud.Image, error)
 	CreateServer(context.Context, hcloud.ServerCreateOpts) (hcloud.ServerCreateResult, error)
@@ -215,6 +216,11 @@ func (c *realClient) DeleteIPTargetOfLoadBalancer(ctx context.Context, lb *hclou
 
 func (c *realClient) AddServiceToLoadBalancer(ctx context.Context, lb *hcloud.LoadBalancer, opts hcloud.LoadBalancerAddServiceOpts) error {
 	_, _, err := c.client.LoadBalancer.AddService(ctx, lb, opts)
+	return err
+}
+
+func (c *realClient) UpdateServiceOnLoadBalancer(ctx context.Context, lb *hcloud.LoadBalancer, listenPort int, opts hcloud.LoadBalancerUpdateServiceOpts) error {
+	_, _, err := c.client.LoadBalancer.UpdateService(ctx, lb, listenPort, opts)
 	return err
 }
 

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -421,9 +421,39 @@ func (c *cacheHCloudClient) AddServiceToLoadBalancer(_ context.Context, lb *hclo
 	}
 
 	// Add it
-	c.loadBalancerCache.idMap[lb.ID].Services = append(
-		c.loadBalancerCache.idMap[lb.ID].Services, hcloud.LoadBalancerService{ListenPort: *opts.ListenPort, DestinationPort: *opts.DestinationPort})
+	service := hcloud.LoadBalancerService{ListenPort: *opts.ListenPort, DestinationPort: *opts.DestinationPort}
+	if opts.Proxyprotocol != nil {
+		service.Proxyprotocol = *opts.Proxyprotocol
+	}
+	c.loadBalancerCache.idMap[lb.ID].Services = append(c.loadBalancerCache.idMap[lb.ID].Services, service)
 	return nil
+}
+
+func (c *cacheHCloudClient) UpdateServiceOnLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, listenPort int, opts hcloud.LoadBalancerUpdateServiceOpts) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	// Check if loadBalancer exists
+	if _, found := c.loadBalancerCache.idMap[lb.ID]; !found {
+		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+	}
+
+	for i, s := range c.loadBalancerCache.idMap[lb.ID].Services {
+		if s.ListenPort != listenPort {
+			continue
+		}
+		if opts.Proxyprotocol != nil {
+			c.loadBalancerCache.idMap[lb.ID].Services[i].Proxyprotocol = *opts.Proxyprotocol
+		}
+		if opts.DestinationPort != nil {
+			c.loadBalancerCache.idMap[lb.ID].Services[i].DestinationPort = *opts.DestinationPort
+		}
+		if opts.Protocol != "" {
+			c.loadBalancerCache.idMap[lb.ID].Services[i].Protocol = opts.Protocol
+		}
+		return nil
+	}
+
+	return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
 }
 
 func (c *cacheHCloudClient) DeleteServiceFromLoadBalancer(_ context.Context, lb *hcloud.LoadBalancer, listenPort int) error {

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -1882,6 +1882,55 @@ func (_c *Client_UpdateLoadBalancer_Call) RunAndReturn(run func(context.Context,
 	return _c
 }
 
+// UpdateServiceOnLoadBalancer provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *Client) UpdateServiceOnLoadBalancer(_a0 context.Context, _a1 *hcloud.LoadBalancer, _a2 int, _a3 hcloud.LoadBalancerUpdateServiceOpts) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateServiceOnLoadBalancer")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *hcloud.LoadBalancer, int, hcloud.LoadBalancerUpdateServiceOpts) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Client_UpdateServiceOnLoadBalancer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateServiceOnLoadBalancer'
+type Client_UpdateServiceOnLoadBalancer_Call struct {
+	*mock.Call
+}
+
+// UpdateServiceOnLoadBalancer is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *hcloud.LoadBalancer
+//   - _a2 int
+//   - _a3 hcloud.LoadBalancerUpdateServiceOpts
+func (_e *Client_Expecter) UpdateServiceOnLoadBalancer(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *Client_UpdateServiceOnLoadBalancer_Call {
+	return &Client_UpdateServiceOnLoadBalancer_Call{Call: _e.mock.On("UpdateServiceOnLoadBalancer", _a0, _a1, _a2, _a3)}
+}
+
+func (_c *Client_UpdateServiceOnLoadBalancer_Call) Run(run func(_a0 context.Context, _a1 *hcloud.LoadBalancer, _a2 int, _a3 hcloud.LoadBalancerUpdateServiceOpts)) *Client_UpdateServiceOnLoadBalancer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*hcloud.LoadBalancer), args[2].(int), args[3].(hcloud.LoadBalancerUpdateServiceOpts))
+	})
+	return _c
+}
+
+func (_c *Client_UpdateServiceOnLoadBalancer_Call) Return(_a0 error) *Client_UpdateServiceOnLoadBalancer_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_UpdateServiceOnLoadBalancer_Call) RunAndReturn(run func(context.Context, *hcloud.LoadBalancer, int, hcloud.LoadBalancerUpdateServiceOpts) error) *Client_UpdateServiceOnLoadBalancer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewClient(t interface {

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -292,46 +292,33 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 
 	toCreate, toDelete := utils.DifferenceOfIntSlices(wantServiceListenPorts, slices.Collect(maps.Keys(existingServicesByPort)))
 
-	// kubeAPIServiceExists: whether the kube-API service already exists on the LB.
-	// New cluster: service absent → create immediately with EnableProxyProtocol from spec (no annotation check).
-	// Existing cluster migration: service present without proxy protocol → wait for all CP nodes to carry the
-	// annotation before recreating, to avoid sending malformed PROXY-protocol headers to unprepared backends.
+	// Two cases for the kube-API service:
+	//   - present without proxy protocol → an existing cluster enabling it: wait until every
+	//     control-plane machine is annotated, then switch it on in place below.
+	//   - absent → create it below from the spec value. The service is only absent when an
+	//     existing load balancer is taken over instead of creating a new one, or if the service
+	//     got manually deleted.
 	existingKubeAPIService, kubeAPIServiceExists := existingServicesByPort[kubeAPIServicePort]
 	proxyProtocolAlreadyActive := kubeAPIServiceExists && existingKubeAPIService.Proxyprotocol
 
 	// proxyProtocolShouldGetEnabled: whether proxy protocol should get enabled now.
-	// The workload cluster is only contacted when the spec wants proxy protocol but the LB
-	// service doesn't have it yet. For new clusters or when already active, no call is made.
+	// The control-plane machines are only checked when the spec wants proxy protocol but the LB
+	// service doesn't have it yet. When the service is absent or already has it, no check is made.
 	var proxyProtocolShouldGetEnabled bool
 	var requeueForProxyProtocol bool
 	if s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol && kubeAPIServiceExists && !proxyProtocolAlreadyActive {
 		var err error
-		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneNodesReadyForProxyProtocol(ctx)
+		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if !proxyProtocolShouldGetEnabled {
-			s.scope.V(1).Info("proxy protocol: not all CP nodes ready yet, requeueing")
+			s.scope.V(1).Info("proxy protocol: not all control-plane machines annotated yet, requeueing")
 			requeueForProxyProtocol = true
 		}
 	}
-	// Enabling proxy protocol is a one-way operation: delete the existing service and
-	// recreate it with proxy protocol on once all CP nodes signal readiness.
-	if proxyProtocolShouldGetEnabled && !proxyProtocolAlreadyActive {
-		toDelete = append(toDelete, kubeAPIServicePort)
-		toCreate = append(toCreate, kubeAPIServicePort)
-	}
 
-	// kubeAPIProxyProtocol: the proxy protocol value to use when creating the kube-API service.
-	// For existing clusters, wait for CP nodes to signal readiness before enabling.
-	// For new clusters, use the spec value directly.
-	kubeAPIProxyProtocol := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol
-	if kubeAPIServiceExists {
-		kubeAPIProxyProtocol = proxyProtocolShouldGetEnabled
-	}
-
-	// delete services that are no longer in the spec, or the kube-API service being recreated
-	// to enable proxy protocol
+	// delete services that are no longer in the spec
 	var multierr error
 
 	for _, listenPort := range toDelete {
@@ -349,8 +336,10 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	for i, listenPort := range toCreate {
 		proxyProtocol := false
 		if listenPort == kubeAPIServicePort {
-			// Proxy protocol is only relevant for the kube-apiserver port (default 6443).
-			proxyProtocol = kubeAPIProxyProtocol
+			// Proxy protocol is only relevant for the kube-API service, which is created here
+			// straight from the spec value. The annotation check only guards enabling proxy
+			// protocol on a service that already exists.
+			proxyProtocol = s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol
 		}
 		destinationPort := wantServiceListenPortsMap[listenPort].DestinationPort
 		serviceOpts := hcloud.LoadBalancerAddServiceOpts{
@@ -368,7 +357,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			}
 		} else if listenPort == kubeAPIServicePort {
 			// Status.ControlPlaneLoadBalancer was snapshotted from the LB state fetched at the
-			// start of Reconcile, before this service was (re)created, so it still shows the old
+			// start of Reconcile, before this service was created, so it still shows the old
 			// value. Update it now so callers observe the change in this reconcile instead of
 			// waiting for the next one (e.g. the next full resync, up to --sync-period later).
 			s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled = proxyProtocol
@@ -376,6 +365,24 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	}
 	if requeueForProxyProtocol {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, multierr
+	}
+
+	// If proxy protocol is not active yet but should be, activate it in place. HCloud's
+	// update_service flips Proxyprotocol on the live service, so the kube-API service is
+	// never absent from the LB.
+	if proxyProtocolShouldGetEnabled && !proxyProtocolAlreadyActive {
+		proxyProtocol := true
+		updateOpts := hcloud.LoadBalancerUpdateServiceOpts{Proxyprotocol: &proxyProtocol}
+		if err := s.scope.HCloudClient.UpdateServiceOnLoadBalancer(ctx, lb, kubeAPIServicePort, updateOpts); err != nil {
+			// return immediately on rate limit
+			hcloudutil.HandleRateLimitExceeded(s.scope.HetznerCluster, err, "UpdateServiceOnLoadBalancer")
+			multierr = errors.Join(multierr, fmt.Errorf("failed to update kube-API service on load balancer to enable proxy protocol: %w", err))
+			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+				return reconcile.Result{}, multierr
+			}
+		} else {
+			s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled = true
+		}
 	}
 	return reconcile.Result{}, multierr
 }
@@ -418,7 +425,7 @@ func createOptsFromSpec(hc *infrav2.HetznerCluster) hcloud.LoadBalancerCreateOpt
 	// Set name
 	name := utils.GenerateName(nil, fmt.Sprintf("%s-kube-apiserver-", hc.Name))
 
-	proxyprotocol := false
+	proxyprotocol := hc.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol
 
 	var network *hcloud.Network
 	if hc.Status.Network != nil {

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
@@ -220,63 +221,109 @@ func TestReconcileServices_ProxyProtocolAlreadyActive_NoChanges(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
-// TestReconcileServices_ProxyProtocolMigration_NodesNotReady verifies that the kube-API
-// service is NOT recreated when proxy protocol is requested but the control-plane nodes
-// have not yet signalled readiness (annotation absent / workload cluster unreachable).
-func TestReconcileServices_ProxyProtocolMigration_NodesNotReady(t *testing.T) {
+func controlPlaneMachineForProxy(name string, annotated bool) *clusterv1.Machine {
+	annotations := map[string]string{}
+	if annotated {
+		annotations[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] = "true"
+	}
+	return &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         "test-cluster",
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			Annotations: annotations,
+		},
+	}
+}
+
+// newProxyMigrationService builds a Service whose proxy-protocol readiness is decided from the
+// given control-plane machines in the management cluster.
+func newProxyMigrationService(t *testing.T, mockClient *mocks.Client, machines ...client.Object) *Service {
+	t.Helper()
 	hetznerCluster := newTestHetznerCluster()
+	hetznerCluster.Namespace = metav1.NamespaceDefault
 	hetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol = true
 
-	mockClient := &mocks.Client{}
+	scheme := runtime.NewScheme()
+	_ = clusterv1.AddToScheme(scheme)
+
 	svc := newTestService(t, hetznerCluster, mockClient)
+	svc.scope.Client = fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(machines...).Build()
+	svc.scope.APIReader = svc.scope.Client
+	svc.scope.Cluster = &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: metav1.NamespaceDefault},
+	}
+	return svc
+}
+
+// TestReconcileServices_ProxyProtocolMigration_MachinesNotReady verifies that proxy protocol is
+// NOT switched on when it is requested but a control-plane machine has not yet been annotated.
+func TestReconcileServices_ProxyProtocolMigration_MachinesNotReady(t *testing.T) {
+	mockClient := &mocks.Client{}
+	svc := newProxyMigrationService(t, mockClient,
+		controlPlaneMachineForProxy("cp-1", true),
+		controlPlaneMachineForProxy("cp-2", false),
+	)
 	hcloudLB := &hcloud.LoadBalancer{
 		Services: []hcloud.LoadBalancerService{
 			{ListenPort: testKubeAPIListenPort, Proxyprotocol: false},
 		},
 	}
 
-	// Provide a k8s client with no secrets so AllControlPlaneNodesReadyForProxyProtocol
-	// returns false (kubeconfig secret not found → nodes considered not ready).
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeK8sClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
-	svc.scope.Client = fakeK8sClient
-	svc.scope.APIReader = fakeK8sClient
-	svc.scope.Cluster = &clusterv1.Cluster{}
-
-	_, err := svc.reconcileServices(context.Background(), hcloudLB)
+	res, err := svc.reconcileServices(context.Background(), hcloudLB)
 	require.NoError(t, err)
+	require.NotZero(t, res.RequeueAfter, "should requeue while a control-plane machine is not annotated")
 	mockClient.AssertExpectations(t)
 }
 
-// TestReconcileServices_ProxyProtocolMigration_NodesNotReady_StillReconcilesExtraServices
-// verifies that when proxy protocol migration is waiting (CP nodes not ready), the function
-// still reconciles extraServices instead of returning early.
-func TestReconcileServices_ProxyProtocolMigration_NodesNotReady_StillReconcilesExtraServices(t *testing.T) {
+// TestReconcileServices_ProxyProtocolMigration_MachinesReady_SwitchesInPlace verifies that once
+// every control-plane machine is annotated, proxy protocol is switched on in place via
+// UpdateServiceOnLoadBalancer without deleting the kube-API service.
+func TestReconcileServices_ProxyProtocolMigration_MachinesReady_SwitchesInPlace(t *testing.T) {
+	mockClient := &mocks.Client{}
+	svc := newProxyMigrationService(t, mockClient,
+		controlPlaneMachineForProxy("cp-1", true),
+		controlPlaneMachineForProxy("cp-2", true),
+	)
+	hcloudLB := &hcloud.LoadBalancer{
+		Services: []hcloud.LoadBalancerService{
+			{ListenPort: testKubeAPIListenPort, Proxyprotocol: false},
+		},
+	}
+
+	mockClient.On("UpdateServiceOnLoadBalancer", mock.Anything, hcloudLB, mock.Anything, mock.Anything).Return(nil)
+
+	res, err := svc.reconcileServices(context.Background(), hcloudLB)
+	require.NoError(t, err)
+	require.Zero(t, res.RequeueAfter)
+	require.True(t, svc.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled)
+	mockClient.AssertExpectations(t)
+}
+
+// TestReconcileServices_ProxyProtocolMigration_MachinesNotReady_StillReconcilesExtraServices
+// verifies that while proxy protocol migration is waiting (a control-plane machine not yet
+// annotated), the function still reconciles extraServices instead of returning early.
+func TestReconcileServices_ProxyProtocolMigration_MachinesNotReady_StillReconcilesExtraServices(t *testing.T) {
 	const extraListenPort = 8080
 	const extraDestPort = 8081
 
-	hetznerCluster := newTestHetznerCluster()
-	hetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol = true
-	hetznerCluster.Spec.ControlPlaneLoadBalancer.ExtraServices = []infrav2.LoadBalancerServiceSpec{
+	mockClient := &mocks.Client{}
+	svc := newProxyMigrationService(t, mockClient,
+		controlPlaneMachineForProxy("cp-1", true),
+		controlPlaneMachineForProxy("cp-2", false),
+	)
+	svc.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.ExtraServices = []infrav2.LoadBalancerServiceSpec{
 		{Protocol: "tcp", ListenPort: extraListenPort, DestinationPort: extraDestPort},
 	}
-
-	mockClient := &mocks.Client{}
-	svc := newTestService(t, hetznerCluster, mockClient)
 	hcloudLB := &hcloud.LoadBalancer{
 		Services: []hcloud.LoadBalancerService{
 			{ListenPort: testKubeAPIListenPort, Proxyprotocol: false}, // kube-API exists without proxy protocol
 			// extraService is missing from the LB — should be added even while waiting for proxy protocol
 		},
 	}
-
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	fakeK8sClient := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
-	svc.scope.Client = fakeK8sClient
-	svc.scope.APIReader = fakeK8sClient
-	svc.scope.Cluster = &clusterv1.Cluster{}
 
 	// The extra service must be added even though proxy protocol migration is pending.
 	var capturedOpts hcloud.LoadBalancerAddServiceOpts


### PR DESCRIPTION
**What this PR does / why we need it**:
Decides whether the kube-apiserver load balancer can turn on PROXY protocol by reading the cluster's own control plane machines, instead of reaching into the workload cluster. It also turns PROXY protocol on at load balancer creation when the spec asks for it, and switches an existing service in place instead of deleting and recreating it (from #2185).

**Which issue(s) this PR fixes**:
None (forward-port of #2179, which also carries #2185).

**Special notes for your reviewer**:
main has already gone through the v1beta2 migration. The following changes were needed to make it work on main:

- The machine readiness check was written against the v1beta2 types, which is the version the controller uses on main. It replaces the older check that main still had, which read the workload cluster.
- The control plane endpoint handling was adjusted because that field is a plain value on main, but a pointer on release-1.1.
