### PR TITLE
🐛 Align custom provisioner failure event with its condition reason

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1426,7 +1426,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 				msg = output.Message
 			}
 		}
-		record.Warn(s.scope.HetznerBareMetalHost, "InstallImageNotSuccessful", msg)
+		record.Warn(s.scope.HetznerBareMetalHost, "CustomProvisionerFailed", msg)
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
 			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1098,7 +1098,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		record.Warn(hm, "InstallImageNotSuccessful", msg)
+		record.Warn(hm, "CustomProvisionerFailed", msg)
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)


### PR DESCRIPTION
**What this PR does / why we need it**:
When the custom provisioner (image-url-command) fails, the controller emitted a Kubernetes event with reason `InstallImageNotSuccessful`, while the condition on the resource used reason `CustomProvisionerFailed`. The event reason was misleading, because the standard InstallImage did not fail, the custom provisioner did.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None