### PR TITLE
🐛 Align custom provisioner failure event with its condition reason (backport #2192)

### DIFF
--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -1426,7 +1426,7 @@ func (s *Service) actionImageInstallingImageURLCommand(ctx context.Context, sshC
 				msg = output.Message
 			}
 		}
-		record.Warn(s.scope.HetznerBareMetalHost, "InstallImageNotSuccessful", msg)
+		record.Warn(s.scope.HetznerBareMetalHost, "CustomProvisionerFailed", msg)
 		v1beta1conditions.MarkFalse(host, infrav1.ProvisionSucceededCondition,
 			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1098,7 +1098,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		record.Warn(hm, "InstallImageNotSuccessful", msg)
+		record.Warn(hm, "CustomProvisionerFailed", msg)
 		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 			"CustomProvisionerFailed", clusterv1beta1.ConditionSeverityWarning,
 			"%s", msg)


### PR DESCRIPTION
**What this PR does / why we need it**:
Aligns the custom provisioner failure event with its condition reason. The failure event now uses reason `CustomProvisionerFailed` instead of `InstallImageNotSuccessful`, matching the condition.

**Which issue(s) this PR fixes**:
None (backport of PR #2192).

**Special notes for your reviewer**:
Cherry-picked cleanly from main (a9f700b5b), no conflicts.
