### PR TITLE
🌱 Run unit tests on pull requests to release-1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,11 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
     branches:
+      # Keep in sync with the branches in pr-e2e.yaml: a PR that gets e2e-tested
+      # should get unit-tested, too.
       - main
+      - release-1.1
+      - release-1.1-base
       - "releases/**"
       - "v1.1.x"
     paths:


### PR DESCRIPTION
## Summary

`08a3fd3bd` added `release-1.1` (and `release-1.1-base`) to the branch list of `pr-e2e.yaml`, but `test.yml` was not updated. So a pull request against `release-1.1` runs the expensive e2e tests, lint and verify, but **not** the unit tests (`Test Code`). Noticed on #2219, where the unit tests had to be run locally.

This brings the branch list of `test.yml` in line with `pr-e2e.yaml`, so a PR that gets e2e-tested gets unit-tested too, and adds a comment to keep the two lists in sync.

`release-1.1-next` is in neither list and stays out of both.