### PR TITLE
🐛 Gate control-plane load balancer PROXY protocol on the InfraMachine annotation (port #2190 to main)

### DIFF
--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -268,19 +268,15 @@ func IsControlPlaneReady(ctx context.Context, c clientcmd.ClientConfig) error {
 	return err
 }
 
-// AllControlPlaneMachinesAnnotatedForProxyProtocol returns true when the control plane is
-// fully rolled out to the machine template that expects PROXY protocol at the load
-// balancer. It lists the cluster's control-plane Machines in the management cluster (the
-// Cluster API Machine, so one list covers every control plane whatever its infrastructure)
-// and requires every one to carry the annotation
-// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which the
-// control-plane machine template sets and Cluster API propagates onto the Machine.
+// AllControlPlaneInfraMachinesAnnotatedForProxyProtocol returns true when every control-plane
+// infrastructure machine (HCloudMachine and HetznerBareMetalMachine) carries the annotation
+// capi.syself.com/proxy-protocol-for-controlplane-loadbalancer: "true", which is set on the
+// control-plane infrastructure machine template's spec.template.metadata.
 //
 // Machines from an earlier template do not carry the annotation, so the check stays false
 // until the last of them is replaced. It returns false (no error) while the cluster has no
-// control-plane machines yet.
-func (s *ClusterScope) AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
-	machines := &clusterv1.MachineList{}
+// control-plane infrastructure machines yet.
+func (s *ClusterScope) AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx context.Context) (bool, error) {
 	listOptions := []client.ListOption{
 		client.InNamespace(s.Namespace()),
 		client.MatchingLabels{
@@ -288,21 +284,40 @@ func (s *ClusterScope) AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx cont
 			clusterv1.MachineControlPlaneLabel: "",
 		},
 	}
-	if err := s.Client.List(ctx, machines, listOptions...); err != nil {
-		return false, fmt.Errorf("failed to list control-plane Machines: %w", err)
+
+	found := 0
+
+	hcloudMachines := &infrav1.HCloudMachineList{}
+	if err := s.Client.List(ctx, hcloudMachines, listOptions...); err != nil {
+		return false, fmt.Errorf("failed to list control-plane HCloudMachines: %w", err)
 	}
 
-	if len(machines.Items) == 0 {
-		s.V(1).Info("proxy protocol: no control-plane machines found yet")
-		return false, nil
-	}
-
-	for i := range machines.Items {
-		machine := &machines.Items[i]
-		if machine.GetAnnotations()[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
-			s.V(1).Info("proxy protocol: control-plane machine is missing the annotation", "machine", machine.GetName())
+	for i := range hcloudMachines.Items {
+		m := &hcloudMachines.Items[i]
+		if m.GetAnnotations()[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: control-plane HCloudMachine is missing the annotation", "hcloudMachine", m.GetName())
 			return false, nil
 		}
+		found++
+	}
+
+	bmMachines := &infrav1.HetznerBareMetalMachineList{}
+	if err := s.Client.List(ctx, bmMachines, listOptions...); err != nil {
+		return false, fmt.Errorf("failed to list control-plane HetznerBareMetalMachines: %w", err)
+	}
+
+	for i := range bmMachines.Items {
+		m := &bmMachines.Items[i]
+		if m.GetAnnotations()[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] != "true" {
+			s.V(1).Info("proxy protocol: control-plane HetznerBareMetalMachine is missing the annotation", "hetznerBareMetalMachine", m.GetName())
+			return false, nil
+		}
+		found++
+	}
+
+	if found == 0 {
+		s.V(1).Info("proxy protocol: no control-plane infrastructure machines found yet")
+		return false, nil
 	}
 
 	return true, nil

--- a/pkg/scope/cluster_test.go
+++ b/pkg/scope/cluster_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 )
 
@@ -50,13 +51,19 @@ func controlPlaneObjectMeta(namespace, name, clusterName string, annotated bool)
 	}
 }
 
-func controlPlaneMachine(namespace, name, clusterName string, annotated bool) *clusterv1.Machine {
-	return &clusterv1.Machine{
+func controlPlaneHCloudMachine(namespace, name, clusterName string, annotated bool) *infrav1.HCloudMachine {
+	return &infrav1.HCloudMachine{
 		ObjectMeta: controlPlaneObjectMeta(namespace, name, clusterName, annotated),
 	}
 }
 
-func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
+func controlPlaneBareMetalMachine(namespace, name, clusterName string, annotated bool) *infrav1.HetznerBareMetalMachine {
+	return &infrav1.HetznerBareMetalMachine{
+		ObjectMeta: controlPlaneObjectMeta(namespace, name, clusterName, annotated),
+	}
+}
+
+func TestAllControlPlaneInfraMachinesAnnotatedForProxyProtocol(t *testing.T) {
 	const (
 		namespace   = "default"
 		clusterName = "test-cluster"
@@ -65,6 +72,7 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(infrav1.AddToScheme(scheme))
 	utilruntime.Must(infrav2.AddToScheme(scheme))
 
 	tests := []struct {
@@ -73,24 +81,40 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "no control-plane machines yet",
+			name:     "no control-plane infrastructure machines yet",
 			machines: nil,
 			want:     false,
 		},
 		{
-			name: "all control planes annotated",
+			name: "all hcloud control planes annotated",
 			machines: []client.Object{
-				controlPlaneMachine(namespace, "cp-1", clusterName, true),
-				controlPlaneMachine(namespace, "cp-2", clusterName, true),
-				controlPlaneMachine(namespace, "cp-3", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-2", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-3", clusterName, true),
 			},
 			want: true,
 		},
 		{
-			name: "one machine still from the old template misses the annotation",
+			name: "mixed hcloud and bare-metal control planes all annotated",
 			machines: []client.Object{
-				controlPlaneMachine(namespace, "cp-1", clusterName, true),
-				controlPlaneMachine(namespace, "cp-2", clusterName, false),
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneBareMetalMachine(namespace, "cp-2", clusterName, true),
+			},
+			want: true,
+		},
+		{
+			name: "one hcloud machine still from the old template misses the annotation",
+			machines: []client.Object{
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneHCloudMachine(namespace, "cp-2", clusterName, false),
+			},
+			want: false,
+		},
+		{
+			name: "one bare-metal machine still from the old template misses the annotation",
+			machines: []client.Object{
+				controlPlaneHCloudMachine(namespace, "cp-1", clusterName, true),
+				controlPlaneBareMetalMachine(namespace, "cp-2", clusterName, false),
 			},
 			want: false,
 		},
@@ -99,9 +123,9 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			objects := append([]client.Object{}, tt.machines...)
-			// A worker machine of the same cluster (no control-plane label) must never
+			// A worker infrastructure machine of the same cluster (no control-plane label) must never
 			// affect the result.
-			objects = append(objects, &clusterv1.Machine{
+			objects = append(objects, &infrav1.HCloudMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "worker-1",
 					Namespace: namespace,
@@ -120,7 +144,7 @@ func TestAllControlPlaneMachinesAnnotatedForProxyProtocol(t *testing.T) {
 				},
 			}
 
-			got, err := s.AllControlPlaneMachinesAnnotatedForProxyProtocol(context.Background())
+			got, err := s.AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -302,18 +302,19 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	proxyProtocolAlreadyActive := kubeAPIServiceExists && existingKubeAPIService.Proxyprotocol
 
 	// proxyProtocolShouldGetEnabled: whether proxy protocol should get enabled now.
-	// The control-plane machines are only checked when the spec wants proxy protocol but the LB
-	// service doesn't have it yet. When the service is absent or already has it, no check is made.
+	// The control-plane infrastructure machines are only checked when the spec wants proxy protocol
+	// but the LB service doesn't have it yet. When the service is absent or already has it, no check
+	// is made.
 	var proxyProtocolShouldGetEnabled bool
 	var requeueForProxyProtocol bool
 	if s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.EnableProxyProtocol && kubeAPIServiceExists && !proxyProtocolAlreadyActive {
 		var err error
-		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneMachinesAnnotatedForProxyProtocol(ctx)
+		proxyProtocolShouldGetEnabled, err = s.scope.AllControlPlaneInfraMachinesAnnotatedForProxyProtocol(ctx)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 		if !proxyProtocolShouldGetEnabled {
-			s.scope.V(1).Info("proxy protocol: not all control-plane machines annotated yet, requeueing")
+			s.scope.V(1).Info("proxy protocol: not all control-plane infrastructure machines annotated yet, requeueing")
 			requeueForProxyProtocol = true
 		}
 	}

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/mocks"
@@ -221,12 +222,12 @@ func TestReconcileServices_ProxyProtocolAlreadyActive_NoChanges(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
-func controlPlaneMachineForProxy(name string, annotated bool) *clusterv1.Machine {
+func controlPlaneMachineForProxy(name string, annotated bool) *infrav1.HCloudMachine {
 	annotations := map[string]string{}
 	if annotated {
 		annotations[infrav2.ProxyProtocolForControlPlaneLoadBalancerAnnotation] = "true"
 	}
-	return &clusterv1.Machine{
+	return &infrav1.HCloudMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
@@ -249,6 +250,7 @@ func newProxyMigrationService(t *testing.T, mockClient *mocks.Client, machines .
 
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
 
 	svc := newTestService(t, hetznerCluster, mockClient)
 	svc.scope.Client = fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(machines...).Build()


### PR DESCRIPTION
**What this PR does / why we need it**:
Forward-ports PR #2190 from release-1.1. 

**Which issue(s) this PR fixes:**
None (forward-port of PR #2190).

**Special notes for your reviewer**:
None