### PR TITLE
✨ PoC: observe whether a server reached the rescue system, and act on it

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -422,6 +422,15 @@ const (
 	HCloudMachineBootingToRescueV1Beta2Reason = "BootingToRescue"
 	// HCloudMachineBootingToRescueTimedOutV1Beta2Reason indicates booting to rescue mode timed out.
 	HCloudMachineBootingToRescueTimedOutV1Beta2Reason = "BootingToRescueTimedOut"
+	// HCloudMachineWaitingForRescueEnabledV1Beta2Reason indicates the API has not yet reported the
+	// rescue system as armed, so the server is not powered on yet.
+	HCloudMachineWaitingForRescueEnabledV1Beta2Reason = "WaitingForRescueEnabled"
+	// HCloudMachineRescueNotEnteredV1Beta2Reason indicates the server booted something other than
+	// the rescue system and the recovery steps did not change that.
+	HCloudMachineRescueNotEnteredV1Beta2Reason = "RescueNotEntered"
+	// HCloudMachineRetryingBootToRescueV1Beta2Reason indicates a recovery step is in progress to
+	// get the server into the rescue system.
+	HCloudMachineRetryingBootToRescueV1Beta2Reason = "RetryingBootToRescue"
 
 	// HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason indicates the image URL command is not accessible.
 	HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason = "ImageURLCommandNotAccessible"

--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -183,7 +183,31 @@ type HCloudMachineStatus struct {
 	// Used to prevent reboot loops across successive MHC incidents.
 	// +optional
 	LastRemediatedAt *metav1.Time `json:"lastRemediatedAt,omitempty"`
+
+	// RescueRecovery records the last recovery step taken for a server that was powered on to
+	// the rescue system and booted something else. It makes the escalation visible and stops it
+	// repeating a step that already failed.
+	// +optional
+	RescueRecovery RescueRecoveryStep `json:"rescueRecovery,omitempty"`
 }
+
+// RescueRecoveryStep is a step taken to get a server into the rescue system after it booted
+// something else.
+// +kubebuilder:validation:Enum="";PowerCycled;Rearmed
+type RescueRecoveryStep string
+
+const (
+	// RescueRecoveryNone means no recovery has been attempted.
+	RescueRecoveryNone RescueRecoveryStep = ""
+
+	// RescueRecoveryPowerCycled means the server was powered off and on again while the rescue
+	// system was still armed, on the assumption that the arming was fine and the boot was not.
+	RescueRecoveryPowerCycled RescueRecoveryStep = "PowerCycled"
+
+	// RescueRecoveryRearmed means the rescue system was enabled again and the server power-cycled
+	// a second time, on the assumption that the first arming never took effect.
+	RescueRecoveryRearmed RescueRecoveryStep = "Rearmed"
+)
 
 // HCloudMachineV1Beta2Status groups all the fields that will be added or modified in HCloudMachineStatus with the V1Beta2 version.
 type HCloudMachineV1Beta2Status struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -311,6 +311,16 @@ spec:
                 - hil
                 - sin
                 type: string
+              rescueRecovery:
+                description: |-
+                  RescueRecovery records the last recovery step taken for a server that was powered on to
+                  the rescue system and booted something else. It makes the escalation visible and stops it
+                  repeating a step that already failed.
+                enum:
+                - ""
+                - PowerCycled
+                - Rearmed
+                type: string
               sshKeys:
                 description: SSHKeys specifies the ssh keys that were used for provisioning
                   the server.

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -63,6 +63,7 @@ type Client interface {
 	ListServerTypes(context.Context) ([]*hcloud.ServerType, error)
 	GetServerType(context.Context, string) (*hcloud.ServerType, error)
 	PowerOnServer(context.Context, *hcloud.Server) error
+	PowerOffServer(context.Context, *hcloud.Server) error
 	ShutdownServer(context.Context, *hcloud.Server) error
 	RebootServer(context.Context, *hcloud.Server) error
 	CreateNetwork(context.Context, hcloud.NetworkCreateOpts) (*hcloud.Network, error)
@@ -290,6 +291,16 @@ func (c *realClient) RebootServer(ctx context.Context, server *hcloud.Server) er
 
 func (c *realClient) PowerOnServer(ctx context.Context, server *hcloud.Server) error {
 	_, _, err := c.client.Server.Poweron(ctx, server)
+	if err != nil && strings.Contains(err.Error(), errStringUnauthorized) {
+		return fmt.Errorf("%w: %w", ErrUnauthorized, err)
+	}
+	return err
+}
+
+// PowerOffServer cuts the power. ShutdownServer sends ACPI and needs the running system to
+// co-operate, which a server that never reached the rescue system may not be able to do.
+func (c *realClient) PowerOffServer(ctx context.Context, server *hcloud.Server) error {
+	_, _, err := c.client.Server.Poweroff(ctx, server)
 	if err != nil && strings.Contains(err.Error(), errStringUnauthorized) {
 		return fmt.Errorf("%w: %w", ErrUnauthorized, err)
 	}

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -620,6 +620,16 @@ func (c *cacheHCloudClient) PowerOnServer(_ context.Context, server *hcloud.Serv
 	return nil
 }
 
+func (c *cacheHCloudClient) PowerOffServer(_ context.Context, server *hcloud.Server) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if _, found := c.serverCache.idMap[server.ID]; !found {
+		return hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+	}
+	c.serverCache.idMap[server.ID].Status = hcloud.ServerStatusOff
+	return nil
+}
+
 func (c *cacheHCloudClient) DeleteServer(_ context.Context, server *hcloud.Server) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -839,7 +849,17 @@ func (c *cacheHCloudClient) AddServerToPlacementGroup(_ context.Context, server 
 	return nil
 }
 
-func (c *cacheHCloudClient) EnableRescueSystem(_ context.Context, _ *hcloud.Server, _ *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
+// EnableRescueSystem arms the rescue system, which the API reports through RescueEnabled until
+// the server has booted into it. Callers depend on that flag to know the rescue boot is armed
+// before powering the server on, so the fake has to carry it too.
+func (c *cacheHCloudClient) EnableRescueSystem(_ context.Context, server *hcloud.Server, _ *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if server != nil {
+		if cached, found := c.serverCache.idMap[server.ID]; found {
+			cached.RescueEnabled = true
+		}
+	}
 	return result, nil
 }
 

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -1622,6 +1622,53 @@ func (_c *Client_ListServers_Call) RunAndReturn(run func(context.Context, hcloud
 	return _c
 }
 
+// PowerOffServer provides a mock function with given fields: _a0, _a1
+func (_m *Client) PowerOffServer(_a0 context.Context, _a1 *hcloud.Server) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PowerOffServer")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *hcloud.Server) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Client_PowerOffServer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PowerOffServer'
+type Client_PowerOffServer_Call struct {
+	*mock.Call
+}
+
+// PowerOffServer is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *hcloud.Server
+func (_e *Client_Expecter) PowerOffServer(_a0 interface{}, _a1 interface{}) *Client_PowerOffServer_Call {
+	return &Client_PowerOffServer_Call{Call: _e.mock.On("PowerOffServer", _a0, _a1)}
+}
+
+func (_c *Client_PowerOffServer_Call) Run(run func(_a0 context.Context, _a1 *hcloud.Server)) *Client_PowerOffServer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*hcloud.Server))
+	})
+	return _c
+}
+
+func (_c *Client_PowerOffServer_Call) Return(_a0 error) *Client_PowerOffServer_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Client_PowerOffServer_Call) RunAndReturn(run func(context.Context, *hcloud.Server) error) *Client_PowerOffServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PowerOnServer provides a mock function with given fields: _a0, _a1
 func (_m *Client) PowerOnServer(_a0 context.Context, _a1 *hcloud.Server) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -59,6 +59,16 @@ const (
 	actionDone = -1
 
 	preRescueOSImage = "ubuntu-24.04"
+
+	// rescueGracePeriod is how long a boot into the rescue system is given before we stop reading
+	// SSH silence as "still booting" and start asking the API what the server is actually doing.
+	// A healthy boot answers well inside this, so the happy path never spends an API call here.
+	rescueGracePeriod = 45 * time.Second
+
+	// rescueObserveInterval is how often the API is consulted once the grace period has passed.
+	// Slow enough to stay cheap on a shared rate limit, often enough to work through the recovery
+	// steps inside the state's own timeout.
+	rescueObserveInterval = 15 * time.Second
 )
 
 var hcloudImageURLCommandDir = "/shared"
@@ -719,6 +729,41 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
 	}
+
+	// Read the server back before powering it on, and only proceed once the API reports the
+	// rescue system as armed.
+	//
+	// The enable-rescue action reaching "finished" says the request was processed. It does not
+	// say the rescue boot configuration is in effect for the next power-on. Powering on while
+	// those two disagree boots the disk instead, which for the imageURL flow is the pre-rescue
+	// OS the server was created from: a stock distro, with the cluster SSH key on it, that will
+	// never join. RescueEnabled is the API's own statement about the state we depend on, so ask
+	// for it rather than inferring it from the action.
+	server, err := s.scope.HCloudClient.GetServer(ctx, serverID)
+	if err != nil {
+		if handleUnauthorized(hm, err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, handleRateLimit(hm, err, "GetServer", "failed to get server before powering on to rescue")
+	}
+	markHCloudTokenAvailable(hm)
+
+	if server == nil || !server.RescueEnabled {
+		// The action finished but the state has not caught up. Wait for it rather than powering
+		// on into the wrong system; the surrounding timeout still bounds this.
+		msg := "waiting until the API reports the rescue system as armed before powering on"
+		s.scope.Info(msg, "rescueEnabled", server != nil && server.RescueEnabled)
+		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			"WaitingForRescueEnabled", clusterv1beta1.ConditionSeverityInfo, "%s", msg)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineWaitingForRescueEnabledV1Beta2Reason,
+			Message: msg,
+		})
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	// The server was created with StartAfterCreate=false and has never been started, so
 	// powering it on boots it directly into the rescue system.
 	if err := s.scope.HCloudClient.PowerOnServer(ctx, &hcloud.Server{ID: serverID}); err != nil {
@@ -757,6 +802,165 @@ func (s *Service) handleBootStateEnablingRescue(ctx context.Context) (reconcile.
 	// powering on is not instant, so wait a bit before the first attempt instead of retrying
 	// immediately.
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// observeRescueBoot asks the API what the server is doing and, when it is not in the rescue
+// system, works through the recovery steps that can still get it there.
+//
+// The API tells us this directly. RescueEnabled stays true until the server boots into the rescue
+// system, at which point it is cleared. So a server that is running while the flag is still set
+// booted something other than the rescue system, and no amount of further SSH polling will change
+// that. Reading it turns a wait that ends in a guess into a fact we can act on.
+//
+// Recovery escalates rather than giving up, because the state's own timeout is a budget to fix
+// this in, not just a period to wait out:
+//
+//	PowerCycled  the rescue system is still armed, so the arming was fine and the boot was not.
+//	             Power off and on again; the next boot has every chance of reaching it.
+//	Rearmed      it booted wrong a second time, so the arming itself never took effect. Enable the
+//	             rescue system again and power-cycle. The armed check before power-on then applies
+//	             to this attempt too, so the second try does not repeat the first one's mistake.
+//	exhausted    report it and stop acting, leaving the timeout as the single place that decides a
+//	             machine has failed.
+//
+// Returns handled=true when the caller should return the result as-is.
+func (s *Service) observeRescueBoot(ctx context.Context) (reconcile.Result, bool, error) {
+	hm := s.scope.HCloudMachine
+
+	serverID, err := s.scope.ServerIDFromProviderID()
+	if err != nil {
+		return reconcile.Result{}, false, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
+	}
+
+	server, err := s.scope.HCloudClient.GetServer(ctx, serverID)
+	if err != nil {
+		if handleUnauthorized(hm, err) {
+			return reconcile.Result{}, true, nil
+		}
+		// Losing an observation is not fatal. Keep polling SSH and let the timeout bound the state.
+		s.scope.Error(err, "could not read the server while checking whether it entered the rescue system")
+		return reconcile.Result{}, false, nil
+	}
+	markHCloudTokenAvailable(hm)
+
+	if server == nil {
+		return reconcile.Result{}, false, nil
+	}
+
+	if !server.RescueEnabled {
+		// Cleared is what entering the rescue system looks like. Hand back to SSH, which decides
+		// whether what answers is really the rescue system.
+		return reconcile.Result{}, false, nil
+	}
+
+	switch server.Status {
+	case hcloud.ServerStatusOff:
+		// A step powered it off. Bring it back up so the next boot can reach the rescue system.
+		if hm.Status.RescueRecovery == infrav1.RescueRecoveryNone {
+			// Powered off by something other than us. Leave it alone.
+			return reconcile.Result{}, false, nil
+		}
+		msg := fmt.Sprintf("powering the server on again after recovery step %q", hm.Status.RescueRecovery)
+		s.scope.Info(msg)
+		if err := s.scope.HCloudClient.PowerOnServer(ctx, server); err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, true, nil
+			}
+			return reconcile.Result{}, true, handleRateLimit(hm, err, "PowerOnServer", "failed to power on a server retrying the rescue boot")
+		}
+		s.setRescueRecoveryCondition(msg)
+		return reconcile.Result{RequeueAfter: rescueObserveInterval}, true, nil
+
+	case hcloud.ServerStatusRunning:
+		return s.escalateRescueRecovery(ctx, server)
+	}
+
+	// Any other status is a transition. Let it settle.
+	return reconcile.Result{}, false, nil
+}
+
+// escalateRescueRecovery takes the next recovery step for a server that is running while the
+// rescue system is still armed, which means it booted something else.
+func (s *Service) escalateRescueRecovery(ctx context.Context, server *hcloud.Server) (reconcile.Result, bool, error) {
+	hm := s.scope.HCloudMachine
+
+	switch hm.Status.RescueRecovery {
+	case infrav1.RescueRecoveryNone:
+		// First failure. The rescue system is still armed, so assume the arming is good and only
+		// the boot went wrong, and simply boot it again.
+		msg := "server is running while the API still reports the rescue system as armed, so it booted something else; powering it off to boot again"
+		s.scope.Info(msg, "serverStatus", server.Status, "rescueEnabled", server.RescueEnabled)
+		hm.Status.RescueRecovery = infrav1.RescueRecoveryPowerCycled
+		if err := s.scope.HCloudClient.PowerOffServer(ctx, server); err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, true, nil
+			}
+			return reconcile.Result{}, true, handleRateLimit(hm, err, "PowerOffServer", "failed to power off a server that did not enter the rescue system")
+		}
+		s.setRescueRecoveryCondition(msg)
+		return reconcile.Result{RequeueAfter: rescueObserveInterval}, true, nil
+
+	case infrav1.RescueRecoveryPowerCycled:
+		// Booting again did not help, so the arming never took effect. Ask for it again, then
+		// power off. The armed check before power-on gates the next boot on the API reporting the
+		// rescue system as armed, so this attempt waits for what the first one did not.
+		msg := "server booted something other than the rescue system twice; enabling the rescue system again before the next boot"
+		s.scope.Info(msg, "serverStatus", server.Status)
+		hm.Status.RescueRecovery = infrav1.RescueRecoveryRearmed
+
+		sshKeys, err := s.scope.HCloudClient.ListSSHKeys(ctx, hcloud.SSHKeyListOpts{})
+		if err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, true, nil
+			}
+			return reconcile.Result{}, true, handleRateLimit(hm, err, "ListSSHKeys", "failed to list ssh keys while re-enabling the rescue system")
+		}
+		if _, err := s.scope.HCloudClient.EnableRescueSystem(ctx, server, &hcloud.ServerEnableRescueOpts{
+			Type:    hcloud.ServerRescueTypeLinux64,
+			SSHKeys: sshKeys,
+		}); err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, true, nil
+			}
+			return reconcile.Result{}, true, handleRateLimit(hm, err, "EnableRescueSystem", "failed to re-enable the rescue system")
+		}
+
+		if err := s.scope.HCloudClient.PowerOffServer(ctx, server); err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, true, nil
+			}
+			return reconcile.Result{}, true, handleRateLimit(hm, err, "PowerOffServer", "failed to power off a server before retrying the rescue boot")
+		}
+		s.setRescueRecoveryCondition(msg)
+		return reconcile.Result{RequeueAfter: rescueObserveInterval}, true, nil
+	}
+
+	// Both steps have been tried. Say precisely what is wrong and stop acting, so the timeout
+	// stays the single place that decides a machine has failed.
+	msg := "server is running while the API still reports the rescue system as armed, and neither a power cycle nor re-enabling the rescue system changed that"
+	s.scope.Error(nil, msg)
+	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+		"RescueNotEntered", clusterv1beta1.ConditionSeverityWarning, "%s", msg)
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.HCloudMachineRescueNotEnteredV1Beta2Reason,
+		Message: msg,
+	})
+	return reconcile.Result{RequeueAfter: rescueObserveInterval}, true, nil
+}
+
+// setRescueRecoveryCondition reports that a recovery step is in progress.
+func (s *Service) setRescueRecoveryCondition(msg string) {
+	hm := s.scope.HCloudMachine
+	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+		"RetryingBootToRescue", clusterv1beta1.ConditionSeverityInfo, "%s", msg)
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.HCloudMachineRetryingBootToRescueV1Beta2Reason,
+		Message: msg,
+	})
 }
 
 // handleBootStateBootingToRescue is for provisioning with imageURL and image-url-command.
@@ -803,10 +1007,20 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 		return reconcile.Result{}, nil
 	}
 
-	// The server is freshly created and was never started before this boot cycle, so there is no
-	// prior OS it could mistakenly reach over SSH. Attempt SSH directly instead of first checking
-	// server.RescueEnabled via a live GetServer call - ECONNREFUSED below already covers "server
-	// has not yet rebooted into rescue system".
+	// SSH first, because it costs no hcloud API call and a healthy boot answers within seconds.
+	//
+	// It is not sufficient on its own. The server has a prior OS it can reach over SSH: the image
+	// it was created from. If the rescue boot does not take, that image boots instead, and silence
+	// on port 22 no longer distinguishes a slow boot from a wrong one. So once the grace period
+	// has passed, ask the API what the server is actually doing, and keep asking, because the
+	// answer is what the recovery steps are driven from.
+	if durationOfState > rescueGracePeriod {
+		res, handled, err := s.observeRescueBoot(ctx)
+		if handled {
+			return res, err
+		}
+	}
+
 	sshClient, err := s.getSSHClient(ctx)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (waiting for rescue running): %w", err)

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -603,6 +603,12 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		}
 		hcloudClient := mocks.NewClient(GinkgoT())
 		service := newTestService(hcloudMachine, hcloudClient)
+		// The rescue system has to be armed before the server is powered on, so the handler
+		// reads the server back first.
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			RescueEnabled: true,
+		}, nil).Once()
 		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(hcloud.Error{
 			Code:    hcloud.ErrorCodeLocked,
 			Message: "server is locked",
@@ -636,6 +642,10 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		}
 		hcloudClient := mocks.NewClient(GinkgoT())
 		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			RescueEnabled: true,
+		}, nil).Once()
 		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(
 			fmt.Errorf("%w: invalid HCloud token", hcloudclient.ErrUnauthorized)).Once()
 
@@ -646,6 +656,169 @@ var _ = Describe("handleBootStateEnablingRescue", func() {
 		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason)).To(BeTrue())
 		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudTokenAvailableV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudTokenInvalidV1Beta2Reason)).To(BeTrue())
 		Expect(hcloudMachine.Status.BootState).ToNot(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+})
+
+var _ = Describe("rescue state detection", func() {
+	newMachine := func(bootStateSince time.Time, step infrav1.RescueRecoveryStep) *infrav1.HCloudMachine {
+		return &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Spec: infrav1.HCloudMachineSpec{
+				ProviderID: ptr.To("hcloud://1"),
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootStateSince: metav1.NewTime(bootStateSince),
+				RescueRecovery: step,
+				ExternalIDs: infrav1.HCloudMachineStatusExternalIDs{
+					ActionIDEnableRescueSystem: actionDone,
+				},
+			},
+		}
+	}
+
+	It("does not power the server on while the API has not armed the rescue system", func() {
+		hcloudMachine := newMachine(time.Now(), infrav1.RescueRecoveryNone)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			RescueEnabled: false,
+		}, nil).Once()
+
+		res, err := service.handleBootStateEnablingRescue(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+		// Powering on here would boot the image the server was created from.
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+		Expect(hcloudMachine.Status.BootState).ToNot(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineWaitingForRescueEnabledV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("powers off a running server that never entered the rescue system", func() {
+		// Running while the flag is still armed means it booted something else.
+		hcloudMachine := newMachine(time.Now().Add(-2*time.Minute), infrav1.RescueRecoveryNone)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
+		hcloudClient.On("PowerOffServer", mock.Anything, mock.Anything).Return(nil).Once()
+
+		res, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeTrue())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: rescueObserveInterval}))
+		Expect(hcloudMachine.Status.RescueRecovery).To(Equal(infrav1.RescueRecoveryPowerCycled))
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineRetryingBootToRescueV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("powers the server on again after a recovery step powered it off", func() {
+		hcloudMachine := newMachine(time.Now().Add(-2*time.Minute), infrav1.RescueRecoveryPowerCycled)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusOff,
+			RescueEnabled: true,
+		}, nil).Once()
+		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(nil).Once()
+
+		res, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeTrue())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: rescueObserveInterval}))
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("re-enables the rescue system when booting again was not enough", func() {
+		// A second wrong boot means the arming never took effect, so ask for it again.
+		hcloudMachine := newMachine(time.Now().Add(-3*time.Minute), infrav1.RescueRecoveryPowerCycled)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{{ID: 7}}, nil).Once()
+		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(hcloud.ServerEnableRescueResult{}, nil).Once()
+		hcloudClient.On("PowerOffServer", mock.Anything, mock.Anything).Return(nil).Once()
+
+		res, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeTrue())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: rescueObserveInterval}))
+		Expect(hcloudMachine.Status.RescueRecovery).To(Equal(infrav1.RescueRecoveryRearmed))
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("stops acting once both recovery steps have been tried", func() {
+		hcloudMachine := newMachine(time.Now().Add(-4*time.Minute), infrav1.RescueRecoveryRearmed)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
+
+		res, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeTrue())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: rescueObserveInterval}))
+		// The timeout is the single place that decides a machine has failed.
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOffServer", mock.Anything, mock.Anything)
+		hcloudClient.AssertNotCalled(GinkgoT(), "EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything)
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineRescueNotEnteredV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("hands back to SSH once the rescue flag is cleared", func() {
+		// Cleared is what entering the rescue system looks like, so recovery must not interfere.
+		hcloudMachine := newMachine(time.Now().Add(-2*time.Minute), infrav1.RescueRecoveryNone)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: false,
+		}, nil).Once()
+
+		_, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeFalse())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+
+	It("leaves a server alone that something else powered off", func() {
+		hcloudMachine := newMachine(time.Now().Add(-2*time.Minute), infrav1.RescueRecoveryNone)
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+		hcloudClient.On("GetServer", mock.Anything, int64(1)).Return(&hcloud.Server{
+			ID:            1,
+			Status:        hcloud.ServerStatusOff,
+			RescueEnabled: true,
+		}, nil).Once()
+
+		_, handled, err := service.observeRescueBoot(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(handled).To(BeFalse())
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
 })
@@ -1788,6 +1961,12 @@ var _ = Describe("Reconcile", func() {
 		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateEnablingRescue))
 
 		By("reconcile again: server gets powered on ---------------------------------")
+		// The handler reads the server back and only powers it on once the API reports the
+		// rescue system as armed.
+		hcloudClient.On("GetServer", mock.Anything, mock.Anything).Return(&hcloud.Server{
+			ID:            1,
+			RescueEnabled: true,
+		}, nil).Once()
 		hcloudClient.On("PowerOnServer", mock.Anything, mock.Anything).Return(nil).Once()
 		_, err = service.Reconcile(ctx)
 		Expect(err).To(BeNil())
@@ -1851,7 +2030,15 @@ var _ = Describe("Reconcile", func() {
 			}
 		}
 		GinkgoWriter.Printf("GetServer was called %d times during provisioning (imageURL)\n", getServerCalls)
-		Expect(getServerCalls).To(BeNumerically("<=", 1), "GetServer should not be called more than 1 time during imageURL provisioning")
+		// Two, and both are deliberate. One is the read that confirms the API reports the rescue
+		// system as armed before the server is powered on: without it the server can be powered
+		// on while the enable-rescue state has not taken effect, and it boots the pre-rescue OS
+		// instead. The probe in BootingToRescue does not run on this path, because a healthy boot
+		// answers SSH long before it would.
+		//
+		// Keep this bound tight. It exists so the provisioning path does not quietly grow hcloud
+		// API calls, which is a rate-limit budget shared across every machine being provisioned.
+		Expect(getServerCalls).To(BeNumerically("<=", 2), "GetServer should not be called more than 2 times during imageURL provisioning")
 	})
 
 	It("ignores status in output.json when IMAGE_URL_DONE in stdout", func() {


### PR DESCRIPTION
> **Proof of concept, opened as a draft to discuss the approach.** It changes how the rescue boot is verified during `imageURL` provisioning, and touches the provisioning path of every hcloud machine using that flow. Everything here is up for challenge, including whether the approach is right at all.

## The idea

Today CAPH **infers** whether a server reached the rescue system: SSH does not answer, so assume it is still booting, and if six minutes pass, give up. That is a guess with a timer on it, and the diagnosis it produced when we hit this was wrong about what had happened.

This PR stops inferring and starts observing. The API states the fact directly, and once we read it, the six minutes stops being a period to wait out and becomes a budget to fix the problem in.

## Background: how the imageURL flow boots

A Hetzner server must be created from some image. For this flow CAPH creates it from a throwaway one and arranges for that image never to run:

1. Create the server from `ubuntu-24.04`, powered off, no user-data.
2. Enable the rescue system while it is off.
3. Power it on, so the first boot lands in rescue.
4. From inside rescue, write the real image over the disk.

The source says so directly:

```go
// Create the server powered off. Enabling the rescue system while the server is off means
// its first boot goes directly into the rescue system, and the pre-rescue-OS image never boots.
```

So a stock image always sits on that disk, and the design depends on it never executing.

## What we observed

```
08:23:12  create_server   success   finished 08:25:18   (126s)
08:25:18  enable_rescue   success   finished 08:25:29    (11s)
08:25:30  start_server    success   finished 08:25:42    (12s)   <- issued 1s after rescue armed
08:25:45  dial tcp :22 i/o timeout        (repeats)
08:31:31  BootingToRescue -> ProvisioningFailed
          "get hostname failed: ssh i/o timeout ... in this state since 6m1s"
          "hcloudmachine: ProvisioningFailed. Not reconciling this machine."
08:32:41  the server finished booting -- into the throwaway image, 70s after CAPH gave up
```

It booted the wrong image. CAPH could not tell, so it reported an SSH problem for what was an OS-identity problem. The code says why it does not check:

```go
// The server is freshly created and was never started before this boot cycle, so there is no
// prior OS it could mistakenly reach over SSH.
```

There is one, and it is what booted.

Across every server in that project using this flow, the failed one is the only one where `start_server` was issued 1 second after `enable_rescue` finished. The others had 4-5 seconds and all entered rescue. A small sample, not proof, but consistent with the action reporting success before the boot configuration is in effect.

## The fact this rests on

`rescue_enabled` is cleared when the server boots into the rescue system. So a server that is **running** while the flag is **still set** booted something else, and no further SSH polling will change that.

The failed machine supports it: the flag is still set after hours of running the wrong image. Every server that provisioned normally has it cleared.

## The state model

| `rescue_enabled` | server | SSH | meaning | action |
|---|---|---|---|---|
| true | off | — | a recovery step powered it off | power on |
| true | starting/stopping | — | mid-transition | let it settle |
| true | running | silent | booting, or booted wrong with no sshd yet | observe again |
| true | running | answers | **booted the wrong image** | recover |
| false | running | `rescue` | in rescue | proceed |
| false | running | other | rescue consumed, wrong image running | existing hostname check |
| false | any | — | rescue entered | hand back to SSH |

## What changes

**Confirm the rescue system is armed before powering on.** `handleBootStateEnablingRescue` currently powers the server on using a synthesised `&hcloud.Server{ID: serverID}`, verifying only that the *action* finished. It now reads the server back and proceeds only when `RescueEnabled` is true, otherwise requeues with a `WaitingForRescueEnabled` condition.

**Observe, continuously, once a boot has had long enough.** SSH stays the first check, so a healthy boot spends nothing here. After a 45s grace period the API is consulted every 15s, because the answer is what the recovery steps are driven from.

**Recover in steps instead of giving up.**

| step | reading | action |
|---|---|---|
| `PowerCycled` | the arming was fine, the boot was not | power off and on again |
| `Rearmed` | the arming never took effect | enable the rescue system afresh, then power-cycle |
| exhausted | neither worked | report `RescueNotEntered`, stop acting |

The `Rearmed` step benefits from the first change: the armed check gates that boot too, so the retry does not repeat the first attempt's mistake.

The step is recorded in `status.rescueRecovery`, so escalation is visible in status and no step repeats. The existing six-minute timeout stays the single place that decides a machine has failed — this only makes reaching it much less likely.

## Cost

One `GetServer` per machine provisioned, from the armed check. Then one per observation while a server is failing to reach rescue, which is bounded by the state's own timeout and costs nothing on a healthy boot.

An existing assertion caps `GetServer` calls during `imageURL` provisioning. It moves from 1 to 2 with the reason recorded inline rather than being removed, because it exists to stop this path quietly growing API calls against a rate limit shared by every machine being provisioned.

## Testing

`make test-unit` passes, 148 tests; `make lint` clean. Seven specs cover the state model and the ladder: not powering on while unarmed, powering off a running-but-armed server, powering back on afterwards, re-enabling the rescue system on the second failure, stopping once both steps are spent, handing back to SSH when the flag clears, and leaving alone a server something else powered off. Server-package coverage 55.1% -> 60.3%.

The fake client's `EnableRescueSystem` was a no-op; it now sets `RescueEnabled` to match the real API, since callers depend on that flag.

## Deliberately out of scope

- The six-minute timeout and remediation are unchanged. The timeout stays the only place a machine is declared failed, and deleting or recreating a machine remains remediation's job, not the provider's.
- The `imageName` flow, which does not use the rescue system.
- Identifying *which* image booted. `rescue_enabled` answers "is this the rescue system", which is the only question that matters here.

## Open questions

- 45s grace and 15s observation interval are first guesses. The intent is "past any healthy boot" without spending API calls early.
- Two recovery steps may be the wrong number, and there may be a third worth having.
- During the incident CAPH's behaviour implies it read `rescue_enabled` as false, while the API reports true now, with a single `enable_rescue` action on record. That transition is unexplained and may warrant asking Hetzner.
