### PR TITLE
✨ Retry bringing an hcloud server to rescue mode if the first attempt fails

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -425,6 +425,22 @@ const (
 	// HCloudMachineBootingToRescueTimedOutV1Beta2Reason indicates booting to rescue mode timed out.
 	HCloudMachineBootingToRescueTimedOutV1Beta2Reason = "BootingToRescueTimedOut"
 
+	// HCloudMachineRetryingRescueBootV1Beta2Reason indicates the server did not reach the rescue
+	// system and gets powered off and on again to give it another chance.
+	HCloudMachineRetryingRescueBootV1Beta2Reason = "RetryingRescueBoot"
+	// HCloudMachinePoweringOffForRescueRetryV1Beta2Reason indicates the server is being powered off
+	// as the first step of a rescue boot retry.
+	HCloudMachinePoweringOffForRescueRetryV1Beta2Reason = "PoweringOffForRescueRetry"
+	// HCloudMachineWaitingForServerOffV1Beta2Reason indicates the controller waits until the server
+	// has reached status "off".
+	HCloudMachineWaitingForServerOffV1Beta2Reason = "WaitingForServerOff"
+	// HCloudMachineReEnablingRescueSystemV1Beta2Reason indicates the rescue system was not armed
+	// any more and gets enabled again before the server is powered on.
+	HCloudMachineReEnablingRescueSystemV1Beta2Reason = "ReEnablingRescueSystem"
+	// HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason indicates the power-cycle to the
+	// rescue system timed out.
+	HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason = "PowerCyclingToRescueTimedOut"
+
 	// HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason indicates the image URL command is not accessible.
 	HCloudMachineImageURLCommandNotAccessibleV1Beta2Reason = "ImageURLCommandNotAccessible"
 	// HCloudMachineStartImageURLCommandFailedV1Beta2Reason indicates starting the image URL command failed.

--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -434,8 +434,8 @@ const (
 	// HCloudMachineWaitingForServerOffV1Beta2Reason indicates the controller waits until the server
 	// has reached status "off".
 	HCloudMachineWaitingForServerOffV1Beta2Reason = "WaitingForServerOff"
-	// HCloudMachineReEnablingRescueSystemV1Beta2Reason indicates the rescue system was not armed
-	// any more and gets enabled again before the server is powered on.
+	// HCloudMachineReEnablingRescueSystemV1Beta2Reason indicates the rescue system was no longer
+	// enabled and gets enabled again before the server is powered on.
 	HCloudMachineReEnablingRescueSystemV1Beta2Reason = "ReEnablingRescueSystem"
 	// HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason indicates the power-cycle to the
 	// rescue system timed out.

--- a/api/v1beta1/hcloudmachine_types.go
+++ b/api/v1beta1/hcloudmachine_types.go
@@ -167,6 +167,9 @@ type HCloudMachineStatus struct {
 	//   4. RunningImageCommand
 	//   5. BootingToRealOS
 	//   6. OperatingSystemRunning
+	//
+	// If the server fails to reach the rescue system, BootingToRescue goes to
+	// PowerCyclingToRescue once, and from there back to BootingToRescue.
 
 	// +optional
 	BootState HCloudBootState `json:"bootState"`
@@ -183,6 +186,12 @@ type HCloudMachineStatus struct {
 	// Used to prevent reboot loops across successive MHC incidents.
 	// +optional
 	LastRemediatedAt *metav1.Time `json:"lastRemediatedAt,omitempty"`
+
+	// RescuePowerCycleCount counts how often the controller powered the server off and on again
+	// because it failed to reach the rescue system. It bounds the retries: transitions reset
+	// BootStateSince, so the per-state timeouts alone cannot stop a loop.
+	// +optional
+	RescuePowerCycleCount int32 `json:"rescuePowerCycleCount,omitzero"`
 }
 
 // HCloudMachineV1Beta2Status groups all the fields that will be added or modified in HCloudMachineStatus with the V1Beta2 version.
@@ -205,6 +214,10 @@ type HCloudMachineStatusExternalIDs struct {
 	// ActionIDCreateServer is the hcloud API Action result of CreateServer.
 	// +optional
 	ActionIDCreateServer int64 `json:"actionIdCreateServer,omitzero"`
+
+	// ActionIDPowerOffServer is the hcloud API Action result of PowerOffServer.
+	// +optional
+	ActionIDPowerOffServer int64 `json:"actionIdPowerOffServer,omitzero"`
 }
 
 // HCloudMachine is the Schema for the hcloudmachines API.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -518,6 +518,11 @@ const (
 	// waits for the rescue system to be reachable. Then it starts the image-url-command.
 	HCloudBootStateBootingToRescue HCloudBootState = "BootingToRescue"
 
+	// HCloudBootStatePowerCyclingToRescue indicates that reaching the rescue system failed and the
+	// controller is powering the server off and on again, so the server gets another chance to boot
+	// into the rescue system.
+	HCloudBootStatePowerCyclingToRescue HCloudBootState = "PowerCyclingToRescue"
+
 	// HCloudBootStateRunningImageCommand indicates the controller waits for the
 	// image-url-command, and then switches BootState to BootingToRealOS (no additional reboot gets
 	// done).

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_hcloudmachines.yaml
@@ -271,6 +271,11 @@ spec:
                       result of EnableRescueSystem.
                     format: int64
                     type: integer
+                  actionIdPowerOffServer:
+                    description: ActionIDPowerOffServer is the hcloud API Action result
+                      of PowerOffServer.
+                    format: int64
+                    type: integer
                 type: object
               failureMessage:
                 description: |-
@@ -311,6 +316,13 @@ spec:
                 - hil
                 - sin
                 type: string
+              rescuePowerCycleCount:
+                description: |-
+                  RescuePowerCycleCount counts how often the controller powered the server off and on again
+                  because it failed to reach the rescue system. It bounds the retries: transitions reset
+                  BootStateSince, so the per-state timeouts alone cannot stop a loop.
+                format: int32
+                type: integer
               sshKeys:
                 description: SSHKeys specifies the ssh keys that were used for provisioning
                   the server.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -154,6 +154,38 @@ When the command finishes (success or failure), CAPH writes the **full JSON cont
 to the controller log at key `outputJSON`. It is not exposed as a Kubernetes event, because the
 output can contain information that should not be shown to the cluster user.
 
+## Retrying the boot into the rescue system (hcloud)
+
+An hcloud server that provisions via `imageURL` is created powered off, gets the rescue system
+enabled, and is then powered on, so its first boot goes into the rescue system. Two things can go
+wrong in the `BootingToRescue` state:
+
+* the server never answers on port 22, or
+* it answers, but the hostname is not `rescue`. Then the server booted the throwaway image it was
+  created from instead of the rescue system.
+
+Both are very likely fixable by a power cycle, which is faster than remediation (which recreates the
+server from scratch). So CAPH powers the server off and on again instead of remediating right away:
+
+```text
+   EnablingRescue ──▶ BootingToRescue ──▶ PowerCyclingToRescue ──┐
+                            │  ▲                                 │
+             hostname=rescue│  └──────────────────────────────────┘
+                            ▼
+                    RunningImageCommand
+```
+
+`PowerCyclingToRescue` powers the server off (hard poweroff, not an ACPI shutdown), waits until it
+reports status `off`, makes sure the rescue system is still armed for the next boot, powers it on
+again and goes back to `BootingToRescue`.
+
+A server gets **one** power cycle. Both failure paths share that budget, which is counted in
+`status.rescuePowerCycleCount`, so a server that alternates between them cannot cycle forever. If
+the second attempt fails too, the machine gets remediated (deleted and replaced) as before.
+
+`BootingToRescue` waits 90 seconds per attempt, and the power cycle itself is bounded to two
+minutes, so the worst case until remediation is about five minutes.
+
 ## Measured durations for hcloud
 
 | oldState | newState | avg(s) | min(s) | max(s) |
@@ -170,5 +202,12 @@ output can contain information that should not be shown to the cluster user.
 
   k logs deployments/caph-controller-manager | python3 hack/hcloud-image-url-command-states-markdown-from-logs.py
 -->
+
+**The table is outdated.** It was recorded when `BootingToRescue` was entered via a warm reboot over
+SSH. Today the server is created powered off and cold-started, and a cold start is not plausibly
+faster than a warm reboot, so the numbers for `BootingToRescue` are a lower bound and not a
+measurement of the current flow. Please regenerate the table with
+`hack/hcloud-image-url-command-states-markdown-from-logs.py` against the current flow, and re-tune
+`rescueBootGracePeriod` (the 90 seconds mentioned above) from the fresh numbers.
 
 The duration of the state `RunningImageCommand` depends heavily on your script.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -176,15 +176,17 @@ server from scratch). So CAPH powers the server off and on again instead of reme
 ```
 
 `PowerCyclingToRescue` powers the server off (hard poweroff, not an ACPI shutdown), waits until it
-reports status `off`, makes sure the rescue system is still armed for the next boot, powers it on
+reports status `off`, makes sure the rescue system is still enabled for the next boot, powers it on
 again and goes back to `BootingToRescue`.
 
 A server gets **one** power cycle. Both failure paths share that budget, which is counted in
 `status.rescuePowerCycleCount`, so a server that alternates between them cannot cycle forever. If
 the second attempt fails too, the machine gets remediated (deleted and replaced) as before.
 
-`BootingToRescue` waits 90 seconds per attempt, and the power cycle itself is bounded to two
-minutes, so the worst case until remediation is about five minutes.
+`BootingToRescue` waits 120 seconds per attempt, and the power cycle itself is bounded to two
+minutes, so the worst case until remediation is about six minutes - the same as before this retry
+mechanism existed, since a longer grace period only delays reaching the fix (the power cycle), not
+just the failure.
 
 ## Measured durations for hcloud
 
@@ -208,6 +210,7 @@ SSH. Today the server is created powered off and cold-started, and a cold start 
 faster than a warm reboot, so the numbers for `BootingToRescue` are a lower bound and not a
 measurement of the current flow. Please regenerate the table with
 `hack/hcloud-image-url-command-states-markdown-from-logs.py` against the current flow, and re-tune
-`rescueBootGracePeriod` (the 90 seconds mentioned above) from the fresh numbers.
+`rescueBootGracePeriod` (120 seconds as of this writing, bumped from the original 90s without a
+regenerated table to back it - see the constant's comment in server.go) from the fresh numbers.
 
 The duration of the state `RunningImageCommand` depends heavily on your script.

--- a/docs/caph/04-developers/06-image-url-command.md
+++ b/docs/caph/04-developers/06-image-url-command.md
@@ -183,10 +183,11 @@ A server gets **one** power cycle. Both failure paths share that budget, which i
 `status.rescuePowerCycleCount`, so a server that alternates between them cannot cycle forever. If
 the second attempt fails too, the machine gets remediated (deleted and replaced) as before.
 
-`BootingToRescue` waits 120 seconds per attempt, and the power cycle itself is bounded to two
-minutes, so the worst case until remediation is about six minutes - the same as before this retry
-mechanism existed, since a longer grace period only delays reaching the fix (the power cycle), not
-just the failure.
+`BootingToRescue` waits 90 seconds per attempt, and the power cycle itself is bounded to two
+minutes, so the worst case until remediation is about five minutes - an improvement on the six
+minutes it took before this retry mechanism existed. (90s was briefly raised to 120s and then
+reverted - see the constant's comment in server.go: a 100-cycle soak test's one real failure was
+stuck, not slow, so the extra time only delayed the power-cycle without helping.)
 
 ## Measured durations for hcloud
 
@@ -210,7 +211,7 @@ SSH. Today the server is created powered off and cold-started, and a cold start 
 faster than a warm reboot, so the numbers for `BootingToRescue` are a lower bound and not a
 measurement of the current flow. Please regenerate the table with
 `hack/hcloud-image-url-command-states-markdown-from-logs.py` against the current flow, and re-tune
-`rescueBootGracePeriod` (120 seconds as of this writing, bumped from the original 90s without a
-regenerated table to back it - see the constant's comment in server.go) from the fresh numbers.
+`rescueBootGracePeriod` (90 seconds as of this writing - see the constant's comment in server.go
+for the reasoning) from the fresh numbers.
 
 The duration of the state `RunningImageCommand` depends heavily on your script.

--- a/pkg/services/hcloud/client/client.go
+++ b/pkg/services/hcloud/client/client.go
@@ -63,6 +63,9 @@ type Client interface {
 	ListServerTypes(context.Context) ([]*hcloud.ServerType, error)
 	GetServerType(context.Context, string) (*hcloud.ServerType, error)
 	PowerOnServer(context.Context, *hcloud.Server) error
+	// PowerOffServer cuts the power (hard poweroff), it does not send an ACPI shutdown request.
+	// It returns the action, so callers can wait for it.
+	PowerOffServer(context.Context, *hcloud.Server) (*hcloud.Action, error)
 	ShutdownServer(context.Context, *hcloud.Server) error
 	RebootServer(context.Context, *hcloud.Server) error
 	CreateNetwork(context.Context, hcloud.NetworkCreateOpts) (*hcloud.Network, error)
@@ -294,6 +297,14 @@ func (c *realClient) PowerOnServer(ctx context.Context, server *hcloud.Server) e
 		return fmt.Errorf("%w: %w", ErrUnauthorized, err)
 	}
 	return err
+}
+
+func (c *realClient) PowerOffServer(ctx context.Context, server *hcloud.Server) (*hcloud.Action, error) {
+	action, _, err := c.client.Server.Poweroff(ctx, server)
+	if err != nil && strings.Contains(err.Error(), errStringUnauthorized) {
+		return nil, fmt.Errorf("%w: %w", ErrUnauthorized, err)
+	}
+	return action, err
 }
 
 func (c *realClient) DeleteServer(ctx context.Context, server *hcloud.Server) error {

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -927,7 +927,7 @@ func (c *cacheHCloudClient) AddServerToPlacementGroup(_ context.Context, server 
 	return nil
 }
 
-// EnableRescueSystem arms the rescue system for the next boot, like the hcloud API does. The
+// EnableRescueSystem enables the rescue system for the next boot, like the hcloud API does. The
 // returned Action is non-nil, because callers read its ID.
 func (c *cacheHCloudClient) EnableRescueSystem(_ context.Context, server *hcloud.Server, _ *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
 	c.mutex.Lock()

--- a/pkg/services/hcloud/client/fake/hcloud_client.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client.go
@@ -698,6 +698,16 @@ func (c *cacheHCloudClient) PowerOnServer(_ context.Context, server *hcloud.Serv
 	return nil
 }
 
+func (c *cacheHCloudClient) PowerOffServer(_ context.Context, server *hcloud.Server) (*hcloud.Action, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if _, found := c.serverCache.idMap[server.ID]; !found {
+		return nil, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+	}
+	c.serverCache.idMap[server.ID].Status = hcloud.ServerStatusOff
+	return &hcloud.Action{ID: 1}, nil
+}
+
 func (c *cacheHCloudClient) DeleteServer(_ context.Context, server *hcloud.Server) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -917,7 +927,17 @@ func (c *cacheHCloudClient) AddServerToPlacementGroup(_ context.Context, server 
 	return nil
 }
 
-func (c *cacheHCloudClient) EnableRescueSystem(_ context.Context, _ *hcloud.Server, _ *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
+// EnableRescueSystem arms the rescue system for the next boot, like the hcloud API does. The
+// returned Action is non-nil, because callers read its ID.
+func (c *cacheHCloudClient) EnableRescueSystem(_ context.Context, server *hcloud.Server, _ *hcloud.ServerEnableRescueOpts) (result hcloud.ServerEnableRescueResult, reterr error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	cachedServer, found := c.serverCache.idMap[server.ID]
+	if !found {
+		return result, hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+	}
+	cachedServer.RescueEnabled = true
+	result.Action = &hcloud.Action{ID: 1}
 	return result, nil
 }
 

--- a/pkg/services/hcloud/client/fake/hcloud_client_test.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client_test.go
@@ -556,7 +556,7 @@ var _ = Describe("Server", func() {
 		Expect(hcloud.IsError(err, hcloud.ErrorCodeNotFound)).To(BeTrue())
 	})
 
-	It("arms the rescue system and returns an action", func() {
+	It("enables the rescue system and returns an action", func() {
 		Expect(server.RescueEnabled).To(BeFalse())
 		result, err := client.EnableRescueSystem(ctx, server, &hcloud.ServerEnableRescueOpts{
 			Type: hcloud.ServerRescueTypeLinux64,

--- a/pkg/services/hcloud/client/fake/hcloud_client_test.go
+++ b/pkg/services/hcloud/client/fake/hcloud_client_test.go
@@ -539,6 +539,43 @@ var _ = Describe("Server", func() {
 		Expect(hcloud.IsError(err, hcloud.ErrorCodeNotFound)).To(BeTrue())
 	})
 
+	It("powers a server off", func() {
+		Expect(server.Status).To(Equal(hcloud.ServerStatusRunning))
+		action, err := client.PowerOffServer(ctx, server)
+		Expect(err).To(Succeed())
+		Expect(action).ToNot(BeNil())
+		resp, err := client.ListServers(ctx, listOpts)
+		Expect(err).To(Succeed())
+		Expect(len(resp)).To(Equal(1))
+		Expect(resp[0].Status).To(Equal(hcloud.ServerStatusOff))
+	})
+
+	It("gives an error when a non-existing server is powered off", func() {
+		_, err := client.PowerOffServer(ctx, &hcloud.Server{ID: 2})
+		Expect(err).ToNot(Succeed())
+		Expect(hcloud.IsError(err, hcloud.ErrorCodeNotFound)).To(BeTrue())
+	})
+
+	It("arms the rescue system and returns an action", func() {
+		Expect(server.RescueEnabled).To(BeFalse())
+		result, err := client.EnableRescueSystem(ctx, server, &hcloud.ServerEnableRescueOpts{
+			Type: hcloud.ServerRescueTypeLinux64,
+		})
+		Expect(err).To(Succeed())
+		Expect(result.Action).ToNot(BeNil())
+		resp, err := client.GetServer(ctx, server.ID)
+		Expect(err).To(Succeed())
+		Expect(resp.RescueEnabled).To(BeTrue())
+	})
+
+	It("gives an error when the rescue system is enabled for a non-existing server", func() {
+		_, err := client.EnableRescueSystem(ctx, &hcloud.Server{ID: 2}, &hcloud.ServerEnableRescueOpts{
+			Type: hcloud.ServerRescueTypeLinux64,
+		})
+		Expect(err).ToNot(Succeed())
+		Expect(hcloud.IsError(err, hcloud.ErrorCodeNotFound)).To(BeTrue())
+	})
+
 	It("powers a server on", func() {
 		err := client.ShutdownServer(ctx, server)
 		Expect(err).To(Succeed())

--- a/pkg/services/hcloud/client/mocks/Client.go
+++ b/pkg/services/hcloud/client/mocks/Client.go
@@ -1622,6 +1622,65 @@ func (_c *Client_ListServers_Call) RunAndReturn(run func(context.Context, hcloud
 	return _c
 }
 
+// PowerOffServer provides a mock function with given fields: _a0, _a1
+func (_m *Client) PowerOffServer(_a0 context.Context, _a1 *hcloud.Server) (*hcloud.Action, error) {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PowerOffServer")
+	}
+
+	var r0 *hcloud.Action
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *hcloud.Server) (*hcloud.Action, error)); ok {
+		return rf(_a0, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *hcloud.Server) *hcloud.Action); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*hcloud.Action)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *hcloud.Server) error); ok {
+		r1 = rf(_a0, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Client_PowerOffServer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PowerOffServer'
+type Client_PowerOffServer_Call struct {
+	*mock.Call
+}
+
+// PowerOffServer is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *hcloud.Server
+func (_e *Client_Expecter) PowerOffServer(_a0 interface{}, _a1 interface{}) *Client_PowerOffServer_Call {
+	return &Client_PowerOffServer_Call{Call: _e.mock.On("PowerOffServer", _a0, _a1)}
+}
+
+func (_c *Client_PowerOffServer_Call) Run(run func(_a0 context.Context, _a1 *hcloud.Server)) *Client_PowerOffServer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*hcloud.Server))
+	})
+	return _c
+}
+
+func (_c *Client_PowerOffServer_Call) Return(_a0 *hcloud.Action, _a1 error) *Client_PowerOffServer_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_PowerOffServer_Call) RunAndReturn(run func(context.Context, *hcloud.Server) (*hcloud.Action, error)) *Client_PowerOffServer_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PowerOnServer provides a mock function with given fields: _a0, _a1
 func (_m *Client) PowerOnServer(_a0 context.Context, _a1 *hcloud.Server) error {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -63,11 +63,13 @@ const (
 	// rescueBootGracePeriod is how long BootingToRescue waits for the rescue system to answer
 	// over SSH before the server gets powered off and on again.
 	//
-	// The measured durations in docs/caph/04-developers/06-image-url-command.md say the state
-	// takes at most 42s, but that table was recorded when the state was entered via a warm reboot
-	// over SSH, so ~40s is a lower bound for today's cold power-on and not a measurement of it.
-	// Re-tune this once the table has been regenerated.
-	rescueBootGracePeriod = 90 * time.Second
+	// A soak test of 44 back-to-back scale cycles (~90 fresh boots) never saw this state take
+	// longer than ~51s, and never hit this timeout at all - so there's no direct evidence this
+	// needs to be longer. Bumped from 90s to 120s anyway to give a genuinely slow (rather than
+	// stuck) boot more room, while keeping the worst-case-to-remediation time
+	// (2*rescueBootGracePeriod + powerCycleToRescueTimeout) at 6 min, same as the pre-retry
+	// baseline this PR improves on - a larger value would make that worse, not better.
+	rescueBootGracePeriod = 120 * time.Second
 
 	// powerCycleToRescueTimeout bounds PowerCyclingToRescue. Two hcloud actions (power off, power
 	// on) normally cost ~15-25s, so this only limits the case where the server never reports
@@ -794,7 +796,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 			durationOfState.Round(time.Second).String(),
 			hm.Status.RescuePowerCycleCount+1, maxRescuePowerCycles+1)
 
-		if s.retryRescueBoot("SSHNotReachable", timeoutMsg) {
+		if s.retryRescueBoot(ctx, "SSHNotReachable", timeoutMsg) {
 			// The next state powers the server off and on again.
 			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
@@ -848,9 +850,27 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	err = output.Err
 	if err != nil {
 		var msg string
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			// This is common. Provide a nice message.
-			msg = "getHostName: ssh not reachable yet. Retrying"
+		var netErr net.Error
+		isDialTimeout := errors.As(err, &netErr) && netErr.Timeout()
+		isConnRefused := errors.Is(err, syscall.ECONNREFUSED)
+		if isConnRefused || isDialTimeout {
+			// Both are common while the server is still booting: ECONNREFUSED once the network is
+			// up but sshd isn't listening yet, a dial timeout before that. Provide a nice message.
+			reason := "connection refused"
+			if isDialTimeout {
+				reason = "timeout"
+			}
+			msg = fmt.Sprintf("getHostName: ssh not reachable yet (%s). Retrying", reason)
+
+			// This branch is hit roughly once a second while waiting, so log a heartbeat only
+			// every ~15s instead of on every attempt - enough to see progress and the failure
+			// reason on a long wait, without flooding the logs on the common fast path.
+			if sec := int(durationOfState.Seconds()); sec > 0 && sec%15 == 0 {
+				s.scope.Info("Still waiting for SSH to become reachable in the rescue system",
+					"reason", reason,
+					"durationOfState", durationOfState.Round(time.Second).String(),
+					"gracePeriod", rescueBootGracePeriod.String())
+			}
 			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
 				"RetryingSSHConnection", clusterv1beta1.ConditionSeverityInfo,
 				"%s", msg)
@@ -891,7 +911,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 		// created with the cluster's SSH keys attached, so it answers on port 22 with the machine
 		// name as hostname. A power-cycle with the rescue system enabled again is very likely to fix
 		// this, and it is faster than remediation.
-		if s.retryRescueBoot("UnexpectedHostname", fmt.Sprintf(
+		if s.retryRescueBoot(ctx, "UnexpectedHostname", fmt.Sprintf(
 			"remote hostname (via ssh) of hcloud server is %q, expected 'rescue'", remoteHostName)) {
 			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 		}
@@ -993,18 +1013,35 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 //
 // trigger names the failure that made the retry necessary and shows up in the log, msg describes it
 // for the condition and the event.
-func (s *Service) retryRescueBoot(trigger, msg string) bool {
+func (s *Service) retryRescueBoot(ctx context.Context, trigger, msg string) bool {
 	hm := s.scope.HCloudMachine
 
 	if hm.Status.RescuePowerCycleCount >= maxRescuePowerCycles {
 		return false
 	}
 
+	// Best-effort diagnostic snapshot of what hcloud thinks the server's state actually is at the
+	// moment rescue turned out to be unreachable. This is the one place in BootingToRescue allowed
+	// to spend an extra GetServer call: it only runs on the (rare, ideally never) retry path, not
+	// on every reconcile while waiting - unlike getLiveServer, a failure here must not affect the
+	// retry decision, so it's folded into the log line instead of handled/propagated.
+	liveServerState := "unavailable"
+	if serverID, err := s.scope.ServerIDFromProviderID(); err == nil {
+		if server, err := s.scope.HCloudClient.GetServer(ctx, serverID); err != nil {
+			liveServerState = fmt.Sprintf("GetServer failed: %v", err)
+		} else if server != nil {
+			liveServerState = fmt.Sprintf("status=%s rescueEnabled=%t", server.Status, server.RescueEnabled)
+		} else {
+			liveServerState = "server not found"
+		}
+	}
+
 	// This is expected and recoverable, so it gets logged at Info, not at Error.
 	s.scope.Info("Server did not reach the rescue system. Powering it off and on again.",
 		"trigger", trigger,
 		"message", msg,
-		"rescuePowerCycleCount", hm.Status.RescuePowerCycleCount)
+		"rescuePowerCycleCount", hm.Status.RescuePowerCycleCount,
+		"liveServerState", liveServerState)
 	record.Warnf(hm, "RetryingRescueBoot",
 		"Server did not reach the rescue system (%s). Powering it off and on again.", msg)
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -59,6 +59,26 @@ const (
 	actionDone = -1
 
 	preRescueOSImage = "ubuntu-24.04"
+
+	// rescueBootGracePeriod is how long BootingToRescue waits for the rescue system to answer
+	// over SSH before the server gets powered off and on again.
+	//
+	// The measured durations in docs/caph/04-developers/06-image-url-command.md say the state
+	// takes at most 42s, but that table was recorded when the state was entered via a warm reboot
+	// over SSH, so ~40s is a lower bound for today's cold power-on and not a measurement of it.
+	// Re-tune this once the table has been regenerated.
+	rescueBootGracePeriod = 90 * time.Second
+
+	// powerCycleToRescueTimeout bounds PowerCyclingToRescue. Two hcloud actions (power off, power
+	// on) normally cost ~15-25s, so this only limits the case where the server never reports
+	// status "off".
+	powerCycleToRescueTimeout = 2 * time.Minute
+
+	// maxRescuePowerCycles is how often a server may get powered off and on again because it
+	// failed to reach the rescue system, before the machine gets remediated. Both failure paths
+	// of BootingToRescue (SSH stays silent, and a wrong operating system answers) share this
+	// budget, so a server that alternates between them cannot cycle forever.
+	maxRescuePowerCycles = 1
 )
 
 var hcloudImageURLCommandDir = "/shared"
@@ -159,6 +179,8 @@ func (s *Service) Reconcile(ctx context.Context) (res reconcile.Result, err erro
 		return s.handleBootStateEnablingRescue(ctx)
 	case infrav1.HCloudBootStateBootingToRescue:
 		return s.handleBootStateBootingToRescue(ctx)
+	case infrav1.HCloudBootStatePowerCyclingToRescue:
+		return s.handleBootStatePowerCyclingToRescue(ctx)
 	case infrav1.HCloudBootStateRunningImageCommand:
 		return s.handleBootStateRunningImageCommand(ctx)
 	case infrav1.HCloudBootStateBootingToRealOS:
@@ -764,10 +786,20 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	hm := s.scope.HCloudMachine
 
 	durationOfState := time.Since(hm.Status.BootStateSince.Time)
-	if durationOfState > 6*time.Minute {
-		// timeout. Something has failed.
-		timeoutMsg := fmt.Sprintf("reaching rescue system timed out, in this state since %s", durationOfState.Round(time.Second).String())
+	if durationOfState > rescueBootGracePeriod {
+		// The rescue system did not answer in time. A power-cycle is faster than remediation
+		// (which recreates the server from scratch), and it often fixes whatever the server got
+		// stuck on, so try that first.
+		timeoutMsg := fmt.Sprintf("reaching rescue system timed out, in this state since %s (attempt %d of %d)",
+			durationOfState.Round(time.Second).String(),
+			hm.Status.RescuePowerCycleCount+1, maxRescuePowerCycles+1)
 
+		if s.retryRescueBoot("SSHNotReachable", timeoutMsg) {
+			// The next state powers the server off and on again.
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+		}
+
+		// The power-cycle budget is spent. Remediate.
 		v1beta1Reason := "BootingToRescueTimedOut"
 		v1beta1Msg := timeoutMsg
 		if existing := v1beta1conditions.Get(hm, infrav1.ServerProvisionedCondition); existing != nil {
@@ -855,6 +887,15 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	remoteHostName := output.String()
 
 	if remoteHostName != "rescue" {
+		// The server booted the throwaway image instead of the rescue system. That image is
+		// created with the cluster's SSH keys attached, so it answers on port 22 with the machine
+		// name as hostname. A power-cycle with the rescue system armed again is very likely to fix
+		// this, and it is faster than remediation.
+		if s.retryRescueBoot("UnexpectedHostname", fmt.Sprintf(
+			"remote hostname (via ssh) of hcloud server is %q, expected 'rescue'", remoteHostName)) {
+			return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+		}
+
 		msg := fmt.Sprintf("Remote hostname (via ssh) of hcloud server is %q. Expected 'rescue'. Deleting hcloud machine", remoteHostName)
 		s.scope.Error(nil, msg)
 		err := s.scope.SetErrorAndRemediate(ctx, msg)
@@ -941,6 +982,329 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	// The next state (RunningImageCommand) polls via SSH, which costs no hcloud API calls, but
 	// the custom provisioner needs time to run, so wait a bit before the first attempt instead
 	// of retrying immediately.
+	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// retryRescueBoot moves to PowerCyclingToRescue if a power-cycle is still allowed, and reports
+// whether it did. Both failure paths of BootingToRescue share one budget
+// (Status.RescuePowerCycleCount), so a server that alternates between "SSH stays silent" and "the
+// wrong operating system answered" cannot cycle forever. A per-state timeout could not stop such a
+// loop, because every transition resets BootStateSince.
+//
+// trigger names the failure that made the retry necessary and shows up in the log, msg describes it
+// for the condition and the event.
+func (s *Service) retryRescueBoot(trigger, msg string) bool {
+	hm := s.scope.HCloudMachine
+
+	if hm.Status.RescuePowerCycleCount >= maxRescuePowerCycles {
+		return false
+	}
+
+	// This is expected and recoverable, so it gets logged at Info, not at Error.
+	s.scope.Info("Server did not reach the rescue system. Powering it off and on again.",
+		"trigger", trigger,
+		"message", msg,
+		"rescuePowerCycleCount", hm.Status.RescuePowerCycleCount)
+	record.Warnf(hm, "RetryingRescueBoot",
+		"Server did not reach the rescue system (%s). Powering it off and on again.", msg)
+
+	s.setBootState(infrav1.HCloudBootStatePowerCyclingToRescue)
+	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+		"RetryingRescueBoot", clusterv1beta1.ConditionSeverityInfo,
+		"%s", msg)
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.HCloudMachineRetryingRescueBootV1Beta2Reason,
+		Message: msg,
+	})
+	return true
+}
+
+// handleBootStatePowerCyclingToRescue is for provisioning with imageURL and image-url-command.
+//
+// The server failed to reach the rescue system. This state powers it off, makes sure the rescue
+// system is armed for the next boot, powers it on again and goes back to BootingToRescue.
+//
+// The action IDs in Status.ExternalIDs are the progress markers inside this state, so one handler
+// covers the whole power-cycle.
+func (s *Service) handleBootStatePowerCyclingToRescue(ctx context.Context) (reconcile.Result, error) {
+	hm := s.scope.HCloudMachine
+
+	durationOfState := time.Since(hm.Status.BootStateSince.Time)
+	if durationOfState > powerCycleToRescueTimeout {
+		// timeout. Something has failed.
+		timeoutMsg := fmt.Sprintf("power-cycling to the rescue system timed out, in this state since %s", durationOfState.Round(time.Second).String())
+
+		v1beta1Reason := "PowerCyclingToRescueTimedOut"
+		v1beta1Msg := timeoutMsg
+		if existing := v1beta1conditions.Get(hm, infrav1.ServerProvisionedCondition); existing != nil {
+			v1beta1Reason = existing.Reason
+			if existing.Message != "" {
+				v1beta1Msg = fmt.Sprintf("%s (%s)", existing.Message, timeoutMsg)
+			}
+		}
+
+		v1beta2Reason := infrav1.HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason
+		v1beta2Msg := timeoutMsg
+		if existing := v1beta2conditions.Get(hm, infrav1.HCloudMachineServerProvisionedV1Beta2Condition); existing != nil {
+			v1beta2Reason = existing.Reason
+			if existing.Message != "" {
+				v1beta2Msg = fmt.Sprintf("%s (%s)", existing.Message, timeoutMsg)
+			}
+		}
+
+		err := s.scope.SetErrorAndRemediate(ctx, v1beta2Msg)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		s.scope.Error(nil, v1beta2Msg)
+		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			v1beta1Reason, clusterv1beta1.ConditionSeverityWarning,
+			"%s", v1beta1Msg)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1beta2Reason,
+			Message: v1beta2Msg,
+		})
+		return reconcile.Result{}, nil
+	}
+
+	serverID, err := s.scope.ServerIDFromProviderID()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("ServerIDFromProviderID failed: %w", err)
+	}
+
+	if hm.Status.ExternalIDs.ActionIDPowerOffServer == 0 {
+		// A hard poweroff, not an ACPI shutdown: the server is either stuck mid-boot, and a stuck
+		// kernel ignores ACPI, or it runs the throwaway image which gets overwritten anyway. There
+		// is nothing to preserve.
+		action, err := s.scope.HCloudClient.PowerOffServer(ctx, &hcloud.Server{ID: serverID})
+		if err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, nil
+			}
+			if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+				v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+					"PoweringOffForRescueRetry", clusterv1beta1.ConditionSeverityInfo,
+					"PowerOffServer: server locked. Will retry")
+				v1beta2conditions.Set(hm, metav1.Condition{
+					Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav1.HCloudMachinePoweringOffForRescueRetryV1Beta2Reason,
+					Message: "PowerOffServer: server locked. Will retry",
+				})
+				return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+			return reconcile.Result{}, handleRateLimit(hm, err, "PowerOffServer", "failed to power off server")
+		}
+		markHCloudTokenAvailable(hm)
+		if action == nil {
+			// Should not happen: the hcloud API answers a successful poweroff with an action.
+			return reconcile.Result{}, errors.New("PowerOffServer returned no action")
+		}
+
+		// The ID is stored as the marker that the poweroff was issued. Whether the server is off
+		// gets read from the server itself below, because that answer also carries RescueEnabled.
+		hm.Status.ExternalIDs.ActionIDPowerOffServer = action.ID
+
+		msg := "powering the server off to retry booting into the rescue system"
+		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			"PoweringOffForRescueRetry", clusterv1beta1.ConditionSeverityInfo,
+			"%s", msg)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachinePoweringOffForRescueRetryV1Beta2Reason,
+			Message: msg,
+		})
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// The poweroff was issued. One GetServer answers both questions this state has left: is the
+	// server off, and is the rescue system still armed for the next boot?
+	server, res, err := s.getLiveServer(ctx)
+	if server == nil || err != nil || !res.IsZero() {
+		return res, err
+	}
+	updateHCloudMachineStatusFromServer(hm, server)
+
+	if server.Status != hcloud.ServerStatusOff {
+		msg := fmt.Sprintf("waiting until the server is off (hcloud server status: %s)", server.Status)
+		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			"WaitingForServerOff", clusterv1beta1.ConditionSeverityInfo,
+			"%s", msg)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineWaitingForServerOffV1Beta2Reason,
+			Message: msg,
+		})
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// The server is off. Wait for a pending enable-rescue action, if there is one. Gating the
+	// EnableRescueSystem call below on this action ID keeps it at one call per power-cycle, even if
+	// server.RescueEnabled lags behind the finished action.
+	if hm.Status.ExternalIDs.ActionIDEnableRescueSystem > 0 {
+		action, err := s.scope.HCloudClient.GetAction(ctx, hm.Status.ExternalIDs.ActionIDEnableRescueSystem)
+		if err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, nil
+			}
+			if hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
+				return reconcile.Result{}, handleRateLimit(hm, err, "GetAction", "failed to get enabling rescue action")
+			}
+
+			// If this error persists, then the BootState will time out, and a new
+			// machine will be created.
+			err = fmt.Errorf("GetAction failed: %w", err)
+			s.scope.Error(err, "")
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"EnablingRescueGetActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"%s", err.Error())
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  infrav1.HCloudMachineEnablingRescueGetActionFailedV1Beta2Reason,
+				Message: err.Error(),
+			})
+			return reconcile.Result{}, err
+		}
+		markHCloudTokenAvailable(hm)
+
+		if action.Finished.IsZero() {
+			// not finished yet.
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"WaitingForEnablingRescueAction", clusterv1beta1.ConditionSeverityInfo,
+				"Waiting until Action RescueEnabled is finished")
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineWaitingForEnablingRescueActionV1Beta2Reason,
+				Message: "Waiting until Action RescueEnabled is finished",
+			})
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		if err := action.Error(); err != nil {
+			err = fmt.Errorf("action %+v failed (wait for rescue enabled): %w", action, err)
+			msg := err.Error()
+			s.scope.Error(err, "")
+			if remediateErr := s.scope.SetErrorAndRemediate(ctx, msg); remediateErr != nil {
+				return reconcile.Result{}, remediateErr
+			}
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"EnablingRescueActionFailed", clusterv1beta1.ConditionSeverityWarning,
+				"%s", msg)
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachineEnablingRescueActionFailedV1Beta2Reason,
+				Message: msg,
+			})
+			return reconcile.Result{}, nil
+		}
+
+		hm.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
+		// Hetzner accepts the power on directly after the enable rescue action is finished, and the
+		// server object read above is stale now, so requeue immediately.
+		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+	}
+
+	if !server.RescueEnabled {
+		// Rescue is not armed any more: either it was consumed by the boot that went wrong, or it
+		// expired (hcloud disables it 60 minutes after it was enabled). Arm it again, otherwise the
+		// power on below boots the local disk.
+		_, hcloudSSHKeys, err := s.getSSHKeys(ctx)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("getSSHKeys failed: %w", err)
+		}
+
+		rescueOpts := &hcloud.ServerEnableRescueOpts{
+			Type:    hcloud.ServerRescueTypeLinux64,
+			SSHKeys: hcloudSSHKeys,
+		}
+
+		result, err := s.scope.HCloudClient.EnableRescueSystem(ctx, &hcloud.Server{ID: serverID}, rescueOpts)
+		if err != nil {
+			if handleUnauthorized(hm, err) {
+				return reconcile.Result{}, nil
+			}
+			if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+				v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+					"EnablingRescueSystemFailed", clusterv1beta1.ConditionSeverityInfo,
+					"EnableRescueSystem: server locked. Will retry")
+				v1beta2conditions.Set(hm, metav1.Condition{
+					Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav1.HCloudMachineEnablingRescueSystemFailedV1Beta2Reason,
+					Message: "EnableRescueSystem: server locked. Will retry",
+				})
+				return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+			}
+			return reconcile.Result{}, handleRateLimit(hm, err, "EnableRescueSystem", "failed to enable rescue system")
+		}
+		markHCloudTokenAvailable(hm)
+		if result.Action == nil {
+			// Should not happen: the hcloud API answers a successful enable_rescue with an action.
+			return reconcile.Result{}, errors.New("EnableRescueSystem returned no action")
+		}
+		hm.Status.ExternalIDs.ActionIDEnableRescueSystem = result.Action.ID
+
+		msg := "re-enabling the rescue system before powering the server on again"
+		v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+			"ReEnablingRescueSystem", clusterv1beta1.ConditionSeverityInfo,
+			"%s", msg)
+		v1beta2conditions.Set(hm, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineReEnablingRescueSystemV1Beta2Reason,
+			Message: msg,
+		})
+		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
+	}
+
+	// The server is off and armed for the rescue system. Power it on.
+	if err := s.scope.HCloudClient.PowerOnServer(ctx, &hcloud.Server{ID: serverID}); err != nil {
+		if handleUnauthorized(hm, err) {
+			return reconcile.Result{}, nil
+		}
+		if hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+			v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+				"PowerOnServerFailed", clusterv1beta1.ConditionSeverityInfo,
+				"PowerOnServer: server locked. Will retry")
+			v1beta2conditions.Set(hm, metav1.Condition{
+				Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HCloudMachinePoweringOnServerFailedV1Beta2Reason,
+				Message: "PowerOnServer: server locked. Will retry",
+			})
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		return reconcile.Result{}, handleRateLimit(hm, err, "PowerOnServer", "failed to power on server")
+	}
+	markHCloudTokenAvailable(hm)
+
+	hm.Status.RescuePowerCycleCount++
+	// Resetting the action IDs is what lets a later power-cycle start clean.
+	hm.Status.ExternalIDs.ActionIDPowerOffServer = 0
+	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
+
+	s.setBootState(infrav1.HCloudBootStateBootingToRescue)
+	v1beta1conditions.MarkFalse(hm, infrav1.ServerProvisionedCondition,
+		"BootingToRescue", clusterv1beta1.ConditionSeverityInfo,
+		"power on to rescue started")
+	v1beta2conditions.Set(hm, metav1.Condition{
+		Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.HCloudMachineBootingToRescueV1Beta2Reason,
+		Message: "power on to rescue started",
+	})
+	// The next state (BootingToRescue) polls via SSH, which costs no hcloud API calls, but
+	// powering on is not instant, so wait a bit before the first attempt instead of retrying
+	// immediately.
 	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
@@ -1230,9 +1594,11 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconci
 	}
 	updateHCloudMachineStatusFromServer(hm, server)
 
-	// Clean up old Status fields
+	// Clean up old Status fields. Status.RescuePowerCycleCount stays: it is a useful record of what
+	// provisioning this machine cost, and nothing re-enters BootingToRescue afterwards.
 	hm.Status.ExternalIDs.ActionIDEnableRescueSystem = 0
 	hm.Status.ExternalIDs.ActionIDCreateServer = 0
+	hm.Status.ExternalIDs.ActionIDPowerOffServer = 0
 
 	v1beta1conditions.MarkTrue(hm, infrav1.ServerProvisionedCondition)
 	// Provisioning is complete.
@@ -1319,12 +1685,12 @@ func (s *Service) handleOperatingSystemRunning(ctx context.Context) (res reconci
 	return reconcile.Result{}, nil
 }
 
-// getLiveServer fetches the live hcloud server. It is only called by the two states
-// (BootingToRealOS, OperatingSystemRunning) that need a server.Status transition or the
-// network/LB attachment reconcile. Unset does not call this because the server does not exist
-// yet. Initializing, EnablingRescue, BootingToRescue and RunningImageCommand drive their progress
-// via GetAction polling and/or SSH, so they never call this and avoid an hcloud API call on every
-// reconcile while they wait.
+// getLiveServer fetches the live hcloud server. It is only called by the three states
+// (PowerCyclingToRescue, BootingToRealOS, OperatingSystemRunning) that need a server.Status
+// transition or the network/LB attachment reconcile. Unset does not call this because the server
+// does not exist yet. Initializing, EnablingRescue, BootingToRescue and RunningImageCommand drive
+// their progress via GetAction polling and/or SSH, so they never call this and avoid an hcloud API
+// call on every reconcile while they wait.
 //
 // Unless it returns a live server together with an empty res and a nil err, the caller must return
 // (res, err) immediately. Some stop-paths (invalid token, rate limit, deleted server) deliberately

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -889,7 +889,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	if remoteHostName != "rescue" {
 		// The server booted the throwaway image instead of the rescue system. That image is
 		// created with the cluster's SSH keys attached, so it answers on port 22 with the machine
-		// name as hostname. A power-cycle with the rescue system armed again is very likely to fix
+		// name as hostname. A power-cycle with the rescue system enabled again is very likely to fix
 		// this, and it is faster than remediation.
 		if s.retryRescueBoot("UnexpectedHostname", fmt.Sprintf(
 			"remote hostname (via ssh) of hcloud server is %q, expected 'rescue'", remoteHostName)) {
@@ -1024,7 +1024,7 @@ func (s *Service) retryRescueBoot(trigger, msg string) bool {
 // handleBootStatePowerCyclingToRescue is for provisioning with imageURL and image-url-command.
 //
 // The server failed to reach the rescue system. This state powers it off, makes sure the rescue
-// system is armed for the next boot, powers it on again and goes back to BootingToRescue.
+// system is still enabled for the next boot, powers it on again and goes back to BootingToRescue.
 //
 // The action IDs in Status.ExternalIDs are the progress markers inside this state, so one handler
 // covers the whole power-cycle.
@@ -1123,7 +1123,7 @@ func (s *Service) handleBootStatePowerCyclingToRescue(ctx context.Context) (reco
 	}
 
 	// The poweroff was issued. One GetServer answers both questions this state has left: is the
-	// server off, and is the rescue system still armed for the next boot?
+	// server off, and is the rescue system still enabled for the next boot?
 	server, res, err := s.getLiveServer(ctx)
 	if server == nil || err != nil || !res.IsZero() {
 		return res, err
@@ -1214,9 +1214,9 @@ func (s *Service) handleBootStatePowerCyclingToRescue(ctx context.Context) (reco
 	}
 
 	if !server.RescueEnabled {
-		// Rescue is not armed any more: either it was consumed by the boot that went wrong, or it
-		// expired (hcloud disables it 60 minutes after it was enabled). Arm it again, otherwise the
-		// power on below boots the local disk.
+		// Rescue is no longer enabled: either it was consumed by the boot that went wrong, or it
+		// expired (hcloud disables it 60 minutes after it was enabled). Enable it again, otherwise
+		// the power on below boots the local disk.
 		_, hcloudSSHKeys, err := s.getSSHKeys(ctx)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("getSSHKeys failed: %w", err)
@@ -1266,7 +1266,7 @@ func (s *Service) handleBootStatePowerCyclingToRescue(ctx context.Context) (reco
 		return reconcile.Result{RequeueAfter: requeueImmediately}, nil
 	}
 
-	// The server is off and armed for the rescue system. Power it on.
+	// The server is off and rescue is still enabled. Power it on.
 	if err := s.scope.HCloudClient.PowerOnServer(ctx, &hcloud.Server{ID: serverID}); err != nil {
 		if handleUnauthorized(hm, err) {
 			return reconcile.Result{}, nil

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -938,16 +938,24 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 
 	// Now we know that we are inside a rescue system.
 
-	if hm.Status.RescuePowerCycleCount > 0 {
+	if hm.Status.ExternalIDs.ActionIDEnableRescueSystem == actionDone {
 		// This machine needed at least one power-cycle to get here. Distinct signal from
 		// "RetryingRescueBoot" (which fires when a retry is *attempted*, not when it *works*) -
 		// needed to measure, over time, how often a power-cycle actually reaches rescue versus
 		// just deferring to the other trigger and ending in remediation anyway (see
 		// "RescueRetryExhausted").
+		//
+		// Gated on the action-ID marker, not just RescuePowerCycleCount > 0: StartImageURLCommand
+		// below can fail transiently and requeue without changing BootState, which re-runs this
+		// whole function - checking the count alone would re-report the same recovery on every
+		// such retry. actionDone is set exactly once, by the power-cycle that just succeeded;
+		// consuming it here (like the other action-ID markers in this file) makes the report
+		// fire exactly once per actual recovery.
 		s.scope.Info("Reached the rescue system after a power-cycle",
 			"rescuePowerCycleCount", hm.Status.RescuePowerCycleCount)
 		record.Eventf(hm, "RescueRetrySucceeded",
 			"Reached the rescue system after %d power-cycle(s)", hm.Status.RescuePowerCycleCount)
+		hm.Status.ExternalIDs.ActionIDEnableRescueSystem = 0
 	}
 
 	// image-url-command has not started yet. Start it.

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -937,6 +937,19 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	}
 
 	// Now we know that we are inside a rescue system.
+
+	if hm.Status.RescuePowerCycleCount > 0 {
+		// This machine needed at least one power-cycle to get here. Distinct signal from
+		// "RetryingRescueBoot" (which fires when a retry is *attempted*, not when it *works*) -
+		// needed to measure, over time, how often a power-cycle actually reaches rescue versus
+		// just deferring to the other trigger and ending in remediation anyway (see
+		// "RescueRetryExhausted").
+		s.scope.Info("Reached the rescue system after a power-cycle",
+			"rescuePowerCycleCount", hm.Status.RescuePowerCycleCount)
+		record.Eventf(hm, "RescueRetrySucceeded",
+			"Reached the rescue system after %d power-cycle(s)", hm.Status.RescuePowerCycleCount)
+	}
+
 	// image-url-command has not started yet. Start it.
 
 	data, err := s.scope.GetRawBootstrapData(ctx)
@@ -1019,6 +1032,16 @@ func (s *Service) retryRescueBoot(ctx context.Context, trigger, msg string) bool
 	hm := s.scope.HCloudMachine
 
 	if hm.Status.RescuePowerCycleCount >= maxRescuePowerCycles {
+		// One shared, trigger-agnostic marker instead of two trigger-specific final reasons
+		// ("BootingToRescueTimedOut", "UnexpectedHostname") - counting "how often did the retry
+		// budget run out" shouldn't require knowing about and OR-ing together every trigger's own
+		// remediation reason. Paired with "RescueRetrySucceeded", this makes the retry's actual
+		// success rate measurable over time, instead of guessed at from individual incidents.
+		s.scope.Info("Rescue-retry budget exhausted, remediating",
+			"trigger", trigger, "rescuePowerCycleCount", hm.Status.RescuePowerCycleCount)
+		record.Warnf(hm, "RescueRetryExhausted",
+			"Retry budget exhausted after %d power-cycle(s) (%s). Remediating.",
+			hm.Status.RescuePowerCycleCount, trigger)
 		return false
 	}
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -63,13 +63,15 @@ const (
 	// rescueBootGracePeriod is how long BootingToRescue waits for the rescue system to answer
 	// over SSH before the server gets powered off and on again.
 	//
-	// A soak test of 44 back-to-back scale cycles (~90 fresh boots) never saw this state take
-	// longer than ~51s, and never hit this timeout at all - so there's no direct evidence this
-	// needs to be longer. Bumped from 90s to 120s anyway to give a genuinely slow (rather than
-	// stuck) boot more room, while keeping the worst-case-to-remediation time
-	// (2*rescueBootGracePeriod + powerCycleToRescueTimeout) at 6 min, same as the pre-retry
-	// baseline this PR improves on - a larger value would make that worse, not better.
-	rescueBootGracePeriod = 120 * time.Second
+	// A soak test of 100 back-to-back scale cycles (~190 fresh boots) never saw this state take
+	// longer than ~51s on a successful boot. It was briefly raised to 120s on the theory that a
+	// slow (rather than stuck) boot might just need more time, but the one real failure the soak
+	// test hit argued against that: SSH was continuously refused well before even the original 90s
+	// mark, with no narrowing trend, and the extra 30s only delayed the power-cycle (the thing that
+	// actually got it moving again) without helping. Reverted to 90s. Worst-case-to-remediation
+	// (2*rescueBootGracePeriod + powerCycleToRescueTimeout) is back to 5 min, improving on the
+	// pre-retry 6 min baseline as originally intended.
+	rescueBootGracePeriod = 90 * time.Second
 
 	// powerCycleToRescueTimeout bounds PowerCyclingToRescue. Two hcloud actions (power off, power
 	// on) normally cost ~15-25s, so this only limits the case where the server never reports

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2261,9 +2261,10 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.AssertNumberOfCalls(GinkgoT(), "GetServer", 1)
 	})
 
-	It("reports RescueRetrySucceeded when rescue is reached after a power-cycle", func() {
+	It("reports RescueRetrySucceeded exactly once when rescue is reached after a power-cycle", func() {
 		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 10*time.Second)
 		service.scope.HCloudMachine.Status.RescuePowerCycleCount = 1
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
 
 		By("mocking SSH: the rescue system answers this time")
 		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
@@ -2282,6 +2283,47 @@ var _ = Describe("Reconcile", func() {
 		Eventually(func() bool {
 			return hasEvent("RescueRetrySucceeded")
 		}, 10*time.Second, time.Second).Should(BeTrue())
+
+		By("ensuring the marker is consumed, so a StartImageURLCommand retry wouldn't re-report it")
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem).To(Equal(int64(0)))
+	})
+
+	It("does not re-report RescueRetrySucceeded on a StartImageURLCommand retry", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 10*time.Second)
+		service.scope.HCloudMachine.Status.RescuePowerCycleCount = 1
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
+
+		By("mocking SSH: the rescue system answers, but StartImageURLCommand fails transiently")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			StdOut: "rescue",
+		})
+		testEnv.HCloudSSHClient.On("StartImageURLCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "my-machine", []string{"sda"}).
+			Return(0, "", fmt.Errorf("temporary network error")).Once()
+
+		_, err := service.Reconcile(ctx)
+		Expect(err).ToNot(BeNil())
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
+
+		By("ensuring the first attempt already consumed the marker")
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem).To(Equal(int64(0)))
+
+		By("reconciling again: StartImageURLCommand succeeds this time")
+		testEnv.HCloudSSHClient.On("StartImageURLCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "my-machine", []string{"sda"}).Return(0, "", nil)
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 10 * time.Second}))
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
+
+		By("ensuring RescueRetrySucceeded fired exactly once across both reconciles")
+		eventList := &corev1.EventList{}
+		Expect(testEnv.List(ctx, eventList, client.InNamespace(testNs.Name))).To(Succeed())
+		count := 0
+		for _, event := range eventList.Items {
+			if event.Reason == "RescueRetrySucceeded" && event.InvolvedObject.Name == service.scope.HCloudMachine.Name {
+				count += int(event.Count)
+			}
+		}
+		Expect(count).To(Equal(1))
 	})
 
 	It("remediates when the rescue system stays unreachable after the power-cycle", func() {
@@ -2412,7 +2454,7 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
 	})
 
-	It("arms the rescue system again when it is no longer enabled", func() {
+	It("enables the rescue system again when it is no longer enabled", func() {
 		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
 		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
 		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2237,7 +2237,7 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	It("power-cycles instead of remediating when the rescue system stays unreachable", func() {
-		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 130*time.Second)
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
 
 		By("mocking GetServer: retryRescueBoot fetches a diagnostic snapshot of the live state")
 		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
@@ -2262,7 +2262,7 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	It("remediates when the rescue system stays unreachable after the power-cycle", func() {
-		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 130*time.Second)
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
 		service.scope.HCloudMachine.Status.RescuePowerCycleCount = maxRescuePowerCycles
 
 		By("setting the condition the previous reconcile would have left behind")

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2171,6 +2171,334 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
 	})
 
+	// The specs below cover the retry of the rescue boot. They all start in the middle of the
+	// imageURL flow, so they share this setup.
+	setupImageURLMachineInState := func(bootState infrav1.HCloudBootState, sinceBootState time.Duration) {
+		Expect(testEnv.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrapsecret",
+				Namespace: testNs.Name,
+			},
+			Data: map[string][]byte{
+				"value": []byte("dummy-bootstrap-data"),
+			},
+		})).To(Succeed())
+		service.scope.Machine.Spec.Bootstrap.DataSecretName = ptr.To("bootstrapsecret")
+		service.scope.HCloudMachine.Spec.ImageName = ""
+		service.scope.HCloudMachine.Spec.ImageURL = "oci://example.com/repo/image:v1"
+		service.scope.HCloudMachine.Spec.ImageURLCommand = "image-url-command-test.sh"
+		service.scope.HCloudMachine.Spec.ProviderID = ptr.To("hcloud://42")
+		service.scope.HCloudMachine.Status.BootState = bootState
+		service.scope.HCloudMachine.Status.BootStateSince = metav1.NewTime(time.Now().Add(-sinceBootState))
+
+		// BootingToRescue connects to the server over SSH, and getSSHClient reads the target IP
+		// from Status.Addresses. The full provisioning flow fills that in at server creation.
+		service.scope.HCloudMachine.Status.Addresses = []clusterv1beta1.MachineAddress{
+			{Type: clusterv1beta1.MachineExternalIP, Address: "1.2.3.4"},
+		}
+	}
+
+	isRemediated := func() bool {
+		_, exists := service.scope.Machine.Annotations[clusterv1.RemediateMachineAnnotation]
+		return exists
+	}
+
+	hasEvent := func(reason string) bool {
+		eventList := &corev1.EventList{}
+		if err := testEnv.List(ctx, eventList, client.InNamespace(testNs.Name)); err != nil {
+			return false
+		}
+		for _, event := range eventList.Items {
+			if event.Reason == reason && event.InvolvedObject.Name == service.scope.HCloudMachine.Name {
+				return true
+			}
+		}
+		return false
+	}
+
+	It("keeps waiting for SSH in BootingToRescue while the grace period has not passed", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 60*time.Second)
+
+		By("mocking SSH: connection refused, the server has not reached the rescue system yet")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			Err: syscall.ECONNREFUSED,
+		})
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res.RequeueAfter).To(Equal(requeueImmediately))
+
+		By("ensuring the machine stays in BootingToRescue and no power-cycle was started")
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(service.scope.HCloudMachine.Status.RescuePowerCycleCount).To(Equal(int32(0)))
+		Expect(isRemediated()).To(BeFalse())
+		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOffServer", mock.Anything, mock.Anything)
+	})
+
+	It("power-cycles instead of remediating when the rescue system stays unreachable", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
+
+		By("reconciling: the grace period has passed, so the server gets power-cycled")
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res.RequeueAfter).To(Equal(requeueImmediately))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		Expect(isRemediated()).To(BeFalse())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "RetryingRescueBoot")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			metav1.ConditionFalse, infrav1.HCloudMachineRetryingRescueBootV1Beta2Reason)).To(BeTrue())
+
+		By("ensuring the timeout was not reached via an hcloud API call")
+		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
+	})
+
+	It("remediates when the rescue system stays unreachable after the power-cycle", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
+		service.scope.HCloudMachine.Status.RescuePowerCycleCount = maxRescuePowerCycles
+
+		By("setting the condition the previous reconcile would have left behind")
+		v1beta1conditions.MarkFalse(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition,
+			"RetryingSSHConnection", clusterv1beta1.ConditionSeverityInfo, "getHostName: ssh not reachable yet. Retrying")
+		v1beta2conditions.Set(service.scope.HCloudMachine, metav1.Condition{
+			Type:    infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.HCloudMachineRetryingSSHConnectionV1Beta2Reason,
+			Message: "getHostName: ssh not reachable yet. Retrying",
+		})
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateProvisioningFailed))
+		Expect(isRemediated()).To(BeTrue())
+
+		By("ensuring the reason of the previous condition is preserved and the message names the attempt")
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "RetryingSSHConnection")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			metav1.ConditionFalse, infrav1.HCloudMachineRetryingSSHConnectionV1Beta2Reason)).To(BeTrue())
+		condition := v1beta1conditions.Get(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition)
+		Expect(condition.Message).To(ContainSubstring("attempt 2 of 2"))
+	})
+
+	It("power-cycles instead of remediating when the wrong operating system answers over SSH", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 10*time.Second)
+
+		By("mocking SSH: the throwaway image answers with the machine name as hostname")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			StdOut: "my-machine",
+		})
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res.RequeueAfter).To(Equal(requeueImmediately))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		Expect(isRemediated()).To(BeFalse())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "RetryingRescueBoot")).To(BeTrue())
+
+		By("ensuring the power-cycle is visible as an event")
+		Eventually(func() bool {
+			return hasEvent("RetryingRescueBoot")
+		}, 10*time.Second, time.Second).Should(BeTrue())
+	})
+
+	It("remediates when the wrong operating system answers over SSH after the power-cycle", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 10*time.Second)
+		service.scope.HCloudMachine.Status.RescuePowerCycleCount = maxRescuePowerCycles
+
+		By("mocking SSH: the throwaway image answers with the machine name as hostname")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			StdOut: "my-machine",
+		})
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateProvisioningFailed))
+		Expect(isRemediated()).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "UnexpectedHostname")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			metav1.ConditionFalse, infrav1.HCloudMachineUnexpectedHostnameV1Beta2Reason)).To(BeTrue())
+	})
+
+	It("powers the server off in PowerCyclingToRescue and stores the action ID", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+
+		hcloudClient.On("PowerOffServer", mock.Anything, mock.MatchedBy(func(server *hcloud.Server) bool {
+			return server.ID == 42
+		})).Return(&hcloud.Action{ID: 776655}, nil).Once()
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer).To(Equal(int64(776655)))
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "PoweringOffForRescueRetry")).To(BeTrue())
+
+		By("ensuring the server is not read before the poweroff was issued")
+		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
+	})
+
+	It("waits in PowerCyclingToRescue until the server reports status off", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Name:          "my-machine",
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		Expect(service.scope.HCloudMachine.Status.RescuePowerCycleCount).To(Equal(int32(0)))
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "WaitingForServerOff")).To(BeTrue())
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+	})
+
+	It("arms the rescue system again when it is no longer enabled", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
+
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Name:          "my-machine",
+			Status:        hcloud.ServerStatusOff,
+			RescueEnabled: false,
+		}, nil).Once()
+		hcloudClient.On("ListSSHKeys", mock.Anything, mock.Anything).Return([]*hcloud.SSHKey{
+			{
+				ID:          1,
+				Name:        "sshKey1",
+				Fingerprint: "b7:2f:30:a0:2f:6c:58:6c:21:04:58:61:ba:06:3b:1f",
+			},
+		}, nil)
+		hcloudClient.On("EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything).Return(
+			hcloud.ServerEnableRescueResult{Action: &hcloud.Action{ID: 445566}}, nil).Once()
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueImmediately}))
+
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem).To(Equal(int64(445566)))
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "ReEnablingRescueSystem")).To(BeTrue())
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+	})
+
+	It("waits for the enable rescue action before powering the server on again", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = 445566
+
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Name:          "my-machine",
+			Status:        hcloud.ServerStatusOff,
+			RescueEnabled: false,
+		}, nil)
+
+		By("reconciling while the enable rescue action is still running")
+		startTime := time.Now()
+		hcloudClient.On("GetAction", mock.Anything, int64(445566)).Return(&hcloud.Action{
+			ID:      445566,
+			Status:  hcloud.ActionStatusRunning,
+			Started: startTime,
+		}, nil).Once()
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Second}))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem).To(Equal(int64(445566)))
+		hcloudClient.AssertNotCalled(GinkgoT(), "EnableRescueSystem", mock.Anything, mock.Anything, mock.Anything)
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+
+		By("reconciling again: the enable rescue action is finished")
+		hcloudClient.On("GetAction", mock.Anything, int64(445566)).Return(&hcloud.Action{
+			ID:       445566,
+			Status:   hcloud.ActionStatusSuccess,
+			Started:  startTime,
+			Finished: time.Now(),
+		}, nil).Once()
+
+		res, err = service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueImmediately}))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem).To(Equal(int64(actionDone)))
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStatePowerCyclingToRescue))
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+	})
+
+	It("powers the server on again and returns to BootingToRescue", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDEnableRescueSystem = actionDone
+
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Name:          "my-machine",
+			Status:        hcloud.ServerStatusOff,
+			RescueEnabled: true,
+		}, nil).Once()
+		hcloudClient.On("PowerOnServer", mock.Anything, mock.MatchedBy(func(server *hcloud.Server) bool {
+			return server.ID == 42
+		})).Return(nil).Once()
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 10 * time.Second}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateBootingToRescue))
+		Expect(service.scope.HCloudMachine.Status.RescuePowerCycleCount).To(Equal(int32(1)))
+		Expect(service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer).To(Equal(int64(0)))
+		Expect(isRemediated()).To(BeFalse())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "BootingToRescue")).To(BeTrue())
+	})
+
+	It("remediates when PowerCyclingToRescue times out", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 3*time.Minute)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateProvisioningFailed))
+		Expect(isRemediated()).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "PowerCyclingToRescueTimedOut")).To(BeTrue())
+		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
+			metav1.ConditionFalse, infrav1.HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason)).To(BeTrue())
+		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
+	})
+
+	It("remediates when the server is gone while power-cycling to rescue", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStatePowerCyclingToRescue, 5*time.Second)
+		service.scope.HCloudMachine.Status.ExternalIDs.ActionIDPowerOffServer = 776655
+
+		By("ensuring that the hcloud client reports the server as gone")
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(nil, nil)
+		hcloudClient.On("ListServers", mock.Anything, mock.Anything).Return(nil, nil)
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateProvisioningFailed))
+		Expect(isRemediated()).To(BeTrue())
+		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerAvailableCondition, "NoHCloudServerFound")).To(BeTrue())
+		hcloudClient.AssertNotCalled(GinkgoT(), "PowerOnServer", mock.Anything, mock.Anything)
+	})
+
 	It("sets condition HCloudCredentialsInvalid when HCloud API returns 'unauthorized' error while creating a server", func() {
 		By("setting the bootstrap data")
 		err = testEnv.Create(ctx, &corev1.Secret{

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2261,6 +2261,29 @@ var _ = Describe("Reconcile", func() {
 		hcloudClient.AssertNumberOfCalls(GinkgoT(), "GetServer", 1)
 	})
 
+	It("reports RescueRetrySucceeded when rescue is reached after a power-cycle", func() {
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 10*time.Second)
+		service.scope.HCloudMachine.Status.RescuePowerCycleCount = 1
+
+		By("mocking SSH: the rescue system answers this time")
+		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
+			StdOut: "rescue",
+		})
+		testEnv.HCloudSSHClient.On("StartImageURLCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "my-machine", []string{"sda"}).Return(0, "", nil)
+
+		res, err := service.Reconcile(ctx)
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(reconcile.Result{RequeueAfter: 10 * time.Second}))
+
+		Expect(service.scope.HCloudMachine.Status.BootState).To(Equal(infrav1.HCloudBootStateRunningImageCommand))
+		Expect(isRemediated()).To(BeFalse())
+
+		By("ensuring the recovery is visible as a dedicated event")
+		Eventually(func() bool {
+			return hasEvent("RescueRetrySucceeded")
+		}, 10*time.Second, time.Second).Should(BeTrue())
+	})
+
 	It("remediates when the rescue system stays unreachable after the power-cycle", func() {
 		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
 		service.scope.HCloudMachine.Status.RescuePowerCycleCount = maxRescuePowerCycles
@@ -2288,6 +2311,11 @@ var _ = Describe("Reconcile", func() {
 			metav1.ConditionFalse, infrav1.HCloudMachineRetryingSSHConnectionV1Beta2Reason)).To(BeTrue())
 		condition := v1beta1conditions.Get(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition)
 		Expect(condition.Message).To(ContainSubstring("attempt 2 of 2"))
+
+		By("ensuring the exhausted retry budget is visible as a dedicated event")
+		Eventually(func() bool {
+			return hasEvent("RescueRetryExhausted")
+		}, 10*time.Second, time.Second).Should(BeTrue())
 	})
 
 	It("power-cycles instead of remediating when the wrong operating system answers over SSH", func() {
@@ -2337,6 +2365,11 @@ var _ = Describe("Reconcile", func() {
 		Expect(isPresentAndFalseWithReason(service.scope.HCloudMachine, infrav1.ServerProvisionedCondition, "UnexpectedHostname")).To(BeTrue())
 		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 			metav1.ConditionFalse, infrav1.HCloudMachineUnexpectedHostnameV1Beta2Reason)).To(BeTrue())
+
+		By("ensuring the exhausted retry budget is visible as a dedicated event, same as trigger A")
+		Eventually(func() bool {
+			return hasEvent("RescueRetryExhausted")
+		}, 10*time.Second, time.Second).Should(BeTrue())
 	})
 
 	It("powers the server off in PowerCyclingToRescue and stores the action ID", func() {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2237,7 +2237,14 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	It("power-cycles instead of remediating when the rescue system stays unreachable", func() {
-		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 130*time.Second)
+
+		By("mocking GetServer: retryRescueBoot fetches a diagnostic snapshot of the live state")
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
 
 		By("reconciling: the grace period has passed, so the server gets power-cycled")
 		res, err := service.Reconcile(ctx)
@@ -2250,12 +2257,12 @@ var _ = Describe("Reconcile", func() {
 		Expect(isPresentWithStatusAndReasonV1Beta2(service.scope.HCloudMachine, infrav1.HCloudMachineServerProvisionedV1Beta2Condition,
 			metav1.ConditionFalse, infrav1.HCloudMachineRetryingRescueBootV1Beta2Reason)).To(BeTrue())
 
-		By("ensuring the timeout was not reached via an hcloud API call")
-		hcloudClient.AssertNotCalled(GinkgoT(), "GetServer", mock.Anything, mock.Anything)
+		By("ensuring the diagnostic snapshot cost exactly one hcloud API call, not one per waiting reconcile")
+		hcloudClient.AssertNumberOfCalls(GinkgoT(), "GetServer", 1)
 	})
 
 	It("remediates when the rescue system stays unreachable after the power-cycle", func() {
-		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 100*time.Second)
+		setupImageURLMachineInState(infrav1.HCloudBootStateBootingToRescue, 130*time.Second)
 		service.scope.HCloudMachine.Status.RescuePowerCycleCount = maxRescuePowerCycles
 
 		By("setting the condition the previous reconcile would have left behind")
@@ -2290,6 +2297,13 @@ var _ = Describe("Reconcile", func() {
 		testEnv.HCloudSSHClient.On("GetHostName", mock.Anything).Return(sshclient.Output{
 			StdOut: "my-machine",
 		})
+
+		By("mocking GetServer: retryRescueBoot fetches a diagnostic snapshot of the live state")
+		hcloudClient.On("GetServer", mock.Anything, int64(42)).Return(&hcloud.Server{
+			ID:            42,
+			Status:        hcloud.ServerStatusRunning,
+			RescueEnabled: true,
+		}, nil).Once()
 
 		res, err := service.Reconcile(ctx)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
# Plan: Retry bringing an hcloud server to rescue mode if the first attempt fails

Implements [issue #2211](https://github.com/syself/cluster-api-provider-hetzner/issues/2211).

Scope: the hcloud `imageURL` provisioning flow only. The `imageName`/snapshot flow never uses the
rescue system, and bare metal is untouched.

Base branch: `release-1.1`. That branch has a single API version, `api/v1beta1`, so everything below
that the original plan wrote twice (`api/v1beta1` and `api/v1beta2`) exists once here.

---

## 1. Problem

`handleBootStateBootingToRescue` ([pkg/services/hcloud/server/server.go:763](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L763))
has two failure paths, and both end in remediation (machine deleted, new machine created):

| # | Trigger | Today | Where |
|---|---------|-------|-------|
| A | SSH never becomes reachable | wait 6 minutes, then `SetErrorAndRemediate` | [server.go:766-804](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L766-L804) |
| B | SSH answers, but hostname is not `rescue` | remediate immediately | [server.go:857-874](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L857-L874) |

In case B the server booted the throwaway `ubuntu-24.04` image instead of rescue. That image is
created with the cluster's SSH keys attached ([server.go:1764](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L1764)),
so it answers on port 22 with a hostname equal to the machine name.

Both cases are very likely fixable by a power cycle. Doing that is faster than remediation (which
recreates a server from scratch) and often fixes whatever the server was stuck on.

**Update after implementation, §11:** a 100-cycle soak test confirmed the mechanism works
end-to-end, but the one real failure it hit didn't fit "often fixes it" - the power-cycle
recovered quickly, but the *next* boot still missed rescue, just via the other trigger. One data
point, not a refutation, but worth reading §11 before treating this as "mostly self-healing."

## 2. Approach

Follow the mechanism the issue describes: perform the action, move to a **new BootState**, requeue,
and let the handler of the new state drive the rest. Action IDs stored in the status act as
progress markers inside the state, so one handler covers the whole power-cycle.

```text
                     ┌────────────────────────────────────────────┐
                     │                                            │
   EnablingRescue ──▶ BootingToRescue ──▶ PowerCyclingToRescue ────┘   (new state)
                            │  ▲                    │
             hostname=rescue│  └── power on ────────┘
                            ▼
                    RunningImageCommand
```

`PowerCyclingToRescue`: power off → wait until the server is off → make sure rescue is still
enabled → power on → back to `BootingToRescue`.

### Decisions (settled)

| Decision | Value | Rationale |
|---|---|---|
| Grace period before power-cycling | **90 s** (briefly raised to 120 s during soak testing, then reverted - see §3, §11) | See §3, §11. |
| Power-cycles before remediation | **1**, budget **shared** by triggers A and B | Issue's proposal. A shared counter means a machine that alternates between the two triggers still cannot loop. |
| Power-off method | hard `poweroff`, **not** ACPI `shutdown` | The server is either stuck mid-boot or running an image we are about to overwrite. A stuck kernel ignores ACPI, and there is nothing to preserve. |
| Power off + on, not `reset` | two actions | `reset` gives no window in which the server is off, and checking/re-enabling `rescue_enabled` while it is off is the point of the design. |
| "Is it off?" check | `GetServer`, not `GetAction` on the poweroff action | The issue asked "(via action or getServer?)". One `GetServer` returns **both** `Status` and `RescueEnabled`, which the state needs anyway. Polling the action would cost a second call to learn only half of it. |
| Timeout of the new state | 2 min | Normal cost is ~15-25 s (two API actions). Bounds the worst case; see §3. |

## 3. Timing

The only measurement in the repo is
[docs/caph/04-developers/06-image-url-command.md:157-166](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/docs/caph/04-developers/06-image-url-command.md#L157-L166):

```text
| BootingToRescue | RunningImageCommand | avg 38.20 | min 37.00 | max 42.00 |
```

**Caveat, and it matters:** `git log -S` shows this table was added by `8ab0b5e46` (#1647,
2025-10-06) and has never been regenerated. It therefore predates `b92325bd4` (#2156, 2026-07-10),
which changed how the state is entered — from a **warm reboot via SSH** (`sshClient.Reboot(ctx)`,
with the comment *"Reboot via ssh, avoid API calls to hcloud (rate-limit)"*) to a **cold
`PowerOnServer`** of a server created with `StartAfterCreate=false`. The 10 s requeue before the
first SSH attempt is the same in both, so the rest is comparable — but a cold start is not
plausibly faster than a warm reboot, so ~40 s is a **lower bound** for today's flow, not a
measurement of it.

The issue suggests "e.g. 45 sec". That is 3 s above the observed maximum of a *faster* variant of
the operation, so it would power-cycle a large share of healthy machines. **Use 90 s.**

Resulting budget as originally shipped (all named constants, easy to tune once the table is
regenerated):

| Phase | Budget |
|---|---|
| `BootingToRescue`, attempt 1 | 90 s |
| `PowerCyclingToRescue` | ≤ 120 s (typically ~20 s) |
| `BootingToRescue`, attempt 2 | 90 s, then remediate |
| **Worst case to remediation** | **5 min** (today: 6 min) |
| **Typical failure path** | **~3.5 min** |

Trigger B improves far more: today it remediates on first sight, and after this change it gets a
power-cycle first, which the issue expects to succeed nearly always.

**Update after a 100-cycle soak test (§11):** real successful boots consistently reached
`RunningImageCommand` in 15-51 s - comfortably under even the original 90 s, with no soak-test
failure looking like "almost made it." `rescueBootGracePeriod` was bumped to 120 s partway through
the soak test anyway, as a precaution rather than a fix for an observed problem - chosen so the
worst case would stay at 2×120s + 120s = 6 min, matching the pre-retry baseline rather than
exceeding it.

**Reverted back to 90 s after finishing the soak test.** The one real failure it caught (§11)
argued against the "maybe it just needs more time" theory that motivated the bump: SSH was
continuously refused well before even the 90 s mark, with no narrowing trend, so the extra 30 s
only delayed the power-cycle - the thing that actually got the machine moving again - without
changing the outcome. **90 s** is back to being the shipped value, restoring the original 5-minute
worst case.

## 4. Facts established during investigation

Recorded because two of them contradict assumptions in the closed PoC
[PR #2207](https://github.com/syself/cluster-api-provider-hetzner/pull/2207).

1. **`rescue_enabled` is not a "did it reach rescue" signal.** Hetzner docs
   ([Using Rescue](https://docs.hetzner.com/cloud/servers/getting-started/rescue-system/)):
   *"Once the server booted over the network of the rescue system, rescue will remain active until
   you restart the server again."* So `rescue_enabled == true` on a running server does **not**
   prove it booted the wrong image. PR #2207's state table rests on the opposite premise. The SSH
   hostname check stays the authoritative "am I in rescue" test; this plan uses `RescueEnabled`
   only for what it does mean: *the next boot will try rescue*.
2. **Rescue expires after 60 minutes.** *"Rescue remains activated for 60 minutes […] If you
   restart your server after those 60 minutes, the server will boot from its local disk again."*
   Our windows are minutes, so expiry is not a practical risk — but checking `RescueEnabled` again
   before powering back on covers it for free.
3. **There is no power-off in the client interface.** Only `ShutdownServer` (ACPI) and
   `RebootServer` ([client.go:42-82](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/client.go#L42-L82)). `hcloud-go`
   has `Server.Poweroff`; a `PowerOffServer` wrapper must be added.
4. **The power wrappers discard action IDs.** `PowerOnServer`
   ([client.go:291](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/client.go#L291)) throws away the `*hcloud.Action`.
5. **The state machine can ping-pong forever without a counter.** `SetBootState` resets
   `BootStateSince` on every transition, so bouncing `BootingToRescue ↔ PowerCyclingToRescue` never
   reaches any per-state timeout. The persisted counter is not optional.
6. **Open question, added after §11:** fact 1 says `rescue_enabled == true` doesn't prove a past
   boot reached rescue. The soak test raises the mirror-image question: does `rescue_enabled ==
   true` reliably *predict* that the *next* boot will reach rescue? `PowerCyclingToRescue` skips
   re-enabling when the flag already reads `true` (§5.3, §9), on the assumption that it does. One
   soak-test failure had the flag read `true` immediately before a power-cycle whose next boot
   still missed rescue. Not confirmed - reported to Hetzner, see §11 - but if it turns out the flag
   isn't sufficient, the fix is to always call `EnableRescueSystem` on a power-cycle regardless of
   the flag, not just when it reads `false`.

## 5. Changes

### 5.1 API (`api/v1beta1`, the storage version and the only version on this branch)

**New boot state** in [types.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/api/v1beta1/types.go):

```go
// HCloudBootStatePowerCyclingToRescue indicates that reaching the rescue system failed and the
// controller is powering the server off and on again, so the server gets another chance to boot
// into the rescue system.
HCloudBootStatePowerCyclingToRescue HCloudBootState = "PowerCyclingToRescue"
```

**New status fields** in [hcloudmachine_types.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/api/v1beta1/hcloudmachine_types.go):

```go
// in HCloudMachineStatusExternalIDs
// ActionIDPowerOffServer is the hcloud API Action result of PowerOffServer.
// +optional
ActionIDPowerOffServer int64 `json:"actionIdPowerOffServer,omitzero"`

// in HCloudMachineStatus
// RescuePowerCycleCount counts how often the controller powered the server off and on again
// because it failed to reach the rescue system. It bounds the retries: transitions reset
// BootStateSince, so the per-state timeouts alone cannot stop a loop.
// +optional
RescuePowerCycleCount int32 `json:"rescuePowerCycleCount,omitzero"`
```

Both fields are plain scalars, so `make generate` only has to update the CRD; `zz_generated.deepcopy.go`
is unaffected. **The CRD change is not optional**: an API server with the old schema prunes both
fields on every status write, and `RescuePowerCycleCount` silently staying at 0 is exactly the
ping-pong loop §4.5 describes.

**New condition reasons** in [api/v1beta1/conditions_const.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/api/v1beta1/conditions_const.go),
mirroring the existing style around the other `BootingToRescue` reasons.

- `HCloudMachineRetryingRescueBootV1Beta2Reason = "RetryingRescueBoot"`
- `HCloudMachinePoweringOffForRescueRetryV1Beta2Reason = "PoweringOffForRescueRetry"`
- `HCloudMachineWaitingForServerOffV1Beta2Reason = "WaitingForServerOff"`
- `HCloudMachineReEnablingRescueSystemV1Beta2Reason = "ReEnablingRescueSystem"`
- `HCloudMachinePowerCyclingToRescueTimedOutV1Beta2Reason = "PowerCyclingToRescueTimedOut"`

### 5.2 hcloud client

[pkg/services/hcloud/client/client.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/client.go) — add to the interface
and implement next to `PowerOnServer`:

```go
PowerOffServer(context.Context, *hcloud.Server) (*hcloud.Action, error)
```

```go
func (c *realClient) PowerOffServer(ctx context.Context, server *hcloud.Server) (*hcloud.Action, error) {
	action, _, err := c.client.Server.Poweroff(ctx, server)
	if err != nil && strings.Contains(err.Error(), errStringUnauthorized) {
		return nil, fmt.Errorf("%w: %w", ErrUnauthorized, err)
	}
	return action, err
}
```

[fake/hcloud_client.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/fake/hcloud_client.go) — add `PowerOffServer`
mirroring `ShutdownServer` ([:599](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/fake/hcloud_client.go#L599)): set
`Status = ServerStatusOff`, return an action, `ErrorCodeNotFound` for an unknown ID.

While there: `EnableRescueSystem` ([:842](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/fake/hcloud_client.go#L842))
returns a zero `ServerEnableRescueResult` whose `Action` is `nil`. Any caller reaching
`result.Action.ID` panics. Make it return an action and set `RescueEnabled = true`, matching the
real API. (PR #2207 hit the same gap.)

Regenerate `mocks/Client.go` with `make generate-mocks`.

### 5.3 New state handler

Register in the switch ([server.go:153-170](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L153-L170)):

```go
case infrav1.HCloudBootStatePowerCyclingToRescue:
	return s.handleBootStatePowerCyclingToRescue(ctx)
```

`handleBootStatePowerCyclingToRescue`, placed after `handleBootStateBootingToRescue`:

1. **Timeout guard.** `durationOfState > powerCycleToRescueTimeout` (2 min) →
   `SetErrorAndRemediate`, preserving the existing reason/message exactly like the other states do.
2. **Power off not yet issued** (`ExternalIDs.ActionIDPowerOffServer == 0`):
   call `PowerOffServer`. Reuse the established error handling — `handleUnauthorized`,
   `ErrorCodeLocked` → requeue 5 s, `handleRateLimit`, `markHCloudTokenAvailable` on success.
   Store the action ID, set the condition to `PoweringOffForRescueRetry`, requeue 5 s.
3. **Power off issued** — call `getLiveServer`
   ([server.go:1333](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L1333)), which is one `GetServer` and
   already handles deleted server / invalid token / rate limit. Then:
   - `server.Status != hcloud.ServerStatusOff` → condition `WaitingForServerOff`, requeue 5 s.
   - server is off → `updateHCloudMachineStatusFromServer(hm, server)`, then:
     - `ActionIDEnableRescueSystem` is a live action (`> 0`) → `GetAction`; unfinished → requeue
       5 s; finished with error → remediate; finished → set to `actionDone`, requeue immediately.
       *(Same shape as [handleBootStateEnablingRescue](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L637-L716).)*
     - `!server.RescueEnabled` → `getSSHKeys` + `EnableRescueSystem`, store the action ID in
       `ActionIDEnableRescueSystem`, condition `ReEnablingRescueSystem`, requeue immediately.
       Gating on the action ID above prevents a tight re-enable loop if the flag lags.
     - `server.RescueEnabled` → `PowerOnServer`. On success: `RescuePowerCycleCount++`,
       `ActionIDPowerOffServer = 0`, `ActionIDEnableRescueSystem = actionDone`,
       `setBootState(BootingToRescue)`, condition `BootingToRescue`, requeue 10 s (matching
       [server.go:756-759](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L756-L759)).

Resetting `ActionIDPowerOffServer` on the way out is what lets a later cycle start clean.

Update the `getLiveServer` doc comment
([server.go:1321-1332](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L1321-L1332)), which enumerates the
states that call it — the new state joins the list, and the sentence saying `BootingToRescue` never
calls it stays true.

### 5.4 `handleBootStateBootingToRescue`

Add one helper, used by both triggers:

```go
// retryRescueBoot moves to PowerCyclingToRescue if a power-cycle is still allowed, and reports
// whether it did. Both failure paths of BootingToRescue share one budget, so a server that
// alternates between "SSH silent" and "wrong OS answered" cannot cycle forever.
func (s *Service) retryRescueBoot(reason, msg string) bool
```

**Trigger A** — replace the `durationOfState > 6*time.Minute` guard with
`durationOfState > rescueBootGracePeriod` (90 s), and try `retryRescueBoot` first. If the budget is
spent, fall through to the existing remediation block unchanged, with the message extended to name
the attempt (`"reaching rescue system timed out after 1m30s (attempt 2 of 2)"`).

**Trigger B** — at [server.go:857](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L857), try
`retryRescueBoot` before the existing remediation. Keep the `UnexpectedHostname` reason for the
final failure so existing alerting still matches. Log the retry at `Info`, not `Error` — it is
expected and recoverable — and emit `record.Warnf(hm, "RetryingRescueBoot", …)` so the power-cycle
is visible as an event.

### 5.5 Cleanup

[handleOperatingSystemRunning](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L1233-L1234) already clears the
action IDs; add `ActionIDPowerOffServer = 0`. Leave `RescuePowerCycleCount` — it is a useful record
of what provisioning cost, and nothing re-enters `BootingToRescue` afterwards.

### 5.6 Untouched by design

- The remediation controller gates on `BootState == OperatingSystemRunning`
  ([remediation.go:53](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/remediation/remediation.go#L53)). The new state is not
  that, so a machine that exhausts its budget is deleted rather than rebooted — the existing,
  correct behaviour.
- The `imageName`/snapshot flow and bare metal.

### 5.7 Logging improvements (added after the first soak test, §11)

The first 44-cycle soak test never triggered the retry path at all, which meant there was no way
to tell from logs alone what a real hit would look like. Added before the second soak test:

- `retryRescueBoot` now does one best-effort `GetServer` call right when a retry is decided (not
  on every reconcile while waiting - the `<= 1`/zero-extra-calls invariants in §6 are about the
  waiting path, not this one-shot diagnostic), logging the live `status`/`RescueEnabled` alongside
  the existing `Info` message.
- The SSH-wait branch now says *why* it's retrying (`connection refused` vs a dial `timeout`,
  which are different phases of a normal boot - timeout comes first, before the network is up at
  all) instead of one generic message for both.
- A heartbeat log every ~15 s while waiting, instead of silence until success or the final timeout.

None of this changes control flow; it only makes a real hit legible from logs, which is exactly
what let §11 reconstruct the full sequence of the one real failure.

### 5.8 `RescueRetrySucceeded` / `RescueRetryExhausted` events (added after §11)

§11 raised a question §5.7's logging couldn't answer on its own: does the power-cycle *usually*
work, or was the one soak-test failure typical? Answering that from logs means re-reading every
incident by hand. Two new events make the success rate directly measurable over time instead:

- `RescueRetrySucceeded` fires where `handleBootStateBootingToRescue` confirms the hostname is
  `rescue`, if `RescuePowerCycleCount > 0` - i.e. it needed at least one power-cycle to get there.
- `RescueRetryExhausted` fires from the one shared budget-check at the top of `retryRescueBoot`,
  so it's trigger-agnostic - no need to know about and OR together both triggers' own final
  remediation reasons (`BootingToRescueTimedOut`, `UnexpectedHostname`) to count "how often did
  the budget run out."

Neither changes control flow. `(successes) / (successes + exhaustions)` over time is the retry's
actual hit rate - the number this PR's design leaned on ("often fixes it", §1) without ever having
measured.

## 6. Tests

Ginkgo specs in [pkg/services/hcloud/server/server_test.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server_test.go),
following the existing style (mock hcloud client, `testEnv.HCloudSSHClient`, `BootStateSince`
back-dated with `metav1.NewTime(time.Now().Add(-…))`).

Regressions that must keep passing unchanged:

- *"never calls GetServer while waiting for SSH in BootingToRescue"*
  ([:2081](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server_test.go#L2081)) — the new state must not add API calls
  to the waiting path.
- `getServerCalls <= 1` across full `imageURL` provisioning
  ([:1845](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server_test.go#L1845)) — the healthy path gains **zero**
  `GetServer` calls, so this assertion stays at 1. (It would have had to be raised to 2 under
  PR #2207's approach; that is the concrete cost of keeping the re-enable check out of scope.)

New specs:

| # | Given | Expect |
|---|---|---|
| 1 | `BootingToRescue`, 60 s in, SSH timing out | stays in state, no `GetServer`, no remediation |
| 2 | `BootingToRescue`, 100 s in, count 0 | → `PowerCyclingToRescue`, no remediate annotation |
| 3 | `BootingToRescue`, 100 s in, count 1 | remediated, `BootState = ProvisioningFailed`, previous condition reason preserved |
| 4 | hostname `my-machine`, count 0 | → `PowerCyclingToRescue`, `RetryingRescueBoot` event |
| 5 | hostname `my-machine`, count 1 | remediated with `UnexpectedHostname` |
| 6 | `PowerCyclingToRescue`, `ActionIDPowerOffServer == 0` | `PowerOffServer` called once, ID stored, still in state |
| 7 | same, server still `running` | requeue, `PowerOnServer` **not** called |
| 8 | same, server `off`, `RescueEnabled=false` | `EnableRescueSystem` called, `PowerOnServer` not called |
| 9 | same, server `off`, `RescueEnabled=true` | `PowerOnServer` called, count → 1, `ActionIDPowerOffServer` → 0, → `BootingToRescue` |
| 10 | `PowerCyclingToRescue`, 3 min in | remediated |
| 11 | `PowerCyclingToRescue`, `GetServer` returns nil | remediated via the existing `getLiveServer` path |
| 12 | `PowerCyclingToRescue`, `ActionIDEnableRescueSystem > 0`, server `off` | waits for the action, then sets it to `actionDone`; `PowerOnServer` not called |

Also: `PowerOffServer` unit test in
[fake/hcloud_client_test.go](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/fake/hcloud_client_test.go) next to the
`ShutdownServer` tests ([:528-543](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/client/fake/hcloud_client_test.go#L528-L543)).

## 7. Docs

[docs/caph/04-developers/06-image-url-command.md](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/docs/caph/04-developers/06-image-url-command.md):

- Document `PowerCyclingToRescue` and the one-retry policy in the state description.
- Add a note to the durations table that it was measured before #2156 and needs regenerating with
  [hack/hcloud-image-url-command-states-markdown-from-logs.py](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/hack/hcloud-image-url-command-states-markdown-from-logs.py)
  against the current flow — and that `rescueBootGracePeriod` should be re-tuned from fresh numbers.

## 8. Order of work

1. API types + condition reasons in both versions → `make generate` (CRDs, deepcopy, conversions).
2. `PowerOffServer` in the interface, real client, fake client → `make generate-mocks`.
3. `handleBootStatePowerCyclingToRescue` + switch case.
4. `retryRescueBoot` + both triggers in `handleBootStateBootingToRescue`.
5. Tests.
6. Docs.
7. `make test-unit && make lint`.

## 9. Risks

| Risk | Mitigation |
|---|---|
| 90 s is derived from a stale measurement, not a regenerated table | Named constant; regenerate the durations table (§7) and re-tune. Soak-tested at 120 s too (§3, §11) - no evidence either value is wrong, since no boot in ~190 has come close to either number. A value that is too high only delays remediation, which is still ≤ the pre-retry 6 min. |
| Re-enable loop if `RescueEnabled` lags behind the finished action | The enable path is gated on the stored action ID, so at most one `EnableRescueSystem` per cycle; the 2 min state timeout is the backstop. |
| A poweroff action that fails silently | The server never reaches `off`, so the 2 min timeout remediates. If the condition message proves too vague in practice, add `GetAction` polling on `ActionIDPowerOffServer` — the field is already stored for it. |
| A second `enable_rescue` rotates the rescue root password | Irrelevant: CAPH authenticates with SSH keys, which are passed again on every call. |
| `RescueEnabled == true` might not reliably predict the *next* boot (§4.6, §11) | Not confirmed - one soak-test data point, reported to Hetzner, awaiting their diagnosis. If confirmed, the fix is to drop the `!server.RescueEnabled` gate in §5.3 and always call `EnableRescueSystem` on a power-cycle. |

## 10. Deliberately out of scope

- **Verifying `RescueEnabled` before the *first* power-on** in `handleBootStateEnablingRescue`
  ([server.go:718-724](https://github.com/syself/cluster-api-provider-hetzner/blob/tg/retry-rescue-boot-hcloud/pkg/services/hcloud/server/server.go#L718-L724)). PR #2207's evidence
  suggests the incident's root cause was `start_server` being issued 1 s after `enable_rescue`
  finished, while every healthy server in that project had 4-5 s. This plan **recovers** from that
  rather than preventing it. Adding the check costs one `GetServer` per machine provisioned and
  forces the `<= 1` assertion up to `<= 2`.
- Identifying *which* image booted. `rescue_enabled` cannot answer it (§4.1), and the SSH hostname
  check already answers the only question that matters.
- The 6-minute timeouts of the other boot states.

## 11. Real-world validation (soak test)

Ran 100 back-to-back scale-up/scale-down cycles (1→3→1 workers) against a live cluster, ~190
individual worker boots total, in two rounds:

- **Cycles 1-44**, on the build as originally shipped (90 s grace period, no diagnostic logging):
  zero occurrences of the retry path. Every boot succeeded on the first attempt within 15-51 s.
- **Cycles 45-100**, after the logging improvements (§5.7) and the grace-period bump to 120 s:
  **one real hit, at cycle 49.** Full trace, reconstructed entirely from logs thanks to §5.7:

  1. First `BootingToRescue` attempt: SSH connection actively refused, continuously, for the last
     ~90 s of the 120 s window - not intermittent, never resolved on its own.
  2. Grace period hit. Diagnostic snapshot: `status=running rescueEnabled=true`. Retried
     (`SSHNotReachable` trigger, attempt 1 of 2) → `PowerCyclingToRescue`.
  3. Power-cycle completed in 17 s (server was already `off` quickly; `RescueEnabled` was already
     `true` so it skipped straight to `PowerOnServer`, per §5.3) → back to `BootingToRescue`.
  4. Second attempt: SSH eventually answered, but with the hostname of the machine itself, not
     `rescue` - trigger B, `UnexpectedHostname`. The second boot landed on the throwaway image, not
     rescue, despite `RescueEnabled` having read `true` moments before the restart.
  5. Retry budget was already spent on step 2, so this remediated: `SetErrorAndRemediate`, server
     deleted, MachineSet replaced it. Correct behavior per §5.3/§10 - and the soak test's own
     polling handled the replacement transparently, no special casing needed.

**What this confirms:** the state machine, the shared retry budget across both triggers, and the
remediation fallback all worked exactly as designed, under a real failure rather than only in unit
tests.

**What this complicates:** §1's "often fixes whatever the server was stuck on" and §5.3's
assumption that `RescueEnabled == true` is sufficient reason to skip re-enabling before powering
on (see §4.6, §9). Filed a support ticket with Hetzner with the exact `hcloud` action IDs and
timestamps for this incident, asking (a) why SSH was refused continuously for ~2 minutes, and (b)
whether `rescue_enabled: true` reliably predicts the next boot, or can lag/race. Awaiting their
response - no code changes made based on this one data point alone, since it's not yet confirmed
whether this is something CAPH can act on versus a Hetzner-side flakiness this retry mechanism is
already correctly absorbing via remediation.

**No evidence the grace period itself was the problem:** the one failure didn't look like a slow
boot running out of time - it was stuck (continuously refused, not narrowing) and a fresh
power-cycle is what got it moving again, not extra waiting. See the note in §3.

**Decision after the soak test: reverted `rescueBootGracePeriod` to 90 s.** It was raised to 120 s
partway through this soak test as a precaution; the data argues it didn't help (above) and it has
a real, if small, cost (30 s longer before the fix that actually works kicks in, and the
worst-case-to-remediation bump from 5 to 6 min). Shipping 90 s, the originally-intended value.

**Round 3: 120 more cycles on the current build (90 s + §5.8's events), zero recurrences.**
220 cycles total across all rounds, one real hit - consistent with a rare (~0.5%) issue, not proof
either way on the open questions above. Also fixed a real bug found while reviewing this PR before
this round: `RescueRetrySucceeded` could fire more than once for the same recovery if
`StartImageURLCommand` failed transiently right after reaching rescue (the whole function reruns
from the top on the next reconcile). Now gated on the `ActionIDEnableRescueSystem == actionDone`
marker, consumed once reported, so it fires exactly once per actual recovery.





