### PR TITLE
🌱 Reduce custom provisioner first requeue from 20s to 10s (port #2210 to main)

### DIFF
--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -941,7 +941,7 @@ func (s *Service) handleBootStateBootingToRescue(ctx context.Context) (reconcile
 	// The next state (RunningImageCommand) polls via SSH, which costs no hcloud API calls, but
 	// the custom provisioner needs time to run, so wait a bit before the first attempt instead
 	// of retrying immediately.
-	return reconcile.Result{RequeueAfter: 20 * time.Second}, nil
+	return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
 // handleBootStateRunningImageCommand is for provisioning with imageURL and image-url-command.


### PR DESCRIPTION
## Summary

Port of #2210 (merged into `release-1.1`) to `main`.

Reduces the first requeue after transitioning to `RunningImageCommand` from 20s to 10s. The next state polls via SSH (no hcloud API cost), so a shorter initial wait speeds up provisioning without extra API load.
