### PR TITLE
🐛 Fix stale HetznerCluster.Status causing cp targets to be skipped on LB attach (port #2107 to main)

### DIFF
--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/annotations"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	"sigs.k8s.io/cluster-api/util/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,6 +59,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
@@ -862,6 +864,16 @@ func (r *HetznerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			handler.EnqueueRequestsFromMapFunc(r.clusterToHetznerCluster),
 			builder.WithPredicates(IgnoreInsignificantClusterStatusUpdates(log)),
 		).
+		Watches(
+			&infrav1.HetznerBareMetalMachine{},
+			handler.EnqueueRequestsFromMapFunc(r.baremetalMachineToHetznerCluster),
+			builder.WithPredicates(controlPlaneMachineToHetznerClusterPredicate()),
+		).
+		Watches(
+			&infrav1.HCloudMachine{},
+			handler.EnqueueRequestsFromMapFunc(r.hcloudMachineToHetznerCluster),
+			builder.WithPredicates(controlPlaneMachineToHetznerClusterPredicate()),
+		).
 		Complete(r)
 	if err != nil {
 		return fmt.Errorf("error creating controller: %w", err)
@@ -1015,5 +1027,81 @@ func IgnoreInsignificantHetznerClusterStatusUpdates(logger logr.Logger) predicat
 		CreateFunc:  func(_ event.CreateEvent) bool { return true },
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return true },
+	}
+}
+
+// bareMetalMachineToHetznerCluster maps an HetznerBareMetalMachine to the owning HetznerCluster.
+func (r *HetznerClusterReconciler) baremetalMachineToHetznerCluster(ctx context.Context, o client.Object) []reconcile.Request {
+	bm, ok := o.(*infrav1.HetznerBareMetalMachine)
+	if !ok {
+		return nil
+	}
+
+	clusterName := bm.Labels[clusterv1.ClusterNameLabel]
+	if clusterName == "" {
+		return nil
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: bm.Namespace, Name: clusterName}, cluster); err != nil {
+		return nil
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "HetznerCluster" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: bm.Namespace, Name: cluster.Spec.InfrastructureRef.Name},
+	}}
+}
+
+// hcloudMachineToHetznerCluster maps an HCloudMachine to the owning HetznerCluster.
+func (r *HetznerClusterReconciler) hcloudMachineToHetznerCluster(ctx context.Context, o client.Object) []reconcile.Request {
+	hm, ok := o.(*infrav1.HCloudMachine)
+	if !ok {
+		return nil
+	}
+
+	clusterName := hm.Labels[clusterv1.ClusterNameLabel]
+	if clusterName == "" {
+		return nil
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: hm.Namespace, Name: clusterName}, cluster); err != nil {
+		return nil
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "HetznerCluster" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Namespace: hm.Namespace, Name: cluster.Spec.InfrastructureRef.Name},
+	}}
+}
+
+// controlPlaneMachineToHetznerClusterPredicate returns a predicate that fires only when:
+//   - a machine is deleted (so the HetznerCluster can update its LB target status), or
+//   - ServerAvailableCondition transitions to True.
+func controlPlaneMachineToHetznerClusterPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldGetter, ok := e.ObjectOld.(v1beta1conditions.Getter)
+			if !ok {
+				return false
+			}
+			newGetter, ok := e.ObjectNew.(v1beta1conditions.Getter)
+			if !ok {
+				return false
+			}
+			wasTrue := v1beta1conditions.IsTrue(oldGetter, infrav1.ServerAvailableCondition)
+			isTrue := v1beta1conditions.IsTrue(newGetter, infrav1.ServerAvailableCondition)
+			return !wasTrue && isTrue
+		},
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -343,6 +343,60 @@ func TestIgnoreInsignificantHetznerClusterStatusUpdates(t *testing.T) {
 	}
 }
 
+// TestControlPlaneMachineToHetznerClusterPredicate verifies that the watch predicate for
+// control-plane infrastructure machines reconciles the HetznerCluster only when a machine's
+// ServerAvailableCondition transitions to True or when the machine is deleted, so the
+// HetznerCluster.Status load-balancer targets do not go stale.
+func TestControlPlaneMachineToHetznerClusterPredicate(t *testing.T) {
+	p := controlPlaneMachineToHetznerClusterPredicate()
+
+	machineWithServerAvailable := func(available bool) *infrav1.HCloudMachine {
+		m := &infrav1.HCloudMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "cp-1", Namespace: "default"},
+		}
+		if available {
+			v1beta1conditions.MarkTrue(m, infrav1.ServerAvailableCondition)
+		} else {
+			v1beta1conditions.MarkFalse(m, infrav1.ServerAvailableCondition,
+				"NotReady", clusterv1beta1.ConditionSeverityInfo, "not ready yet")
+		}
+		return m
+	}
+
+	t.Run("ServerAvailable false->true triggers reconcile", func(t *testing.T) {
+		e := event.UpdateEvent{ObjectOld: machineWithServerAvailable(false), ObjectNew: machineWithServerAvailable(true)}
+		if !p.Update(e) {
+			t.Error("expected ServerAvailable false->true to trigger reconcile")
+		}
+	})
+
+	t.Run("ServerAvailable staying true does not trigger reconcile", func(t *testing.T) {
+		e := event.UpdateEvent{ObjectOld: machineWithServerAvailable(true), ObjectNew: machineWithServerAvailable(true)}
+		if p.Update(e) {
+			t.Error("expected no reconcile when ServerAvailable stays true")
+		}
+	})
+
+	t.Run("ServerAvailable staying false does not trigger reconcile", func(t *testing.T) {
+		e := event.UpdateEvent{ObjectOld: machineWithServerAvailable(false), ObjectNew: machineWithServerAvailable(false)}
+		if p.Update(e) {
+			t.Error("expected no reconcile when ServerAvailable stays false")
+		}
+	})
+
+	t.Run("deletion triggers reconcile", func(t *testing.T) {
+		if !p.Delete(event.DeleteEvent{Object: machineWithServerAvailable(true)}) {
+			t.Error("expected machine deletion to trigger reconcile")
+		}
+	})
+
+	t.Run("creation does not trigger reconcile", func(t *testing.T) {
+		if p.Create(event.CreateEvent{Object: machineWithServerAvailable(true)}) {
+			t.Error("expected machine creation to not trigger reconcile")
+		}
+	})
+}
+
 // TestWorkloadClusterSecretNames verifies which workload-cluster secrets CAPH
 // reconciles for the configured management-cluster secret name.
 func TestWorkloadClusterSecretNames(t *testing.T) {

--- a/pkg/services/baremetal/baremetal/baremetal.go
+++ b/pkg/services/baremetal/baremetal/baremetal.go
@@ -630,13 +630,59 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, host *inf
 		return nil
 	}
 
-	// check whether IPs of host have been added as load balancer targets already
+	// check whether IPs of host have been added as load balancer targets already.
 	var foundIPv4 bool
 	var foundIPv6 bool
 
-	for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
-		if target.Type == infrav1.LoadBalancerTargetTypeIP {
-			switch target.IP {
+	if v1beta1conditions.IsTrue(s.scope.BareMetalMachine, infrav1.ServerAvailableCondition) {
+		// The status may be slightly outdated but that is acceptable as this check
+		// is only a safeguard against unexpected changes (e.g. a user manually removing a target).
+		// In the vast majority of reconciles there is nothing to do, so we skip the extra API call
+		// to fetch the live load-balancer targets.
+		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
+			if target.Type == infrav1.LoadBalancerTargetTypeIP {
+				switch target.IP {
+				case host.Spec.Status.IPv4:
+					foundIPv4 = true
+				case host.Spec.Status.IPv6:
+					foundIPv6 = true
+				}
+			}
+		}
+	} else {
+		// use the HCloud API.
+		clusterTagKey := s.scope.HetznerCluster.ClusterTagKey()
+		opts := hcloud.LoadBalancerListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: utils.LabelsToLabelSelector(map[string]string{
+					clusterTagKey: string(infrav1.ResourceLifecycleOwned),
+				}),
+			},
+		}
+
+		loadBalancers, err := s.scope.HCloudClient.ListLoadBalancers(ctx, opts)
+		if err != nil {
+			hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HetznerCluster, err, "ListLoadBalancers")
+			return fmt.Errorf("failed to list load balancers: %w", err)
+		}
+
+		if len(loadBalancers) != 1 {
+			return fmt.Errorf("found %v loadbalancers in HCloud", len(loadBalancers))
+		}
+
+		lb := loadBalancers[0]
+
+		// This should never be the case: the label selector is cluster-scoped,
+		// so the only LB it can return is the one we own.
+		if lb.ID != s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID {
+			return fmt.Errorf("mismatch between the owned loadbalancer ID (%d) and the one specified in HetznerCluster.Status.ControlPlaneLoadBalancer.ID (%d)", lb.ID, s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID)
+		}
+
+		for _, target := range lb.Targets {
+			if target.Type != hcloud.LoadBalancerTargetTypeIP || target.IP == nil {
+				continue
+			}
+			switch target.IP.IP {
 			case host.Spec.Status.IPv4:
 				foundIPv4 = true
 			case host.Spec.Status.IPv6:

--- a/pkg/services/baremetal/baremetal/baremetal_test.go
+++ b/pkg/services/baremetal/baremetal/baremetal_test.go
@@ -1136,6 +1136,14 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 			},
 		}
 
+		// ServerAvailableCondition is not set, so the live load balancer is read. It holds the
+		// other control-plane target but not this host, so the host still needs attaching.
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{ID: 123, Targets: []hcloud.LoadBalancerTarget{
+				{Type: hcloud.LoadBalancerTargetTypeIP, IP: &hcloud.LoadBalancerTargetIP{IP: "192.0.2.9"}},
+			}},
+		}, nil).Once()
+
 		service := newServiceForLoadBalancerAttachment(machine, bareMetalMachine, newControlPlaneCluster(), hetznerCluster, hcloudClient)
 
 		err := service.reconcileLoadBalancerAttachment(context.Background(), newHost("192.0.2.10"))
@@ -1167,6 +1175,11 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 				},
 			},
 		}
+
+		// ServerAvailableCondition is not set, so the live load balancer is read. It has no
+		// targets yet, so this first control-plane host gets attached.
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).
+			Return([]*hcloud.LoadBalancer{{ID: 123}}, nil).Once()
 
 		hcloudClient.On(
 			"AddIPTargetToLoadBalancer",
@@ -1364,6 +1377,32 @@ var _ = Describe("reconcileLoadBalancerAttachment", func() {
 		Expect(service.reconcileLoadBalancerAttachment(context.Background(), newHostWithIPs(hostIPv4, hostIPv6))).To(Succeed())
 		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
 	})
+
+	It("reads attached targets from the live HCloud load balancer when ServerAvailable is not yet true", func() {
+		hcloudClient := mocks.NewClient(GinkgoT())
+
+		// ServerAvailable is not set, so reconcileLoadBalancerAttachment fetches the live load
+		// balancer state instead of trusting the (possibly stale) cluster status. The live LB
+		// already has the IPv4 address as a target, so nothing is attached.
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).Return([]*hcloud.LoadBalancer{
+			{
+				ID: 123,
+				Targets: []hcloud.LoadBalancerTarget{
+					{Type: hcloud.LoadBalancerTargetTypeIP, IP: &hcloud.LoadBalancerTargetIP{IP: hostIPv4}},
+				},
+			},
+		}, nil).Once()
+
+		// The bare metal machine has no ServerAvailable condition yet, forcing the live lookup.
+		service := newServiceForLoadBalancerAttachment(
+			newHealthyMachine(), &infrav1.HetznerBareMetalMachine{}, newControlPlaneCluster(),
+			newClusterForAddressFamily(infrav1.LoadBalancerTargetAddressFamilyIPv4), hcloudClient,
+		)
+
+		Expect(service.reconcileLoadBalancerAttachment(context.Background(), newHost(hostIPv4))).To(Succeed())
+		Expect(hcloudClient.AssertExpectations(GinkgoT())).To(BeTrue())
+		Expect(hcloudClient.AssertNotCalled(GinkgoT(), "AddIPTargetToLoadBalancer", mock.Anything, mock.Anything, mock.Anything)).To(BeTrue())
+	})
 })
 
 var _ = Describe("Reconcile with control-plane load balancer attachment", func() {
@@ -1457,6 +1496,23 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 			WithObjects(host, bareMetalMachine, machine).
 			Build()
 
+		// Before ServerAvailableCondition is true, reconcileLoadBalancerAttachment reads the
+		// live load balancer instead of the cluster status. Mirror the status targets onto the
+		// live load balancer so both views agree. Worker nodes never reach this call, so it is
+		// optional.
+		liveTargets := make([]hcloud.LoadBalancerTarget, 0, len(lbTargets))
+		for _, t := range lbTargets {
+			if t.Type == infrav1.LoadBalancerTargetTypeIP {
+				liveTargets = append(liveTargets, hcloud.LoadBalancerTarget{
+					Type: hcloud.LoadBalancerTargetTypeIP,
+					IP:   &hcloud.LoadBalancerTargetIP{IP: t.IP},
+				})
+			}
+		}
+		hcloudClient := mocks.NewClient(GinkgoT())
+		hcloudClient.On("ListLoadBalancers", mock.Anything, mock.Anything).
+			Return([]*hcloud.LoadBalancer{{ID: 123, Targets: liveTargets}}, nil).Maybe()
+
 		service := &Service{
 			scope: &scope.BareMetalMachineScope{
 				Logger:           log,
@@ -1465,7 +1521,7 @@ var _ = Describe("Reconcile with control-plane load balancer attachment", func()
 				Machine:          machine,
 				BareMetalMachine: bareMetalMachine,
 				HetznerCluster:   hetznerCluster,
-				HCloudClient:     mocks.NewClient(GinkgoT()),
+				HCloudClient:     hcloudClient,
 			},
 		}
 

--- a/pkg/services/hcloud/server/server.go
+++ b/pkg/services/hcloud/server/server.go
@@ -1533,6 +1533,53 @@ func (s *Service) reconcileLoadBalancerAttachment(ctx context.Context, server *h
 		return reconcile.Result{}, nil
 	}
 
+	if v1beta1conditions.IsTrue(hm, infrav1.ServerAvailableCondition) {
+		// The status may be slightly outdated but that is acceptable as this check
+		// is only a safeguard against unexpected changes (e.g. a user manually removing a target).
+		// In the vast majority of reconciles there is nothing to do, so we skip the extra API call
+		// to fetch the live load-balancer targets.
+		for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
+			if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {
+				return reconcile.Result{}, nil
+			}
+		}
+	} else {
+		clusterTagKey := s.scope.HetznerCluster.ClusterTagKey()
+		opts := hcloud.LoadBalancerListOpts{
+			ListOpts: hcloud.ListOpts{
+				LabelSelector: utils.LabelsToLabelSelector(map[string]string{
+					clusterTagKey: string(infrav1.ResourceLifecycleOwned),
+				}),
+			},
+		}
+
+		loadBalancers, err := s.scope.HCloudClient.ListLoadBalancers(ctx, opts)
+		if err != nil {
+			hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HetznerCluster, err, "ListLoadBalancers")
+			return reconcile.Result{}, fmt.Errorf("failed to list load balancers: %w", err)
+		}
+
+		if len(loadBalancers) != 1 {
+			return reconcile.Result{}, fmt.Errorf("found %v loadbalancers in HCloud", len(loadBalancers))
+		}
+
+		lb := loadBalancers[0]
+
+		// This should never be the case: the label selector is cluster-scoped,
+		// so the only LB it can return is the one we own.
+		if lb.ID != s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID {
+			return reconcile.Result{}, fmt.Errorf("mismatch between the owned loadbalancer ID (%d) and the one specified in HetznerCluster.Status.ControlPlaneLoadBalancer.ID (%d)", lb.ID, s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ID)
+		}
+
+		for _, target := range lb.Targets {
+			if target.Type == hcloud.LoadBalancerTargetTypeServer &&
+				target.Server != nil && target.Server.Server != nil &&
+				target.Server.Server.ID == server.ID {
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
 	// if already attached do nothing
 	for _, target := range s.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.Target {
 		if target.Type == infrav1.LoadBalancerTargetTypeServer && target.ServerID == server.ID {

--- a/pkg/services/hcloud/server/server_test.go
+++ b/pkg/services/hcloud/server/server_test.go
@@ -2397,6 +2397,13 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 		// handleOperatingSystemRunning, that condition would be overwritten to True.
 		// Ready must still flip to true so CAPI can propagate ProviderID and
 		// downstream controllers can observe the apiserver pod health.
+
+		// ServerAvailableCondition is not True yet, so reconcileLoadBalancerAttachment fetches
+		// live LB state. Return the owned load balancer with no target for this server, so the
+		// code falls through to the apiserver health gate.
+		service.scope.HCloudClient.(*mocks.Client).On("ListLoadBalancers", mock.Anything, mock.Anything).
+			Return([]*hcloud.LoadBalancer{{ID: 1}}, nil)
+
 		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
 			ID: 1,
 			Target: []infrav1.LoadBalancerTarget{
@@ -2417,6 +2424,27 @@ var _ = Describe("handleOperatingSystemRunning", func() {
 
 	It("sets Ready and ServerAvailableCondition when reconcileLoadBalancerAttachment returns an empty Result", func() {
 		// No load balancer → reconcileLoadBalancerAttachment returns an empty Result.
+		res, err := service.handleOperatingSystemRunning(context.Background())
+		Expect(err).To(Succeed())
+		Expect(res).To(Equal(reconcile.Result{}))
+
+		Expect(hcloudMachine.Status.Ready).To(BeTrue())
+		Expect(v1beta1conditions.IsTrue(hcloudMachine, infrav1.ServerAvailableCondition)).To(BeTrue())
+	})
+
+	It("does not call ListLoadBalancers when ServerAvailableCondition is already True", func() {
+		// ServerAvailableCondition is already True, so reconcileLoadBalancerAttachment trusts the
+		// HetznerCluster.Status target cache instead of fetching live LB state. The strict client
+		// mock has no ListLoadBalancers expectation, so it fails the test if that call is made.
+		v1beta1conditions.MarkTrue(hcloudMachine, infrav1.ServerAvailableCondition)
+
+		service.scope.HetznerCluster.Status.ControlPlaneLoadBalancer = &infrav1.LoadBalancerStatus{
+			ID: 1,
+			Target: []infrav1.LoadBalancerTarget{
+				{Type: infrav1.LoadBalancerTargetTypeServer, ServerID: server.ID},
+			},
+		}
+
 		res, err := service.handleOperatingSystemRunning(context.Background())
 		Expect(err).To(Succeed())
 		Expect(res).To(Equal(reconcile.Result{}))


### PR DESCRIPTION
**What this PR does / why we need it**:
Forward-ports PR #2107 from release-1.1. reconcileLoadBalancerAttachment decided "already a load-balancer target" from HetznerCluster.Status, which only the HetznerCluster controller updates. During a rollout a target can be removed and re-added with the same ID while the status is stale, so the attach was skipped and the control-plane node was never added back.

Until a machine's ServerAvailableCondition is True, the HCloud and bare-metal services now fetch the live load balancer from the Hetzner API instead of trusting the status, then fall back to the status cache once confirmed. The HetznerCluster controller also watches control-plane HCloudMachines and HetznerBareMetalMachines and reconciles when a machine's ServerAvailableCondition transitions to True or the machine is deleted, keeping the status target list fresh.

Adapted to main: the controller is on v1beta2 (mapper funcs use the v1beta2 Cluster contract); the two HandleRateLimitExceeded call sites use the V1Beta1 variant; the bare-metal live-fetch branch composes with the address-family logic from PR #2206.

**Which issue(s) this PR fixes:**
None (forward-port of PR #2107).

**Special notes for your reviewer**:

The watch predicate and the load-balancer gate read the v1beta1 ServerAvailable condition for now, because the HCloudMachine and HetznerBareMetalMachine machine scopes are still infrav1 (v1beta1) resources, so their v1beta1 conditions are the native ones to read. This will move to the v1beta2 ServerAvailable condition when those scopes are migrated to v1beta2.