### PR TITLE
✨ Add condition for proxy protocol activation wait (backport #2213)

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -31,6 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedReason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnReason = "LoadBalancerFailedToOwn"
+	// LoadBalancerWaitingForProxyProtocolReason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingForProxyProtocolReason = "LoadBalancerWaitingForProxyProtocol"
 )
 
 const (
@@ -501,6 +503,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedV1Beta2Reason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason = "DeletionFailed"
+	// HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason indicates that proxy protocol activation is
+	// waiting for all control-plane machines to be annotated.
+	HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason = "WaitingForProxyProtocol"
 )
 
 const (

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -31,8 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedReason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnReason = "LoadBalancerFailedToOwn"
-	// LoadBalancerWaitingForProxyProtocolReason used while proxy protocol activation waits for all control-plane machines to be annotated.
-	LoadBalancerWaitingForProxyProtocolReason = "LoadBalancerWaitingForProxyProtocol"
+	// LoadBalancerWaitingToActivateReason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingToActivateReason = "LoadBalancerWaitingToActivate"
 )
 
 const (
@@ -503,9 +503,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedV1Beta2Reason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason = "DeletionFailed"
-	// HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason indicates that proxy protocol activation is
+	// HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason indicates that proxy protocol activation is
 	// waiting for all control-plane machines to be annotated.
-	HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason = "WaitingForProxyProtocol"
+	HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason = "WaitingToActivate"
 )
 
 const (

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -31,8 +31,8 @@ const (
 	LoadBalancerServiceSyncFailedReason = "LoadBalancerServiceSyncFailed"
 	// LoadBalancerFailedToOwnReason used when no owned label could be set on a load balancer.
 	LoadBalancerFailedToOwnReason = "LoadBalancerFailedToOwn"
-	// LoadBalancerWaitingToActivateReason used while proxy protocol activation waits for all control-plane machines to be annotated.
-	LoadBalancerWaitingToActivateReason = "LoadBalancerWaitingToActivate"
+	// LoadBalancerWaitingToActivateProxyProtocolReason used while proxy protocol activation waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingToActivateProxyProtocolReason = "LoadBalancerWaitingToActivateProxyProtocol"
 )
 
 const (
@@ -503,9 +503,9 @@ const (
 	HetznerClusterLoadBalancerUpdateFailedV1Beta2Reason = "UpdateFailed"
 	// HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason indicates that an error occurred during load balancer delete.
 	HetznerClusterLoadBalancerDeletionFailedV1Beta2Reason = "DeletionFailed"
-	// HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason indicates that proxy protocol activation is
+	// HetznerClusterLoadBalancerWaitingToActivateProxyProtocolV1Beta2Reason indicates that proxy protocol activation is
 	// waiting for all control-plane machines to be annotated.
-	HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason = "WaitingToActivate"
+	HetznerClusterLoadBalancerWaitingToActivateProxyProtocolV1Beta2Reason = "WaitingToActivateProxyProtocol"
 )
 
 const (

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -341,8 +341,24 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			return reconcile.Result{}, err
 		}
 		if !proxyProtocolShouldGetEnabled {
+			const msg = "waiting for all control-plane machines to be annotated before enabling proxy protocol"
 			s.scope.V(1).Info("proxy protocol: not all control-plane infrastructure machines annotated yet, requeueing")
 			requeueForProxyProtocol = true
+
+			v1beta1conditions.MarkFalse(
+				s.scope.HetznerCluster,
+				infrav1.LoadBalancerReadyCondition,
+				infrav1.LoadBalancerWaitingForProxyProtocolReason,
+				clusterv1beta1.ConditionSeverityInfo,
+				msg,
+			)
+
+			v1beta2conditions.Set(s.scope.HetznerCluster, metav1.Condition{
+				Type:    infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason,
+				Message: msg,
+			})
 		}
 	}
 
@@ -398,7 +414,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	}
 
 	if requeueForProxyProtocol {
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, multierr
+		return reconcile.Result{RequeueAfter: 2 * time.Minute}, multierr
 	}
 
 	// If proxy protocol is not active yet but should be, activate it in place. HCloud's

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -348,7 +348,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			v1beta1conditions.MarkFalse(
 				s.scope.HetznerCluster,
 				infrav1.LoadBalancerReadyCondition,
-				infrav1.LoadBalancerWaitingForProxyProtocolReason,
+				infrav1.LoadBalancerWaitingToActivateReason,
 				clusterv1beta1.ConditionSeverityInfo,
 				msg,
 			)
@@ -356,7 +356,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			v1beta2conditions.Set(s.scope.HetznerCluster, metav1.Condition{
 				Type:    infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason,
+				Reason:  infrav1.HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason,
 				Message: msg,
 			})
 		}

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -348,7 +348,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			v1beta1conditions.MarkFalse(
 				s.scope.HetznerCluster,
 				infrav1.LoadBalancerReadyCondition,
-				infrav1.LoadBalancerWaitingToActivateReason,
+				infrav1.LoadBalancerWaitingToActivateProxyProtocolReason,
 				clusterv1beta1.ConditionSeverityInfo,
 				msg,
 			)
@@ -356,7 +356,7 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 			v1beta2conditions.Set(s.scope.HetznerCluster, metav1.Condition{
 				Type:    infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason,
+				Reason:  infrav1.HetznerClusterLoadBalancerWaitingToActivateProxyProtocolV1Beta2Reason,
 				Message: msg,
 			})
 		}

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -240,7 +240,7 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 		cond := v1beta2conditions.Get(svc.scope.HetznerCluster, infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-		Expect(cond.Reason).To(Equal(infrav1.HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason))
+		Expect(cond.Reason).To(Equal(infrav1.HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason))
 	})
 })
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -240,7 +240,7 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 		cond := v1beta2conditions.Get(svc.scope.HetznerCluster, infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition)
 		Expect(cond).NotTo(BeNil())
 		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-		Expect(cond.Reason).To(Equal(infrav1.HetznerClusterLoadBalancerWaitingToActivateV1Beta2Reason))
+		Expect(cond.Reason).To(Equal(infrav1.HetznerClusterLoadBalancerWaitingToActivateProxyProtocolV1Beta2Reason))
 	})
 })
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer_test.go
@@ -19,6 +19,7 @@ package loadbalancer
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -229,11 +231,16 @@ var _ = Describe("reconcileServices proxy protocol migration", func() {
 
 		res, err := svc.reconcileServices(context.Background(), lb)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res.RequeueAfter).NotTo(BeZero())
+		Expect(res.RequeueAfter).To(Equal(2 * time.Minute))
 
 		Expect(lb.Services).To(HaveLen(1))
 		Expect(lb.Services[0].Proxyprotocol).To(BeFalse())
 		Expect(svc.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled).To(BeFalse())
+
+		cond := v1beta2conditions.Get(svc.scope.HetznerCluster, infrav1.HetznerClusterLoadBalancerReadyV1Beta2Condition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(infrav1.HetznerClusterLoadBalancerWaitingForProxyProtocolV1Beta2Reason))
 	})
 })
 


### PR DESCRIPTION
Backports PR #2213 to release-1.1.

**What this PR does / why we need it**:
When proxy protocol is enabled on the control-plane load balancer for an existing cluster, activation waits until every control-plane machine carries the proxy-protocol annotation. Until now this wait was invisible: `LoadBalancerReady` stayed stale-True and the reconcile requeued every 10 seconds.

This surfaces the wait as a reason on the existing `LoadBalancerReady` condition (`Reason=WaitingForProxyProtocol`, with a message explaining it waits for all control-plane machines to be annotated), and raises the requeue interval from 10 seconds to 2 minutes so we stop hammering the API.

**Which issue(s) this PR fixes:**
Related to issue #2212 (fixed on main by PR #2213).

**Special notes for your reviewer**:
Backport of PR #2213, adapted to release-1.1's condition layout: the constants live in `api/v1beta1` (v1beta1 reason on `LoadBalancerReadyCondition` plus v1beta2 reason on `HetznerClusterLoadBalancerReadyV1Beta2Condition`) and the test is the Ginkgo case in `loadbalancer_test.go`. This adds a reason on the existing `LoadBalancerReady` condition, not a standalone condition, matching the existing load balancer condition convention. `LoadBalancerReady` does not gate the CAPI provisioning contract, so this is observability only.

**TODOs**:
- [x] add unit tests
- [ ] squash commits before merge
- documentation: none needed (reason constants only, no CRD/schema change)
