### PR TITLE
🐛 Check image-url-command timeout before reading over SSH (backport #2217)

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -948,9 +948,6 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	// A stuck machine stops answering over SSH, which makes StateOfImageURLCommand fail on
-	// every reconcile. The timeout is therefore checked here, before that read, so a stuck
-	// machine still gets remediated instead of staying in this state forever.
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
 	// Please keep the number (20) in sync with the docstring of ImageURL.
 	if durationOfState > 20*time.Minute {

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -948,16 +948,9 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res reconcile.Result, err error) {
 	hm := s.scope.HCloudMachine
 
-	hcloudSSHClient, err := s.getSSHClient(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (wait for image-url-command): %w", err)
-	}
-
-	state, logFile, err := hcloudSSHClient.StateOfImageURLCommand(ctx)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("StateOfImageURLCommand failed: %w", err)
-	}
-
+	// A stuck machine stops answering over SSH, which makes StateOfImageURLCommand fail on
+	// every reconcile. The timeout is therefore checked here, before that read, so a stuck
+	// machine still gets remediated instead of staying in this state forever.
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
 	// Please keep the number (20) in sync with the docstring of ImageURL.
 	if durationOfState > 20*time.Minute {
@@ -982,7 +975,7 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 			}
 		}
 
-		s.scope.Error(errors.New(v1beta2Msg), "", "logFile", logFile)
+		s.scope.Error(nil, v1beta2Msg)
 		err := s.scope.SetErrorAndRemediate(ctx, v1beta2Msg)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -998,6 +991,17 @@ func (s *Service) handleBootStateRunningImageCommand(ctx context.Context) (res r
 			Message: v1beta2Msg,
 		})
 		return reconcile.Result{}, nil
+	}
+
+	// Not timed out yet. Read the current image-url-command state over SSH.
+	hcloudSSHClient, err := s.getSSHClient(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("getSSHClient failed (wait for image-url-command): %w", err)
+	}
+
+	state, logFile, err := hcloudSSHClient.StateOfImageURLCommand(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("StateOfImageURLCommand failed: %w", err)
 	}
 
 	sshClient := hcloudSSHClient

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -857,6 +857,36 @@ var _ = Describe("handleBootStateInitializing", func() {
 	})
 })
 
+var _ = Describe("handleBootStateRunningImageCommand", func() {
+	It("remediates from BootStateSince alone when the machine has stopped answering over SSH", func() {
+		// The machine has been in RunningImageCommand past the timeout. newTestService configures
+		// no SSH access, so getSSHPrivateKey fails before any read over SSH; this passes only if
+		// the handler remediates from BootStateSince first.
+		hcloudMachine := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-machine",
+				Namespace: "default",
+			},
+			Status: infrav1.HCloudMachineStatus{
+				BootState:      infrav1.HCloudBootStateRunningImageCommand,
+				BootStateSince: metav1.NewTime(time.Now().Add(-21 * time.Minute)),
+			},
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		service := newTestService(hcloudMachine, hcloudClient)
+
+		res, err := service.handleBootStateRunningImageCommand(context.Background())
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
+		Expect(exists).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(hcloudMachine, infrav1.ServerProvisionedCondition, "RunningImageCommandTimedOut")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(hcloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition, metav1.ConditionFalse, infrav1.HCloudMachineRunningImageURLCommandTimedOutV1Beta2Reason)).To(BeTrue())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+	})
+})
+
 var _ = Describe("getSSHKeys", func() {
 	var (
 		service      *Service


### PR DESCRIPTION
Backports PR #2217 to release-1.1.

**What this PR does / why we need it**:
In `handleBootStateRunningImageCommand` the 20-minute timeout was checked only after `getSSHClient` and `StateOfImageURLCommand`. When a machine stops answering over SSH, those calls fail on every reconcile, so the timeout check was never reached and the machine stayed in `RunningImageCommand` forever. This moves the timeout check above the SSH read, so a stuck machine is remediated from `BootStateSince` alone.

**Which issue(s) this PR fixes:**
Related to issue #2215 (fixed on main by PR #2217).

**Special notes for your reviewer**:
Clean cherry-pick of PR #2217 (commit 8703b8c13), no adaptation needed — release-1.1 carries the identical code including the v1beta2 conditions.

**TODOs**:
- [x] add unit tests
- [ ] squash commits before merge
- documentation: none needed