### PR TITLE
:seedling: bm server for e2e has new mainboard and new disks. (backport #2170)

### DIFF
--- a/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
+++ b/test/e2e/data/infrastructure-hetzner/v1beta1/bases/hetznerbaremetalhosts.yaml
@@ -16,7 +16,7 @@ spec:
   maintenanceMode: false
   description: Test Machine 1670788
 ---
-# 2026-07-08: Disabled again. Hardware reboot into rescue mode timed out (CI run 28847985206).
+# 2026-07-14: new server and new disks.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HetznerBareMetalHost
 metadata:
@@ -27,7 +27,7 @@ metadata:
 spec:
   serverID: 1716772 # ip: 136.243.69.24
   rootDeviceHints:
-    wwn: "0x5002538d41d70a46"
+    wwn: "0x500a075116bd44de"
   maintenanceMode: true
   description: Test Machine 1716772
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the e2e bare metal host sample to the new disk WWN, after the physical CI server got a new mainboard and new disks.

**Which issue(s) this PR fixes**:
None (backport of PR #2170).

**Special notes for your reviewer**:
Cherry-picked cleanly from main (f0d73f76b), no conflicts.
