### PR TITLE
✨ Add condition for proxy protocol activation wait

### DIFF
--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -31,8 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedV1Beta1Reason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnV1Beta1Reason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnV1Beta1Reason = "LoadBalancerFailedToOwn"
-	// LoadBalancerWaitingForProxyProtocolV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
-	LoadBalancerWaitingForProxyProtocolV1Beta1Reason = "LoadBalancerWaitingForProxyProtocol"
+	// LoadBalancerWaitingToActivateV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingToActivateV1Beta1Reason = "LoadBalancerWaitingToActivate"
 )
 
 const (
@@ -344,9 +344,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedReason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedReason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedReason = "DeletionFailed"
-	// HetznerClusterLoadBalancerWaitingForProxyProtocolReason indicates that proxy protocol activation is
+	// HetznerClusterLoadBalancerWaitingToActivateReason indicates that proxy protocol activation is
 	// waiting for all control-plane machines to be annotated.
-	HetznerClusterLoadBalancerWaitingForProxyProtocolReason = "WaitingForProxyProtocol"
+	HetznerClusterLoadBalancerWaitingToActivateReason = "WaitingToActivate"
 )
 
 const (

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -31,6 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedV1Beta1Reason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnV1Beta1Reason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnV1Beta1Reason = "LoadBalancerFailedToOwn"
+	// LoadBalancerWaitingForProxyProtocolV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingForProxyProtocolV1Beta1Reason = "LoadBalancerWaitingForProxyProtocol"
 )
 
 const (
@@ -342,6 +344,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedReason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedReason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedReason = "DeletionFailed"
+	// HetznerClusterLoadBalancerWaitingForProxyProtocolReason indicates that proxy protocol activation is
+	// waiting for all control-plane machines to be annotated.
+	HetznerClusterLoadBalancerWaitingForProxyProtocolReason = "WaitingForProxyProtocol"
 )
 
 const (

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -31,8 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedV1Beta1Reason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnV1Beta1Reason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnV1Beta1Reason = "LoadBalancerFailedToOwn"
-	// LoadBalancerWaitingToActivateV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
-	LoadBalancerWaitingToActivateV1Beta1Reason = "LoadBalancerWaitingToActivate"
+	// LoadBalancerWaitingToActivateProxyProtocolV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingToActivateProxyProtocolV1Beta1Reason = "LoadBalancerWaitingToActivateProxyProtocol"
 )
 
 const (
@@ -344,9 +344,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedReason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedReason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedReason = "DeletionFailed"
-	// HetznerClusterLoadBalancerWaitingToActivateReason indicates that proxy protocol activation is
+	// HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason indicates that proxy protocol activation is
 	// waiting for all control-plane machines to be annotated.
-	HetznerClusterLoadBalancerWaitingToActivateReason = "WaitingToActivate"
+	HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason = "WaitingToActivateProxyProtocol"
 )
 
 const (

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -314,8 +314,24 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			return reconcile.Result{}, err
 		}
 		if !proxyProtocolShouldGetEnabled {
+			const msg = "waiting for all control-plane machines to be annotated before enabling proxy protocol"
 			s.scope.V(1).Info("proxy protocol: not all control-plane infrastructure machines annotated yet, requeueing")
 			requeueForProxyProtocol = true
+
+			deprecatedv1beta1conditions.MarkFalse(
+				s.scope.HetznerCluster,
+				infrav2.LoadBalancerReadyV1Beta1Condition,
+				infrav2.LoadBalancerWaitingForProxyProtocolV1Beta1Reason,
+				clusterv1.ConditionSeverityInfo,
+				msg,
+			)
+
+			conditions.Set(s.scope.HetznerCluster, metav1.Condition{
+				Type:    infrav2.HetznerClusterLoadBalancerReadyCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav2.HetznerClusterLoadBalancerWaitingForProxyProtocolReason,
+				Message: msg,
+			})
 		}
 	}
 
@@ -365,7 +381,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 		}
 	}
 	if requeueForProxyProtocol {
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, multierr
+		return reconcile.Result{RequeueAfter: 2 * time.Minute}, multierr
 	}
 
 	// If proxy protocol is not active yet but should be, activate it in place. HCloud's

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -321,7 +321,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			deprecatedv1beta1conditions.MarkFalse(
 				s.scope.HetznerCluster,
 				infrav2.LoadBalancerReadyV1Beta1Condition,
-				infrav2.LoadBalancerWaitingForProxyProtocolV1Beta1Reason,
+				infrav2.LoadBalancerWaitingToActivateV1Beta1Reason,
 				clusterv1.ConditionSeverityInfo,
 				msg,
 			)
@@ -329,7 +329,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			conditions.Set(s.scope.HetznerCluster, metav1.Condition{
 				Type:    infrav2.HetznerClusterLoadBalancerReadyCondition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav2.HetznerClusterLoadBalancerWaitingForProxyProtocolReason,
+				Reason:  infrav2.HetznerClusterLoadBalancerWaitingToActivateReason,
 				Message: msg,
 			})
 		}

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -321,7 +321,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			deprecatedv1beta1conditions.MarkFalse(
 				s.scope.HetznerCluster,
 				infrav2.LoadBalancerReadyV1Beta1Condition,
-				infrav2.LoadBalancerWaitingToActivateV1Beta1Reason,
+				infrav2.LoadBalancerWaitingToActivateProxyProtocolV1Beta1Reason,
 				clusterv1.ConditionSeverityInfo,
 				msg,
 			)
@@ -329,7 +329,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			conditions.Set(s.scope.HetznerCluster, metav1.Condition{
 				Type:    infrav2.HetznerClusterLoadBalancerReadyCondition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav2.HetznerClusterLoadBalancerWaitingToActivateReason,
+				Reason:  infrav2.HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason,
 				Message: msg,
 			})
 		}

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -19,6 +19,7 @@ package loadbalancer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/stretchr/testify/mock"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -277,7 +279,13 @@ func TestReconcileServices_ProxyProtocolMigration_MachinesNotReady(t *testing.T)
 
 	res, err := svc.reconcileServices(context.Background(), hcloudLB)
 	require.NoError(t, err)
-	require.NotZero(t, res.RequeueAfter, "should requeue while a control-plane machine is not annotated")
+	require.Equal(t, 2*time.Minute, res.RequeueAfter, "should requeue after 2 minutes while a control-plane machine is not annotated")
+
+	cond := conditions.Get(svc.scope.HetznerCluster, infrav2.HetznerClusterLoadBalancerReadyCondition)
+	require.NotNil(t, cond, "LoadBalancerReady condition should report the proxy protocol wait")
+	require.Equal(t, metav1.ConditionFalse, cond.Status)
+	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingForProxyProtocolReason, cond.Reason)
+
 	mockClient.AssertExpectations(t)
 }
 

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -284,7 +284,7 @@ func TestReconcileServices_ProxyProtocolMigration_MachinesNotReady(t *testing.T)
 	cond := conditions.Get(svc.scope.HetznerCluster, infrav2.HetznerClusterLoadBalancerReadyCondition)
 	require.NotNil(t, cond, "LoadBalancerReady condition should report the proxy protocol wait")
 	require.Equal(t, metav1.ConditionFalse, cond.Status)
-	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingToActivateReason, cond.Reason)
+	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason, cond.Reason)
 
 	mockClient.AssertExpectations(t)
 }

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -284,7 +284,7 @@ func TestReconcileServices_ProxyProtocolMigration_MachinesNotReady(t *testing.T)
 	cond := conditions.Get(svc.scope.HetznerCluster, infrav2.HetznerClusterLoadBalancerReadyCondition)
 	require.NotNil(t, cond, "LoadBalancerReady condition should report the proxy protocol wait")
 	require.Equal(t, metav1.ConditionFalse, cond.Status)
-	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingForProxyProtocolReason, cond.Reason)
+	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingToActivateReason, cond.Reason)
 
 	mockClient.AssertExpectations(t)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When proxy protocol is enabled on the control-plane load balancer for an existing cluster, activation waits until every control-plane machine carries the proxy-protocol annotation. Until now this wait was invisible: `LoadBalancerReady` stayed stale-True and the reconcile requeued every 10 seconds.

This surfaces the wait as a reason on the existing `LoadBalancerReady` condition (`Reason=WaitingForProxyProtocol`, with a message explaining it waits for all control-plane machines to be annotated), and raises the requeue interval from 10 seconds to 2 minutes so we stop hammering the API.

**Which issue(s) this PR fixes:**
Fixes #2212

**Special notes for your reviewer**:
Followed the existing load balancer condition convention — every LB state here is a reason on `LoadBalancerReady` (v1beta1 + v1beta2 set together), so this adds a reason, not a standalone condition. `LoadBalancerReady` does not gate the CAPI provisioning contract (that is `status.initialization.provisioned`, driven by the LB IPv4), so this is observability only; the cluster `Ready` summary will show False with this reason during the rollout, which is honest since the LB is not yet at its desired spec.

**TODOs**:
- [x] add unit tests
- [ ] squash commits before merge
- documentation: none needed (reason constants only, no CRD/schema change)
