### PR TITLE
🐛 Gate control-plane load balancer PROXY protocol on the InfraMachine annotation

### DIFF
--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -270,19 +270,13 @@ func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 	return err
 }
 
-// AllControlPlaneMachinesAnnotatedForProxyProtocol returns true when the control plane is
-// fully rolled out to the machine template that expects PROXY protocol at the load
-// balancer. It lists the cluster's control-plane Machines in the management cluster (the
-// Cluster API Machine, so one list covers every control plane whatever its infrastructure)
-// and requires every one to carry the annotation
-// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which the
-// control-plane machine template sets and Cluster API propagates onto the Machine.
-//
-// Machines from an earlier template do not carry the annotation, so the check stays false
-// until the last of them is replaced. It returns false (no error) while the cluster has no
-// control-plane machines yet.
-func (s *ClusterScope) AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
-	machines := &clusterv1.MachineList{}
+// AllControlPlaneInfraMachinesAnnotatedForProxyProtocol returns true when every control-plane
+// infrastructure machine (HCloudMachine and HetznerBareMetalMachine) carries the annotation
+// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which is set on the
+// control-plane infrastructure machine template's spec.template.metadata. It lists the machines in
+// the management cluster, so it needs no workload-cluster client, and returns false (no error) while
+// the cluster has no control-plane infrastructure machines yet.
+func (s *ClusterScope) AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
 	listOptions := []client.ListOption{
 		client.InNamespace(s.Namespace()),
 		client.MatchingLabels{
@@ -290,21 +284,38 @@ func (s *ClusterScope) AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx cont
 			clusterv1.MachineControlPlaneLabel: "",
 		},
 	}
-	if err := s.Client.List(ctx, machines, listOptions...); err != nil {
-		return false, fmt.Errorf("failed to list control-plane Machines: %w", err)
-	}
 
-	if len(machines.Items) == 0 {
-		s.V(1).Info("proxy protocol: no control-plane machines found yet")
-		return false, nil
-	}
+	found := 0
 
-	for i := range machines.Items {
-		machine := &machines.Items[i]
-		if machine.GetAnnotations()[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
-			s.V(1).Info("proxy protocol: control-plane machine is missing the annotation", "machine", machine.GetName())
+	hcloudMachines := &infrav1.HCloudMachineList{}
+	if err := s.Client.List(ctx, hcloudMachines, listOptions...); err != nil {
+		return false, fmt.Errorf("failed to list control-plane HCloudMachines: %w", err)
+	}
+	for i := range hcloudMachines.Items {
+		m := &hcloudMachines.Items[i]
+		if m.GetAnnotations()[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: control-plane HCloudMachine is missing the annotation", "hcloudMachine", m.GetName())
 			return false, nil
 		}
+		found++
+	}
+
+	bmMachines := &infrav1.HetznerBareMetalMachineList{}
+	if err := s.Client.List(ctx, bmMachines, listOptions...); err != nil {
+		return false, fmt.Errorf("failed to list control-plane HetznerBareMetalMachines: %w", err)
+	}
+	for i := range bmMachines.Items {
+		m := &bmMachines.Items[i]
+		if m.GetAnnotations()[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: control-plane HetznerBareMetalMachine is missing the annotation", "hetznerBareMetalMachine", m.GetName())
+			return false, nil
+		}
+		found++
+	}
+
+	if found == 0 {
+		s.V(1).Info("proxy protocol: no control-plane infrastructure machines found yet")
+		return false, nil
 	}
 
 	return true, nil

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -273,9 +273,11 @@ func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 // AllControlPlaneInfraMachinesAnnotatedForProxyProtocol returns true when every control-plane
 // infrastructure machine (HCloudMachine and HetznerBareMetalMachine) carries the annotation
 // capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which is set on the
-// control-plane infrastructure machine template's spec.template.metadata. It lists the machines in
-// the management cluster, so it needs no workload-cluster client, and returns false (no error) while
-// the cluster has no control-plane infrastructure machines yet.
+// control-plane infrastructure machine template's spec.template.metadata.
+//
+// Machines from an earlier template do not carry the annotation, so the check stays false
+// until the last of them is replaced. It returns false (no error) while the cluster has no
+// control-plane infrastructure machines yet.
 func (s *ClusterScope) AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
 	listOptions := []client.ListOption{
 		client.InNamespace(s.Namespace()),
@@ -291,6 +293,7 @@ func (s *ClusterScope) AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx
 	if err := s.Client.List(ctx, hcloudMachines, listOptions...); err != nil {
 		return false, fmt.Errorf("failed to list control-plane HCloudMachines: %w", err)
 	}
+
 	for i := range hcloudMachines.Items {
 		m := &hcloudMachines.Items[i]
 		if m.GetAnnotations()[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
@@ -304,6 +307,7 @@ func (s *ClusterScope) AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx
 	if err := s.Client.List(ctx, bmMachines, listOptions...); err != nil {
 		return false, fmt.Errorf("failed to list control-plane HetznerBareMetalMachines: %w", err)
 	}
+
 	for i := range bmMachines.Items {
 		m := &bmMachines.Items[i]
 		if m.GetAnnotations()[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {

--- a/pkg/scope/cluster_test.go
+++ b/pkg/scope/cluster_test.go
@@ -50,13 +50,19 @@ func controlPlaneObjectMeta(namespace, name, clusterName string, annotated bool)
 	}
 }
 
-func controlPlaneMachine(namespace, name, clusterName string, annotated bool) *clusterv1.Machine {
-	return &clusterv1.Machine{
+func controlPlaneHCloudMachine(namespace, name, clusterName string, annotated bool) *infrav1.HCloudMachine {
+	return &infrav1.HCloudMachine{
 		ObjectMeta: controlPlaneObjectMeta(namespace, name, clusterName, annotated),
 	}
 }
 
-func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
+func controlPlaneBareMetalMachine(namespace, name, clusterName string, annotated bool) *infrav1.HetznerBareMetalMachine {
+	return &infrav1.HetznerBareMetalMachine{
+		ObjectMeta: controlPlaneObjectMeta(namespace, name, clusterName, annotated),
+	}
+}
+
+func TestAllControlPlaneInfraMachinesAnnotatedForProxyProtocol(t *testing.T) {
 	const (
 		namespace   = "default"
 		clusterName = "test-cluster"
@@ -73,24 +79,40 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "no control-plane machines yet",
+			name:     "no control-plane infrastructure machines yet",
 			machines: nil,
 			want:     false,
 		},
 		{
-			name: "all control planes annotated",
+			name: "all hcloud control planes annotated",
 			machines: []client.Object{
-				controlPlaneMachine(namespace, "cp-1", clusterName, true),
-				controlPlaneMachine(namespace, "cp-2", clusterName, true),
-				controlPlaneMachine(namespace, "cp-3", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-2", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-3", clusterName, true),
 			},
 			want: true,
 		},
 		{
-			name: "one machine still from the old template misses the annotation",
+			name: "mixed hcloud and bare-metal control planes all annotated",
 			machines: []client.Object{
-				controlPlaneMachine(namespace, "cp-1", clusterName, true),
-				controlPlaneMachine(namespace, "cp-2", clusterName, false),
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneBareMetalMachine(namespace, "cp-2", clusterName, true),
+			},
+			want: true,
+		},
+		{
+			name: "one hcloud machine still from the old template misses the annotation",
+			machines: []client.Object{
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-2", clusterName, false),
+			},
+			want: false,
+		},
+		{
+			name: "one bare-metal machine still from the old template misses the annotation",
+			machines: []client.Object{
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneBareMetalMachine(namespace, "cp-2", clusterName, false),
 			},
 			want: false,
 		},
@@ -99,9 +121,9 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			objects := append([]client.Object{}, tt.machines...)
-			// A worker machine of the same cluster (no control-plane label) must never
+			// A worker infrastructure machine of the same cluster (no control-plane label) must never
 			// affect the result.
-			objects = append(objects, &clusterv1.Machine{
+			objects = append(objects, &infrav1.HCloudMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "worker-1",
 					Namespace: namespace,
@@ -120,7 +142,7 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 				},
 			}
 
-			got, err := s.AllControlPlaneMachinesAnnotatedForProxyProtocol(context.Background())
+			got, err := s.AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -329,18 +329,19 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	proxyProtocolAlreadyActive := kubeAPIServiceExists && existingKubeAPIService.Proxyprotocol
 
 	// proxyProtocolShouldGetEnabled: whether proxy protocol should get enabled now.
-	// The control-plane machines are only checked when the spec wants proxy protocol but the LB
-	// service doesn't have it yet. When the service is absent or already has it, no check is made.
+	// The control-plane infrastructure machines are only checked when the spec wants proxy protocol
+	// but the LB service doesn't have it yet. When the service is absent or already has it, no check
+	// is made.
 	var proxyProtocolShouldGetEnabled bool
 	var requeueForProxyProtocol bool
 	if s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol && kubeAPIServiceExists && !proxyProtocolAlreadyActive {
 		var err error
-		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx)
+		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if !proxyProtocolShouldGetEnabled {
-			s.scope.V(1).Info("proxy protocol: not all control-plane machines annotated yet, requeueing")
+			s.scope.V(1).Info("proxy protocol: not all control-plane infrastructure machines annotated yet, requeueing")
 			requeueForProxyProtocol = true
 		}
 	}

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -136,12 +136,12 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 		clusterName = "test-cluster"
 	)
 
-	controlPlaneMachine := func(name string, annotated bool) *clusterv1.Machine {
+	controlPlaneMachine := func(name string, annotated bool) *infrav1.HCloudMachine {
 		annotations := map[string]string{}
 		if annotated {
 			annotations[infrav1.ProxyProtocolForControlPlaneLoadBalancerAnnotation] = "true"
 		}
-		return &clusterv1.Machine{
+		return &infrav1.HCloudMachine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
@@ -204,7 +204,7 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 		return NewService(clusterScope), createdLB
 	}
 
-	It("switches proxy protocol on in place once all control-plane machines are annotated, without deleting the service", func() {
+	It("switches proxy protocol on in place once all control-plane infrastructure machines are annotated, without deleting the service", func() {
 		svc, lb := newServiceWithExistingKubeAPIService(
 			controlPlaneMachine("cp-1", true),
 			controlPlaneMachine("cp-2", true),
@@ -220,7 +220,7 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 		Expect(svc.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled).To(BeTrue())
 	})
 
-	It("requeues and leaves proxy protocol off while a control-plane machine is missing the annotation", func() {
+	It("requeues and leaves proxy protocol off while a control-plane infrastructure machine is missing the annotation", func() {
 		svc, lb := newServiceWithExistingKubeAPIService(
 			controlPlaneMachine("cp-1", true),
 			controlPlaneMachine("cp-2", false),


### PR DESCRIPTION
## What

The check that decides when to enable PROXY protocol on the control-plane load balancer now reads the annotation `capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true"` from the control-plane infrastructure machines (`HCloudMachine` and `HetznerBareMetalMachine`) instead of from the control-plane `Machine` objects. The annotation is expected on the infrastructure machine template's `spec.template.metadata`, not on the `KubeadmControlPlane` `machineTemplate`.

## Why

PROXY protocol may only be enabled once every control-plane backend has been rolled to a template that accepts a PROXY header. The readiness annotation therefore has to appear only on machines that were actually created from the new template.

An annotation on the `KubeadmControlPlane` `machineTemplate.metadata` cannot express that. Cluster API treats `machineTemplate` labels and annotations as in-place mutable: when the template reference changes (for example through a ClusterClass rollout), Cluster API copies the new metadata onto the existing, not-yet-replaced `Machine`s right away, without a rollout. The annotation then shows up on the old machines immediately and the check passes before any machine has been replaced, which would enable PROXY protocol against backends that do not expect it.

Infrastructure machine templates do not behave this way. Cluster API copies infrastructure-template metadata onto an `InfraMachine` only when it clones a new one, so the annotation lands only on machines created from the new template. Existing infra machines never gain it, and the check stays false until the last old machine is replaced.

Reading the infrastructure machines also keeps the check entirely in the management cluster; no workload-cluster client is needed.

## Changes

- `pkg/scope`: `AllControlPlaneMachinesAnnotatedForProxyProtocol` (which listed `Machine`s) becomes `AllControlPlaneInfraMachinesAnnotatedForProxyProtocol`, listing the control-plane `HCloudMachine`s and `HetznerBareMetalMachine`s and requiring the annotation on all of them.
- `pkg/services/hcloud/loadbalancer`: call the new function.
- `api`: add a `metadata` field to `HetznerBareMetalMachineTemplateResource` so the bare-metal template can carry annotations under `spec.template.metadata`. `HCloudMachineTemplate` already has this; the bare-metal template now matches it and the Cluster API machine-template contract. CRD regenerated.
- Unit tests updated to cover HCloud and bare-metal control-plane machines.

## Action for template authors

Set `capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true"` on the control-plane infrastructure machine template's `spec.template.metadata.annotations`, not on the `KubeadmControlPlane` `machineTemplate.metadata.annotations`.
