### PR TITLE
🐛 Wait for local cache before remediation reconcile to avoid a second reboot

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -271,7 +271,8 @@ var _ = BeforeSuite(func() {
 	Expect(hcloudRemediationReconciler.SetupWithManager(ctx, testEnv, controller.Options{})).To(Succeed())
 
 	hetznerBareMetalRemediationReconciler := &HetznerBareMetalRemediationReconciler{
-		Client: testEnv.GetClient(),
+		Client:    testEnv.GetClient(),
+		APIReader: testEnv.GetAPIReader(),
 	}
 	Expect(hetznerBareMetalRemediationReconciler.SetupWithManager(ctx, testEnv, controller.Options{})).To(Succeed())
 

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -42,6 +44,7 @@ import (
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	hcloudremediation "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/remediation"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
 
 // HCloudRemediationReconciler reconciles a HCloudRemediation object.
@@ -86,6 +89,62 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		}
 		return reconcile.Result{}, err
 	}
+
+	// ----------------------------------------------------------------
+	// Start: avoid conflict errors. Wait until local cache is up-to-date
+	// Won't be needed once this was implemented:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/3320
+	initialHCloudRemediation := hcloudRemediation.DeepCopy()
+	defer func() {
+		// We can potentially optimize this further by ensuring that the cache is up to date only in
+		// the cases where an outdated cache would lead to problems. Currently, we ensure that the
+		// cache is up to date in all cases, i.e. for all possible changes to the
+		// HCloudRemediation object.
+		if cmp.Equal(initialHCloudRemediation, hcloudRemediation) {
+			// Nothing has changed. No need to wait.
+			return
+		}
+
+		// The object changed. Wait until the new version is in the local cache
+
+		// Get the latest version from the apiserver.
+		apiserverHCloudRemediation := &infrav1.HCloudRemediation{}
+
+		// Use uncached APIReader
+		err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(hcloudRemediation), apiserverHCloudRemediation)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// resource was deleted. No need to reconcile again.
+				reterr = nil
+				res = reconcile.Result{}
+				return
+			}
+			reterr = errors.Join(reterr,
+				fmt.Errorf("failed get HCloudRemediation via uncached APIReader: %w", err))
+			return
+		}
+
+		apiserverRV := apiserverHCloudRemediation.ResourceVersion
+
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			// new resource, read from local cache
+			latestFromLocalCache := &infrav1.HCloudRemediation{}
+			getErr := r.Get(ctx, client.ObjectKeyFromObject(apiserverHCloudRemediation), latestFromLocalCache)
+			if apierrors.IsNotFound(getErr) {
+				// the object was deleted. All is fine.
+				return true, nil
+			}
+			if getErr != nil {
+				return false, getErr
+			}
+			return utils.IsLocalCacheUpToDate(latestFromLocalCache.ResourceVersion, apiserverRV), nil
+		})
+		if err != nil {
+			log.Error(err, "cache sync failed")
+		}
+	}()
+	// End: avoid conflict errors. Wait until local cache is up-to-date
+	// ----------------------------------------------------------------
 
 	log = log.WithValues("HCloudRemediation", klog.KObj(hcloudRemediation))
 

--- a/controllers/hetznerbaremetalremediation_controller.go
+++ b/controllers/hetznerbaremetalremediation_controller.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -35,11 +38,13 @@ import (
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/services/baremetal/remediation"
+	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
 )
 
 // HetznerBareMetalRemediationReconciler reconciles a HetznerBareMetalRemediation object.
 type HetznerBareMetalRemediationReconciler struct {
 	client.Client
+	APIReader        client.Reader
 	WatchFilterValue string
 
 	// Reconcile only this namespace. Only needed for testing
@@ -77,6 +82,62 @@ func (r *HetznerBareMetalRemediationReconciler) Reconcile(ctx context.Context, r
 		}
 		return reconcile.Result{}, err
 	}
+
+	// ----------------------------------------------------------------
+	// Start: avoid conflict errors. Wait until local cache is up-to-date
+	// Won't be needed once this was implemented:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/3320
+	initialBareMetalRemediation := bareMetalRemediation.DeepCopy()
+	defer func() {
+		// We can potentially optimize this further by ensuring that the cache is up to date only in
+		// the cases where an outdated cache would lead to problems. Currently, we ensure that the
+		// cache is up to date in all cases, i.e. for all possible changes to the
+		// HetznerBareMetalRemediation object.
+		if cmp.Equal(initialBareMetalRemediation, bareMetalRemediation) {
+			// Nothing has changed. No need to wait.
+			return
+		}
+
+		// The object changed. Wait until the new version is in the local cache
+
+		// Get the latest version from the apiserver.
+		apiserverBareMetalRemediation := &infrav1.HetznerBareMetalRemediation{}
+
+		// Use uncached APIReader
+		err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(bareMetalRemediation), apiserverBareMetalRemediation)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// resource was deleted. No need to reconcile again.
+				reterr = nil
+				res = reconcile.Result{}
+				return
+			}
+			reterr = errors.Join(reterr,
+				fmt.Errorf("failed get HetznerBareMetalRemediation via uncached APIReader: %w", err))
+			return
+		}
+
+		apiserverRV := apiserverBareMetalRemediation.ResourceVersion
+
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			// new resource, read from local cache
+			latestFromLocalCache := &infrav1.HetznerBareMetalRemediation{}
+			getErr := r.Get(ctx, client.ObjectKeyFromObject(apiserverBareMetalRemediation), latestFromLocalCache)
+			if apierrors.IsNotFound(getErr) {
+				// the object was deleted. All is fine.
+				return true, nil
+			}
+			if getErr != nil {
+				return false, getErr
+			}
+			return utils.IsLocalCacheUpToDate(latestFromLocalCache.ResourceVersion, apiserverRV), nil
+		})
+		if err != nil {
+			log.Error(err, "cache sync failed")
+		}
+	}()
+	// End: avoid conflict errors. Wait until local cache is up-to-date
+	// ----------------------------------------------------------------
 
 	log = log.WithValues("HetznerBareMetalRemediation", klog.KObj(bareMetalRemediation))
 

--- a/main.go
+++ b/main.go
@@ -267,6 +267,7 @@ func main() {
 
 	if err = (&controllers.HetznerBareMetalRemediationReconciler{
 		Client:           mgr.GetClient(),
+		APIReader:        mgr.GetAPIReader(),
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HetznerBareMetalRemediation")


### PR DESCRIPTION
**What this PR does / why we need it**:

Wait for local cache before remediation reconcile

**Which issue(s) this PR fixes:**

Fixes #2240

**Special notes for your reviewer**:

We followed the existing pattern from `hetznerbaremetalhost_controller.go`:

https://github.com/syself/cluster-api-provider-hetzner/blob/1c4fe745f3bf5b22b94d4dddd6c4b3b98f6770fc/controllers/hetznerbaremetalhost_controller.go#L130-L188


