### PR TITLE
✨ v1beta2 migration: switch the HCloudRemediation controller to v1beta2

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -549,16 +549,6 @@ const (
 	HetznerClusterDeletingV1Beta2Reason = clusterv1beta1.DeletingV1Beta2Reason
 )
 
-// HCloudRemediation v1beta2 conditions and reasons.
-const (
-	// HCloudRemediationSkippedV1Beta2Condition reports that remediation was skipped because
-	// the HCloudMachine has a state that makes remediation unnecessary or impossible.
-	HCloudRemediationSkippedV1Beta2Condition = "RemediationSkipped"
-	// HCloudRemediationIrrecoverableServerCreateFailureV1Beta2Reason indicates remediation was skipped because
-	// the HCloudMachine failed to create with an irrecoverable error (e.g. invalid_input, resource_unavailable).
-	HCloudRemediationIrrecoverableServerCreateFailureV1Beta2Reason = "IrrecoverableServerCreateFailure"
-)
-
 // HetznerBareMetalMachine v1beta2 condition types.
 const (
 	// HetznerBareMetalMachineHostAssociatedV1Beta2Condition is true when the host is associated.

--- a/api/v1beta1/hcloudremediation_types.go
+++ b/api/v1beta1/hcloudremediation_types.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
-	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 )
 
 // HCloudRemediationSpec defines the desired state of HCloudRemediation.
@@ -125,64 +124,6 @@ type HCloudRemediationList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []HCloudRemediation `json:"items"`
-}
-
-// HCloudRemediationV1Beta2SummaryOpts returns the v1beta2 summary options for HCloudRemediation.
-// It is the single source of truth for which conditions contribute to the Ready summary,
-// used both by HCloudRemediationScope.Close() and by early-exit error paths that bypass the scope.
-//
-// The order of conditions in ForConditionTypes defines the priority for the Ready summary:
-// when multiple conditions are unhealthy, the summary lists all of them in priority order
-// (highest-priority first). The ordering reflects operational importance:
-//  1. HCloudTokenAvailable      - invalid credentials block everything.
-//  2. HCloudRateLimitExceeded   - rate-limit issues (negative polarity).
-//  3. RemediationSkipped        - remediation was skipped due to an irrecoverable
-//     machine state; surfaced for visibility (negative polarity).
-func HCloudRemediationV1Beta2SummaryOpts() []v1beta2conditions.SummaryOption {
-	return []v1beta2conditions.SummaryOption{
-		// ForConditionTypes lists every condition that contributes to Ready, in
-		// priority order. When multiple conditions are unhealthy the summary
-		// surfaces them in this order, so the most important issue is listed first.
-		v1beta2conditions.ForConditionTypes{
-			HCloudTokenAvailableV1Beta2Condition,
-			HCloudRateLimitExceededV1Beta2Condition,
-			HCloudRemediationSkippedV1Beta2Condition,
-		},
-		// IgnoreTypesIfMissing tells the summary not to treat the absence of a
-		// listed condition as Unknown. Some reconcile paths exit before every
-		// condition has been set (for example, before the token is checked or
-		// before remediation has been evaluated), and we don't want those early
-		// exits to flip Ready to Unknown.
-		v1beta2conditions.IgnoreTypesIfMissing{
-			HCloudTokenAvailableV1Beta2Condition,
-			HCloudRateLimitExceededV1Beta2Condition,
-			HCloudRemediationSkippedV1Beta2Condition,
-		},
-		// CustomMergeStrategy is used only to override the merge reasons, so
-		// the Ready summary uses CAPI's standard Ready reasons (Ready /
-		// NotReady / ReadyUnknown) instead of the generic merge defaults
-		// (IssuesReported / UnknownReported / InfoReported).
-		//
-		// Negative polarity is passed directly into GetDefaultMergePriorityFunc
-		// here. When a CustomMergeStrategy is provided, NewSummaryCondition
-		// skips the path that wires up the NegativePolarityConditionTypes
-		// SummaryOption into the default strategy, so the negative-polarity
-		// types must be specified explicitly inside the strategy.
-		v1beta2conditions.CustomMergeStrategy{
-			MergeStrategy: v1beta2conditions.DefaultMergeStrategy(
-				v1beta2conditions.GetPriorityFunc(v1beta2conditions.GetDefaultMergePriorityFunc(
-					// conditions with negative polarity
-					HCloudRateLimitExceededV1Beta2Condition,
-					HCloudRemediationSkippedV1Beta2Condition,
-				)),
-				v1beta2conditions.ComputeReasonFunc(v1beta2conditions.GetDefaultComputeMergeReasonFunc(
-					clusterv1beta1.NotReadyV1Beta2Reason,
-					clusterv1beta1.ReadyUnknownV1Beta2Reason,
-					clusterv1beta1.ReadyV1Beta2Reason,
-				)),
-			),
-		},
-	}
 }
 
 func init() {

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -519,6 +519,17 @@ const (
 	HCloudMachineDeletingReason = clusterv1.DeletingReason
 )
 
+// HCloudRemediation's v1beta2 conditions.
+
+const (
+	// HCloudRemediationSkippedCondition reports that remediation was skipped because
+	// the HCloudMachine has a state that makes remediation unnecessary or impossible.
+	HCloudRemediationSkippedCondition = "RemediationSkipped"
+	// HCloudRemediationIrrecoverableServerCreateFailureReason indicates remediation was skipped because
+	// the HCloudMachine failed to create with an irrecoverable error (e.g. invalid_input, resource_unavailable).
+	HCloudRemediationIrrecoverableServerCreateFailureReason = "IrrecoverableServerCreateFailure"
+)
+
 // HetznerBareMetalHost's v1beta2 conditions.
 
 const (

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -528,6 +528,11 @@ const (
 	// HCloudRemediationIrrecoverableServerCreateFailureReason indicates remediation was skipped because
 	// the HCloudMachine failed to create with an irrecoverable error (e.g. invalid_input, resource_unavailable).
 	HCloudRemediationIrrecoverableServerCreateFailureReason = "IrrecoverableServerCreateFailure"
+	// RemediationCooldownTriggeredReason indicates that the machine became unhealthy
+	// again within the cooldown window following a prior remediation. Rather than
+	// rebooting again, the controller sets MachineOwnerRemediated to False so CAPI
+	// escalates by deleting the machine.
+	RemediationCooldownTriggeredReason = "RemediationCooldownTriggered"
 )
 
 // HetznerBareMetalHost's v1beta2 conditions.

--- a/api/v1beta2/hcloudremediation_types.go
+++ b/api/v1beta2/hcloudremediation_types.go
@@ -19,6 +19,7 @@ package v1beta2
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 )
 
 // HCloudRemediationSpec defines the desired state of HCloudRemediation.
@@ -127,6 +128,58 @@ func (r *HCloudRemediation) SetV1Beta1Conditions(conditions clusterv1.Conditions
 		r.Status.Deprecated.V1Beta1 = &HCloudRemediationV1Beta1DeprecatedStatus{}
 	}
 	r.Status.Deprecated.V1Beta1.Conditions = conditions
+}
+
+// HCloudRemediationSummaryOpts returns the summary options for the HCloudRemediation Ready condition.
+// It is the single source of truth for which conditions contribute to the Ready summary, used both
+// by HCloudRemediationScope.Close() and by early-exit error paths that bypass the scope.
+//
+// The order of conditions in ForConditionTypes defines the priority for the Ready summary:
+// when multiple conditions are unhealthy, the summary lists all of them in priority order
+// (highest-priority first). The ordering reflects operational importance:
+//  1. HCloudTokenAvailable    - invalid credentials block everything.
+//  2. HCloudRateLimitExceeded - rate-limit issues (negative polarity).
+//  3. RemediationSkipped      - remediation was skipped due to an irrecoverable
+//     machine state; surfaced for visibility (negative polarity).
+func HCloudRemediationSummaryOpts() []conditions.SummaryOption {
+	return []conditions.SummaryOption{
+		// ForConditionTypes lists every condition that contributes to Ready, in priority order.
+		conditions.ForConditionTypes{
+			HCloudTokenAvailableCondition,
+			HCloudRateLimitExceededCondition,
+			HCloudRemediationSkippedCondition,
+		},
+		// IgnoreTypesIfMissing tells the summary not to treat the absence of a listed condition as
+		// Unknown. Some reconcile paths exit before every condition has been set, and we don't want
+		// those early exits to flip Ready to Unknown.
+		conditions.IgnoreTypesIfMissing{
+			HCloudTokenAvailableCondition,
+			HCloudRateLimitExceededCondition,
+			HCloudRemediationSkippedCondition,
+		},
+		// CustomMergeStrategy is used only to override the merge reasons, so the Ready summary uses
+		// CAPI's standard Ready reasons (Ready / NotReady / ReadyUnknown) instead of the generic
+		// merge defaults (IssuesReported / UnknownReported / InfoReported).
+		//
+		// Negative polarity is passed directly into GetDefaultMergePriorityFunc here. When a
+		// CustomMergeStrategy is provided, NewSummaryCondition skips the path that wires up the
+		// NegativePolarityConditionTypes option into the default strategy, so the negative-polarity
+		// types must be specified explicitly inside the strategy.
+		conditions.CustomMergeStrategy{
+			MergeStrategy: conditions.DefaultMergeStrategy(
+				conditions.GetPriorityFunc(conditions.GetDefaultMergePriorityFunc(
+					// conditions with negative polarity
+					HCloudRateLimitExceededCondition,
+					HCloudRemediationSkippedCondition,
+				)),
+				conditions.ComputeReasonFunc(conditions.GetDefaultComputeMergeReasonFunc(
+					clusterv1.NotReadyReason,
+					clusterv1.ReadyUnknownReason,
+					clusterv1.ReadyReason,
+				)),
+			),
+		},
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -79,7 +79,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		return ctrl.Result{}, err
 	}
 	if skipReconciliation {
-		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav1.SkipNamespaceAnnotation)
+		log.Info("Skipping reconciliation for namespace", "namespace", req.Namespace, "annotation", infrav2.SkipNamespaceAnnotation)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/hcloudremediation_controller.go
+++ b/controllers/hcloudremediation_controller.go
@@ -27,12 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
-	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
-	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
-	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1" // deprecated conditions on the v1beta2 HCloudRemediation
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"           // conditions on the still-v1beta1 HCloudMachine
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
@@ -81,7 +83,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		return ctrl.Result{}, nil
 	}
 
-	hcloudRemediation := &infrav1.HCloudRemediation{}
+	hcloudRemediation := &infrav2.HCloudRemediation{}
 	err = r.Get(ctx, req.NamespacedName, hcloudRemediation)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -108,7 +110,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		// The object changed. Wait until the new version is in the local cache
 
 		// Get the latest version from the apiserver.
-		apiserverHCloudRemediation := &infrav1.HCloudRemediation{}
+		apiserverHCloudRemediation := &infrav2.HCloudRemediation{}
 
 		// Use uncached APIReader
 		err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(hcloudRemediation), apiserverHCloudRemediation)
@@ -128,7 +130,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 
 		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (done bool, err error) {
 			// new resource, read from local cache
-			latestFromLocalCache := &infrav1.HCloudRemediation{}
+			latestFromLocalCache := &infrav2.HCloudRemediation{}
 			getErr := r.Get(ctx, client.ObjectKeyFromObject(apiserverHCloudRemediation), latestFromLocalCache)
 			if apierrors.IsNotFound(getErr) {
 				// the object was deleted. All is fine.
@@ -187,7 +189,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 			"reason", irrecoverableMsg,
 		)
 
-		patchHelper, err := v1beta1patch.NewHelper(hcloudRemediation, r.Client)
+		patchHelper, err := patch.NewHelper(hcloudRemediation, r.Client)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to create patch helper for HCloudRemediation: %w", err)
 		}
@@ -195,37 +197,36 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 			"Remediation skipped: HCloudMachine has an irrecoverable server creation error. Delete the Machine to trigger a new creation attempt. Error: %s",
 			irrecoverableMsg,
 		)
-		v1beta1conditions.MarkFalse(
+		deprecatedv1beta1conditions.MarkFalse(
 			hcloudRemediation,
-			infrav1.RemediationSkippedCondition,
-			infrav1.IrrecoverableServerCreateFailureReason,
-			clusterv1beta1.ConditionSeverityWarning,
+			infrav2.RemediationSkippedV1Beta1Condition,
+			infrav2.IrrecoverableServerCreateFailureV1Beta1Reason,
+			clusterv1.ConditionSeverityWarning,
 			"%s",
 			skippedMsg,
 		)
-		// Mirror the v1beta1 condition with a v1beta2 condition (negative polarity:
-		// status=True means remediation IS skipped).
-		v1beta2conditions.Set(hcloudRemediation, metav1.Condition{
-			Type:    infrav1.HCloudRemediationSkippedV1Beta2Condition,
+		// negative polarity: status=True means remediation IS skipped.
+		conditions.Set(hcloudRemediation, metav1.Condition{
+			Type:    infrav2.HCloudRemediationSkippedCondition,
 			Status:  metav1.ConditionTrue,
-			Reason:  infrav1.HCloudRemediationIrrecoverableServerCreateFailureV1Beta2Reason,
+			Reason:  infrav2.HCloudRemediationIrrecoverableServerCreateFailureReason,
 			Message: skippedMsg,
 		})
 
-		// This is an early-exit path that bypasses the scope, so compute the v1beta2
-		// Ready summary here using the shared SummaryOpts.
-		if readyCondition, err := v1beta2conditions.NewSummaryCondition(
+		// This is an early-exit path that bypasses the scope, so compute the Ready summary
+		// here using the shared SummaryOpts.
+		if readyCondition, err := conditions.NewSummaryCondition(
 			hcloudRemediation,
-			clusterv1beta1.ReadyV1Beta2Condition,
-			infrav1.HCloudRemediationV1Beta2SummaryOpts()...,
+			clusterv1.ReadyCondition,
+			infrav2.HCloudRemediationSummaryOpts()...,
 		); err == nil {
-			v1beta2conditions.Set(hcloudRemediation, *readyCondition)
+			conditions.Set(hcloudRemediation, *readyCondition)
 		} else {
-			log.Error(err, "Failed to set v1beta2 Ready condition")
-			v1beta2conditions.Set(hcloudRemediation, metav1.Condition{
-				Type:   clusterv1beta1.ReadyV1Beta2Condition,
+			log.Error(err, "Failed to set Ready condition")
+			conditions.Set(hcloudRemediation, metav1.Condition{
+				Type:   clusterv1.ReadyCondition,
 				Status: metav1.ConditionUnknown,
-				Reason: infrav1.InternalErrorV1Beta2Reason,
+				Reason: clusterv1.InternalErrorReason,
 			})
 		}
 
@@ -250,7 +251,7 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 
 	log = log.WithValues("Cluster", klog.KObj(cluster))
 
-	hetznerCluster := &infrav1.HetznerCluster{}
+	hetznerCluster := &infrav2.HetznerCluster{}
 
 	hetznerClusterName := client.ObjectKey{
 		Namespace: hcloudMachine.Namespace,
@@ -265,9 +266,9 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 
 	// Create the scope.
 	secretManager := secretutil.NewSecretManager(log, r, r.APIReader)
-	hcloudToken, _, err := getAndValidateHCloudTokenV1Beta1(ctx, req.Namespace, hetznerCluster, secretManager)
+	hcloudToken, _, err := getAndValidateHCloudToken(ctx, req.Namespace, hetznerCluster, secretManager)
 	if err != nil {
-		return hcloudTokenErrorResultV1Beta1(ctx, err, hcloudRemediation, r, infrav1.HCloudRemediationV1Beta2SummaryOpts())
+		return hcloudTokenErrorResult(ctx, err, hcloudRemediation, r, infrav2.HCloudRemediationSummaryOpts())
 	}
 
 	hcc := r.HCloudClientFactory.NewClient(hcloudToken)
@@ -285,32 +286,30 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 		return reconcile.Result{}, fmt.Errorf("failed to create scope: %w", err)
 	}
 
-	v1beta1conditions.MarkTrue(hcloudRemediation, infrav1.HCloudTokenAvailableCondition)
-
-	// Always close the scope when exiting this function so we can persist any HCloudRemediation changes.
-	// Note: the deferred block below is responsible for setting the v1beta2 HCloudTokenAvailable condition
-	// on both success and ErrUnauthorized paths, so no pre-defer Set is needed here.
+	// Always close the scope when exiting this function so we can persist any HCloudRemediation
+	// changes. The deferred block also sets the HCloudTokenAvailable condition and its deprecated
+	// v1beta1 counterpart, based on whether the reconcile hit an unauthorized error.
 	defer func() {
 		if reterr != nil && errors.Is(reterr, hcloudclient.ErrUnauthorized) {
-			v1beta1conditions.MarkFalse(hcloudRemediation, infrav1.HCloudTokenAvailableCondition, infrav1.HCloudCredentialsInvalidReason, clusterv1beta1.ConditionSeverityError, "wrong hcloud token")
-			v1beta2conditions.Set(hcloudRemediation, metav1.Condition{
-				Type:    infrav1.HCloudTokenAvailableV1Beta2Condition,
+			deprecatedv1beta1conditions.MarkFalse(hcloudRemediation, infrav2.HCloudTokenAvailableV1Beta1Condition, infrav2.HCloudCredentialsInvalidV1Beta1Reason, clusterv1.ConditionSeverityError, "wrong hcloud token")
+			conditions.Set(hcloudRemediation, metav1.Condition{
+				Type:    infrav2.HCloudTokenAvailableCondition,
 				Status:  metav1.ConditionFalse,
-				Reason:  infrav1.HCloudTokenInvalidV1Beta2Reason,
+				Reason:  infrav2.HCloudTokenInvalidReason,
 				Message: "wrong hcloud token",
 			})
 		} else {
-			v1beta1conditions.MarkTrue(hcloudRemediation, infrav1.HCloudTokenAvailableCondition)
-			v1beta2conditions.Set(hcloudRemediation, metav1.Condition{
-				Type:   infrav1.HCloudTokenAvailableV1Beta2Condition,
+			deprecatedv1beta1conditions.MarkTrue(hcloudRemediation, infrav2.HCloudTokenAvailableV1Beta1Condition)
+			conditions.Set(hcloudRemediation, metav1.Condition{
+				Type:   infrav2.HCloudTokenAvailableCondition,
 				Status: metav1.ConditionTrue,
-				Reason: infrav1.HCloudTokenAvailableV1Beta2Reason,
+				Reason: infrav2.HCloudTokenAvailableReason,
 			})
 		}
 
 		// Always attempt to Patch the Remediation object and status after each reconciliation.
 		// Patch ObservedGeneration only if the reconciliation completed successfully
-		patchOpts := []v1beta1patch.Option{v1beta1patch.WithStatusObservedGeneration{}}
+		patchOpts := []patch.Option{patch.WithStatusObservedGeneration{}}
 
 		if err := remediationScope.Close(ctx, patchOpts...); err != nil {
 			res = reconcile.Result{}
@@ -319,12 +318,9 @@ func (r *HCloudRemediationReconciler) Reconcile(ctx context.Context, req reconci
 	}()
 
 	// Check whether rate limit has been reached and if so, then wait.
-	if wait := reconcileRateLimitV1Beta1(hcloudRemediation, r.RateLimitWaitTime); wait {
+	if wait := reconcileRateLimit(hcloudRemediation, r.RateLimitWaitTime); wait {
 		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-
-	// If we passed the rate limit check, delete any existing rate limit condition.
-	v1beta2conditions.Delete(hcloudRemediation, infrav1.HCloudRateLimitExceededV1Beta2Condition)
 
 	if !hcloudRemediation.DeletionTimestamp.IsZero() {
 		// Nothing to do
@@ -350,7 +346,7 @@ func (r *HCloudRemediationReconciler) reconcileNormal(ctx context.Context, remed
 // SetupWithManager sets up the controller with the Manager.
 func (r *HCloudRemediationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&infrav1.HCloudRemediation{}).
+		For(&infrav2.HCloudRemediation{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -245,6 +245,9 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				if !isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
 					return fmt.Errorf("MachineOwnerRemediatedCondition not set")
 				}
+				if !isPresentAndFalseWithReason(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.MachineOwnerRemediatedWaitingForRemediationReason) {
+					return fmt.Errorf("native MachineOwnerRemediatedCondition not set")
+				}
 				return nil
 			}, timeout).Should(Succeed())
 		})
@@ -333,7 +336,8 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 				testEnv.GetLogger().Info("status of hcloudRemediation", "status", hcloudRemediation.Status.Phase)
 				return hcloudRemediation.Status.Phase == infrav2.PhaseDeleting &&
-					isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason)
+					isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) &&
+					isPresentAndFalseWithReason(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.MachineOwnerRemediatedWaitingForRemediationReason)
 			}, timeout).Should(BeTrue())
 		})
 		It("does no reboot and deletes the machine when retryLimit is 0", func() {
@@ -371,6 +375,9 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				}
 				if !isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
 					return fmt.Errorf("MachineOwnerRemediatedCondition not set")
+				}
+				if !isPresentAndFalseWithReason(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.MachineOwnerRemediatedWaitingForRemediationReason) {
+					return fmt.Errorf("native MachineOwnerRemediatedCondition not set")
 				}
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())

--- a/controllers/hcloudremediation_controller_test.go
+++ b/controllers/hcloudremediation_controller_test.go
@@ -28,14 +28,16 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
-	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/utils"
@@ -43,9 +45,9 @@ import (
 
 var _ = Describe("HCloudRemediationReconciler", func() {
 	var (
-		hcloudRemediation *infrav1.HCloudRemediation
+		hcloudRemediation *infrav2.HCloudRemediation
 		hcloudMachine     *infrav1.HCloudMachine
-		hetznerCluster    *infrav1.HetznerCluster
+		hetznerCluster    *infrav2.HetznerCluster
 
 		capiMachine *clusterv1.Machine
 		capiCluster *clusterv1.Cluster
@@ -118,7 +120,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 		capiMachineKey = client.ObjectKey{Name: capiMachineName, Namespace: testNs.Name}
 
-		hetznerCluster = &infrav1.HetznerCluster{
+		hetznerCluster = &infrav2.HetznerCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hetzner-test1",
 				Namespace: testNs.Name,
@@ -131,7 +133,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					},
 				},
 			},
-			Spec: getDefaultHetznerClusterV1Beta1Spec(),
+			Spec: getDefaultHetznerClusterSpec(),
 		}
 		Expect(testEnv.Create(ctx, hetznerCluster)).To(Succeed())
 
@@ -161,7 +163,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 		hcloudMachineKey = client.ObjectKey{Name: hcloudMachineName, Namespace: testNs.Name}
 
-		hcloudRemediation = &infrav1.HCloudRemediation{
+		hcloudRemediation = &infrav2.HCloudRemediation{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hcloud-remediation",
 				Namespace: testNs.Name,
@@ -174,11 +176,11 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					},
 				},
 			},
-			Spec: infrav1.HCloudRemediationSpec{
-				Strategy: &infrav1.RemediationStrategy{
-					Type:       "Reboot",
-					RetryLimit: 1,
-					Timeout:    &metav1.Duration{Duration: 1 * time.Second},
+			Spec: infrav2.HCloudRemediationSpec{
+				Strategy: &infrav2.RemediationStrategy{
+					Type:           "Reboot",
+					RetryLimit:     ptr.To(int32(1)),
+					TimeoutSeconds: 1,
 				},
 			},
 		}
@@ -204,8 +206,9 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 
 			Eventually(func() bool {
-				return isPresentAndTrueV1Beta1(hcloudMachineKey, hcloudRemediation, infrav1.HCloudTokenAvailableCondition)
-			})
+				return isPresentAndTrueWithReason(hcloudRemediationkey, hcloudRemediation, infrav2.HCloudTokenAvailableCondition, infrav2.HCloudTokenAvailableReason) &&
+					isPresentAndTrueDeprecatedV1Beta1(hcloudRemediationkey, hcloudRemediation, infrav2.HCloudTokenAvailableV1Beta1Condition)
+			}, timeout).Should(BeTrue())
 		})
 
 		It("checks that no remediation is tried if HCloud server does not exist anymore", func() {
@@ -236,8 +239,8 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				if err := testEnv.Get(ctx, hcloudRemediationkey, hcloudRemediation); err != nil {
 					return err
 				}
-				if hcloudRemediation.Status.Phase != infrav1.PhaseDeleting {
-					return fmt.Errorf("hcloudRemediation.Status.Phase is not infrav1.PhaseDeleting")
+				if hcloudRemediation.Status.Phase != infrav2.PhaseDeleting {
+					return fmt.Errorf("hcloudRemediation.Status.Phase is not PhaseDeleting")
 				}
 				if !isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
 					return fmt.Errorf("MachineOwnerRemediatedCondition not set")
@@ -269,11 +272,11 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 					return err
 				}
 
-				if hcloudRemediation.Status.LastRemediated == nil {
-					return fmt.Errorf("hcloudRemediation.Status.LastRemediated == nil")
+				if hcloudRemediation.Status.LastRemediated.IsZero() {
+					return fmt.Errorf("hcloudRemediation.Status.LastRemediated is zero")
 				}
-				if hcloudRemediation.Status.RetryCount != 1 {
-					return fmt.Errorf("hcloudRemediation.Status.RetryCount is %d", hcloudRemediation.Status.RetryCount)
+				if ptr.Deref(hcloudRemediation.Status.RetryCount, 0) != 1 {
+					return fmt.Errorf("hcloudRemediation.Status.RetryCount is %d", ptr.Deref(hcloudRemediation.Status.RetryCount, 0))
 				}
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())
@@ -295,15 +298,15 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				}
 				return nil
 			}, timeout).NotTo(HaveOccurred())
-			hcloudRemediation.Status.RetryCount = hcloudRemediation.Spec.Strategy.RetryLimit
+			hcloudRemediation.Status.RetryCount = ptr.To(ptr.Deref(hcloudRemediation.Spec.Strategy.RetryLimit, 0))
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 
 			Eventually(func() error {
 				if err := testEnv.Get(ctx, hcloudRemediationkey, hcloudRemediation); err != nil {
 					return err
 				}
-				if hcloudRemediation.Status.Phase != infrav1.PhaseWaiting {
-					return fmt.Errorf("hcloudRemediation.Status.Phase != infrav1.PhaseWaiting (phase is %q)", hcloudRemediation.Status.Phase)
+				if hcloudRemediation.Status.Phase != infrav2.PhaseWaiting {
+					return fmt.Errorf("hcloudRemediation.Status.Phase != PhaseWaiting (phase is %q)", hcloudRemediation.Status.Phase)
 				}
 				return nil
 			}, timeout).ShouldNot(HaveOccurred())
@@ -314,11 +317,11 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 
 			By("updating the status to waiting and setting the last remediation to past")
-			hcloudRemediationPatchHelper, err := v1beta1patch.NewHelper(hcloudRemediation, testEnv.GetClient())
+			hcloudRemediationPatchHelper, err := patch.NewHelper(hcloudRemediation, testEnv.GetClient())
 			Expect(err).NotTo(HaveOccurred())
 
-			hcloudRemediation.Status.Phase = infrav1.PhaseWaiting
-			hcloudRemediation.Status.LastRemediated = &metav1.Time{Time: time.Now().Add(-2 * time.Second)}
+			hcloudRemediation.Status.Phase = infrav2.PhaseWaiting
+			hcloudRemediation.Status.LastRemediated = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
 
 			Expect(hcloudRemediationPatchHelper.Patch(ctx, hcloudRemediation)).NotTo(HaveOccurred())
 
@@ -329,7 +332,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				}
 
 				testEnv.GetLogger().Info("status of hcloudRemediation", "status", hcloudRemediation.Status.Phase)
-				return hcloudRemediation.Status.Phase == infrav1.PhaseDeleting &&
+				return hcloudRemediation.Status.Phase == infrav2.PhaseDeleting &&
 					isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason)
 			}, timeout).Should(BeTrue())
 		})
@@ -349,7 +352,7 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 			}, timeout).NotTo(HaveOccurred())
 
 			By("creating the hcloudRemediation with retryLimit 0")
-			hcloudRemediation.Spec.Strategy.RetryLimit = 0
+			hcloudRemediation.Spec.Strategy.RetryLimit = ptr.To(int32(0))
 			Expect(testEnv.Create(ctx, hcloudRemediation)).To(Succeed())
 
 			By("checking that no reboot happened and the machine is handed to CAPI for deletion")
@@ -357,14 +360,14 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 				if err := testEnv.Get(ctx, hcloudRemediationkey, hcloudRemediation); err != nil {
 					return err
 				}
-				if hcloudRemediation.Status.RetryCount != 0 {
-					return fmt.Errorf("expected RetryCount 0, got %d", hcloudRemediation.Status.RetryCount)
+				if ptr.Deref(hcloudRemediation.Status.RetryCount, 0) != 0 {
+					return fmt.Errorf("expected RetryCount 0, got %d", ptr.Deref(hcloudRemediation.Status.RetryCount, 0))
 				}
-				if hcloudRemediation.Status.LastRemediated != nil {
-					return fmt.Errorf("expected LastRemediated to be nil")
+				if !hcloudRemediation.Status.LastRemediated.IsZero() {
+					return fmt.Errorf("expected LastRemediated to be zero")
 				}
-				if hcloudRemediation.Status.Phase != infrav1.PhaseDeleting {
-					return fmt.Errorf("expected Phase %q, got %q", infrav1.PhaseDeleting, hcloudRemediation.Status.Phase)
+				if hcloudRemediation.Status.Phase != infrav2.PhaseDeleting {
+					return fmt.Errorf("expected Phase %q, got %q", infrav2.PhaseDeleting, hcloudRemediation.Status.Phase)
 				}
 				if !isPresentAndFalseWithReasonDeprecatedV1Beta1(capiMachineKey, capiMachine, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.WaitingForRemediationV1Beta1Reason) {
 					return fmt.Errorf("MachineOwnerRemediatedCondition not set")
@@ -403,31 +406,31 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 
 			By("checking that RemediationSkippedCondition is set with IrrecoverableServerCreateFailureReason")
 			Eventually(func() bool {
-				return isPresentAndFalseWithReasonV1Beta1(
+				return isPresentAndFalseWithReasonDeprecatedV1Beta1(
 					hcloudRemediationkey,
 					hcloudRemediation,
-					infrav1.RemediationSkippedCondition,
-					infrav1.IrrecoverableServerCreateFailureReason,
+					infrav2.RemediationSkippedV1Beta1Condition,
+					infrav2.IrrecoverableServerCreateFailureV1Beta1Reason,
 				)
 			}, timeout).Should(BeTrue())
 
-			By("checking v1beta2 RemediationSkipped and Ready conditions are set")
+			By("checking RemediationSkipped and Ready conditions are set")
 			expectedSkippedMsg := "Remediation skipped: HCloudMachine has an irrecoverable server creation error. Delete the Machine to trigger a new creation attempt. Error: server type cax31 not available in location fsn1: resource_unavailable"
 			Eventually(func() bool {
 				if err := testEnv.Get(ctx, hcloudRemediationkey, hcloudRemediation); err != nil {
 					return false
 				}
-				skipped := v1beta2conditions.Get(hcloudRemediation, infrav1.HCloudRemediationSkippedV1Beta2Condition)
+				skipped := conditions.Get(hcloudRemediation, infrav2.HCloudRemediationSkippedCondition)
 				if skipped == nil ||
 					skipped.Status != metav1.ConditionTrue ||
-					skipped.Reason != infrav1.HCloudRemediationIrrecoverableServerCreateFailureV1Beta2Reason ||
+					skipped.Reason != infrav2.HCloudRemediationIrrecoverableServerCreateFailureReason ||
 					skipped.Message != expectedSkippedMsg {
 					return false
 				}
-				ready := v1beta2conditions.Get(hcloudRemediation, clusterv1beta1.ReadyV1Beta2Condition)
+				ready := conditions.Get(hcloudRemediation, clusterv1.ReadyCondition)
 				return ready != nil &&
 					ready.Status == metav1.ConditionFalse &&
-					ready.Reason == clusterv1beta1.NotReadyV1Beta2Reason
+					ready.Reason == clusterv1.NotReadyReason
 			}, timeout).Should(BeTrue())
 		})
 
@@ -497,18 +500,16 @@ var _ = Describe("HCloudRemediationReconciler", func() {
 			}, timeout).Should(Succeed())
 
 			By("Do the job of CAPI: Create a HCloudRemediation")
-			rem := &infrav1.HCloudRemediation{
+			rem := &infrav2.HCloudRemediation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      hcloudMachine.Name,
 					Namespace: hcloudMachine.Namespace,
 				},
-				Spec: infrav1.HCloudRemediationSpec{
-					Strategy: &infrav1.RemediationStrategy{
-						Type:       infrav1.RemediationTypeReboot,
-						RetryLimit: 5,
-						Timeout: &metav1.Duration{
-							Duration: time.Minute,
-						},
+				Spec: infrav2.HCloudRemediationSpec{
+					Strategy: &infrav2.RemediationStrategy{
+						Type:           infrav2.RemediationTypeReboot,
+						RetryLimit:     ptr.To(int32(5)),
+						TimeoutSeconds: 60,
 					},
 				},
 			}

--- a/controllers/hetznercluster_controller_test.go
+++ b/controllers/hetznercluster_controller_test.go
@@ -1421,7 +1421,8 @@ var _ = Describe("Hetzner ClusterReconciler", func() {
 				Expect(testEnv.Create(ctx, instance)).To(Succeed())
 
 				Eventually(func() bool {
-					return isPresentAndTrueDeprecatedV1Beta1(key, instance, infrav2.NetworkReadyV1Beta1Condition)
+					return isPresentAndTrueDeprecatedV1Beta1(key, instance, infrav2.NetworkReadyV1Beta1Condition) &&
+						isPresentAndTrueWithReason(key, instance, infrav2.HetznerClusterNetworkReadyCondition, string(infrav2.HetznerClusterNetworkReadyReason))
 				}, timeout).Should(BeTrue())
 			},
 			)

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -40,12 +40,21 @@ import (
 // counterparts for the controllers that have not been migrated yet, and can be deleted once they
 // are.
 
+// conditionsObject is an API object that owns both the conditions and the deprecated v1beta1
+// conditions and can be status-patched. reconcileRateLimit and hcloudTokenErrorResult accept it so
+// every controller that reconciles such an object shares them.
+type conditionsObject interface {
+	client.Object
+	conditions.Setter
+	deprecatedv1beta1conditions.Setter
+}
+
 // reconcileRateLimit checks whether the rate limit has been reached and returns whether the
 // controller should wait a bit more. When the wait is over it clears the rate-limit conditions
 // (HetznerAPIReachable marked reachable again, HCloudRateLimitExceeded deleted, since we cannot know
 // the limit is gone until the next API call).
-func reconcileRateLimit(cluster *infrav2.HetznerCluster, rateLimitWaitTime time.Duration) bool {
-	condition := conditions.Get(cluster, infrav2.HCloudRateLimitExceededCondition)
+func reconcileRateLimit(obj conditionsObject, rateLimitWaitTime time.Duration) bool {
+	condition := conditions.Get(obj, infrav2.HCloudRateLimitExceededCondition)
 	if condition != nil && condition.Status == metav1.ConditionTrue {
 		if time.Now().Before(condition.LastTransitionTime.Add(rateLimitWaitTime)) {
 			// Rate limit wait has not elapsed yet, so signal the caller to requeue.
@@ -54,8 +63,8 @@ func reconcileRateLimit(cluster *infrav2.HetznerCluster, rateLimitWaitTime time.
 			return true
 		}
 		// Wait time is over, we continue.
-		deprecatedv1beta1conditions.MarkTrue(cluster, infrav2.HetznerAPIReachableV1Beta1Condition)
-		conditions.Delete(cluster, infrav2.HCloudRateLimitExceededCondition)
+		deprecatedv1beta1conditions.MarkTrue(obj, infrav2.HetznerAPIReachableV1Beta1Condition)
+		conditions.Delete(obj, infrav2.HCloudRateLimitExceededCondition)
 	}
 
 	return false
@@ -98,7 +107,7 @@ func getAndValidateHCloudToken(ctx context.Context, namespace string, hetznerClu
 func hcloudTokenErrorResult(
 	ctx context.Context,
 	inerr error,
-	cluster *infrav2.HetznerCluster,
+	obj conditionsObject,
 	crClient client.Client,
 	summaryOpts []conditions.SummaryOption,
 ) (ctrl.Result, error) {
@@ -109,13 +118,13 @@ func hcloudTokenErrorResult(
 	// we requeue the host as we will not know if they create the secret
 	// at some point in the future.
 	case *secretutil.ResolveSecretRefError:
-		deprecatedv1beta1conditions.MarkFalse(cluster,
+		deprecatedv1beta1conditions.MarkFalse(obj,
 			infrav2.HCloudTokenAvailableV1Beta1Condition,
 			infrav2.HetznerSecretUnreachableV1Beta1Reason,
 			clusterv1.ConditionSeverityError,
 			"could not find HetznerSecret",
 		)
-		conditions.Set(cluster, metav1.Condition{
+		conditions.Set(obj, metav1.Condition{
 			Type:    infrav2.HCloudTokenAvailableCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav2.HCloudTokenSecretUnreachableReason,
@@ -126,13 +135,13 @@ func hcloudTokenErrorResult(
 
 	// No need to reconcile again, as it will be triggered as soon as the secret is updated.
 	case *secretutil.HCloudTokenValidationError:
-		deprecatedv1beta1conditions.MarkFalse(cluster,
+		deprecatedv1beta1conditions.MarkFalse(obj,
 			infrav2.HCloudTokenAvailableV1Beta1Condition,
 			infrav2.HCloudCredentialsInvalidV1Beta1Reason,
 			clusterv1.ConditionSeverityError,
 			"invalid or not specified hcloud token in Hetzner secret",
 		)
-		conditions.Set(cluster, metav1.Condition{
+		conditions.Set(obj, metav1.Condition{
 			Type:    infrav2.HCloudTokenAvailableCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav2.HCloudTokenInvalidReason,
@@ -140,14 +149,14 @@ func hcloudTokenErrorResult(
 		})
 
 	default:
-		deprecatedv1beta1conditions.MarkFalse(cluster,
+		deprecatedv1beta1conditions.MarkFalse(obj,
 			infrav2.HCloudTokenAvailableV1Beta1Condition,
 			infrav2.HCloudCredentialsInvalidV1Beta1Reason,
 			clusterv1.ConditionSeverityError,
 			"%s",
 			inerr.Error(),
 		)
-		conditions.Set(cluster, metav1.Condition{
+		conditions.Set(obj, metav1.Condition{
 			Type:    infrav2.HCloudTokenAvailableCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  infrav2.HCloudTokenInvalidReason,
@@ -156,19 +165,19 @@ func hcloudTokenErrorResult(
 		return reconcile.Result{}, fmt.Errorf("an unhandled failure occurred with the Hetzner secret: %w", inerr)
 	}
 
-	deprecatedv1beta1conditions.SetSummary(cluster)
+	deprecatedv1beta1conditions.SetSummary(obj)
 
 	if len(summaryOpts) > 0 {
 		if readyCondition, err := conditions.NewSummaryCondition(
-			cluster,
+			obj,
 			clusterv1.ReadyCondition,
 			summaryOpts...,
 		); err == nil {
-			conditions.Set(cluster, *readyCondition)
+			conditions.Set(obj, *readyCondition)
 		}
 	}
 
-	if err := crClient.Status().Update(ctx, cluster); err != nil {
+	if err := crClient.Status().Update(ctx, obj); err != nil {
 		return reconcile.Result{}, fmt.Errorf("hcloudTokenErrorResult: failed to update: %w", err)
 	}
 	if inerr != nil {

--- a/pkg/scope/hcloudremediation.go
+++ b/pkg/scope/hcloudremediation.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
-	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
-	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	hcloudclient "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
 )
@@ -42,8 +43,8 @@ type HCloudRemediationScopeParams struct {
 	HCloudClient      hcloudclient.Client
 	Machine           *clusterv1.Machine
 	HCloudMachine     *infrav1.HCloudMachine
-	HetznerCluster    *infrav1.HetznerCluster
-	HCloudRemediation *infrav1.HCloudRemediation
+	HetznerCluster    *infrav2.HetznerCluster
+	HCloudRemediation *infrav2.HCloudRemediation
 }
 
 // NewHCloudRemediationScope creates a new Scope from the supplied parameters.
@@ -70,7 +71,7 @@ func NewHCloudRemediationScope(params HCloudRemediationScopeParams) (*HCloudReme
 		return nil, errors.New("failed to generate new scope from nil Logger")
 	}
 
-	patchHelper, err := v1beta1patch.NewHelper(params.HCloudRemediation, params.Client)
+	patchHelper, err := patch.NewHelper(params.HCloudRemediation, params.Client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
@@ -90,45 +91,44 @@ func NewHCloudRemediationScope(params HCloudRemediationScopeParams) (*HCloudReme
 type HCloudRemediationScope struct {
 	logr.Logger
 	Client            client.Client
-	patchHelper       *v1beta1patch.Helper
+	patchHelper       *patch.Helper
 	HCloudClient      hcloudclient.Client
 	Machine           *clusterv1.Machine
 	HCloudMachine     *infrav1.HCloudMachine
-	HCloudRemediation *infrav1.HCloudRemediation
+	HCloudRemediation *infrav2.HCloudRemediation
 }
 
 // Close closes the current scope persisting the remediation configuration and status.
-func (m *HCloudRemediationScope) Close(ctx context.Context, opts ...v1beta1patch.Option) error {
-	// set summary for v1beta1 conditions.
-	v1beta1conditions.SetSummary(m.HCloudRemediation)
+func (m *HCloudRemediationScope) Close(ctx context.Context, opts ...patch.Option) error {
+	// set summary for deprecated v1beta1 conditions.
+	deprecatedv1beta1conditions.SetSummary(m.HCloudRemediation)
 
 	allOpts := append(opts, HCloudRemediationPatchOpts()...)
 
-	// set summary for v1beta2 conditions.
-
-	readyCondition, err := v1beta2conditions.NewSummaryCondition(
+	// set summary for conditions.
+	readyCondition, err := conditions.NewSummaryCondition(
 		m.HCloudRemediation,
-		clusterv1beta1.ReadyV1Beta2Condition,
-		infrav1.HCloudRemediationV1Beta2SummaryOpts()...,
+		clusterv1.ReadyCondition,
+		infrav2.HCloudRemediationSummaryOpts()...,
 	)
 	if err != nil {
 		// Note, this could only happen if we hit edge cases in computing the summary, which should not happen due to the fact
 		// that we are passing a non empty list of ForConditionTypes.
-		m.Error(err, "Failed to set v1beta2 Ready condition")
+		m.Error(err, "Failed to set Ready condition")
 		unknownReadyCondition := metav1.Condition{
-			Type:   clusterv1beta1.ReadyV1Beta2Condition,
+			Type:   clusterv1.ReadyCondition,
 			Status: metav1.ConditionUnknown,
-			Reason: infrav1.InternalErrorV1Beta2Reason,
+			Reason: clusterv1.InternalErrorReason,
 		}
 
 		// set the ready condition with unknown status.
-		v1beta2conditions.Set(m.HCloudRemediation, unknownReadyCondition)
+		conditions.Set(m.HCloudRemediation, unknownReadyCondition)
 
 		patchErr := m.patchHelper.Patch(ctx, m.HCloudRemediation, allOpts...)
 		return errors.Join(err, patchErr)
 	}
 
-	v1beta2conditions.Set(m.HCloudRemediation, *readyCondition)
+	conditions.Set(m.HCloudRemediation, *readyCondition)
 
 	return m.patchHelper.Patch(ctx, m.HCloudRemediation, allOpts...)
 }
@@ -145,8 +145,8 @@ func (m *HCloudRemediationScope) Namespace() string {
 
 // HasRetriesLeft returns true if the retry limit is greater than retry count.
 func (m *HCloudRemediationScope) HasRetriesLeft() bool {
-	return m.HCloudRemediation.Spec.Strategy.RetryLimit > 0 &&
-		m.HCloudRemediation.Spec.Strategy.RetryLimit > m.HCloudRemediation.Status.RetryCount
+	retryLimit := ptr.Deref(m.HCloudRemediation.Spec.Strategy.RetryLimit, 0)
+	return retryLimit > 0 && retryLimit > ptr.Deref(m.HCloudRemediation.Status.RetryCount, 0)
 }
 
 // ServerIDFromProviderID returns the namespace name.
@@ -159,24 +159,24 @@ func (m *HCloudRemediationScope) PatchObject(ctx context.Context) error {
 	return m.patchHelper.Patch(ctx, m.HCloudRemediation, HCloudRemediationPatchOpts()...)
 }
 
-// HCloudRemediationPatchOpts returns the list of v1beta1patch.Option for HCloudRemediation.
+// HCloudRemediationPatchOpts returns the list of patch.Option for HCloudRemediation.
 // Exported so early-exit paths in the controller (that bypass the scope) can share the
 // same owned-conditions list.
-func HCloudRemediationPatchOpts() []v1beta1patch.Option {
-	return []v1beta1patch.Option{
-		// owned v1beta1 conditions.
-		v1beta1patch.WithOwnedConditions{Conditions: []clusterv1beta1.ConditionType{
-			clusterv1beta1.ReadyCondition,
-			infrav1.HCloudTokenAvailableCondition,
-			infrav1.HetznerAPIReachableCondition,
-			infrav1.RemediationSkippedCondition,
+func HCloudRemediationPatchOpts() []patch.Option {
+	return []patch.Option{
+		// owned deprecated v1beta1 conditions.
+		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
+			clusterv1.ReadyV1Beta1Condition,
+			infrav2.HCloudTokenAvailableV1Beta1Condition,
+			infrav2.HetznerAPIReachableV1Beta1Condition,
+			infrav2.RemediationSkippedV1Beta1Condition,
 		}},
-		// owned v1beta2 conditions.
-		v1beta1patch.WithOwnedV1Beta2Conditions{Conditions: []string{
-			clusterv1beta1.ReadyV1Beta2Condition,
-			infrav1.HCloudTokenAvailableV1Beta2Condition,
-			infrav1.HCloudRateLimitExceededV1Beta2Condition,
-			infrav1.HCloudRemediationSkippedV1Beta2Condition,
+		// owned conditions.
+		patch.WithOwnedConditions{Conditions: []string{
+			clusterv1.ReadyCondition,
+			infrav2.HCloudTokenAvailableCondition,
+			infrav2.HCloudRateLimitExceededCondition,
+			infrav2.HCloudRemediationSkippedCondition,
 		}},
 	}
 }

--- a/pkg/services/hcloud/remediation/remediation.go
+++ b/pkg/services/hcloud/remediation/remediation.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	hcloudutil "github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/util"
 )
@@ -93,7 +95,7 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 
 	remediationType := s.scope.HCloudRemediation.Spec.Strategy.Type
 
-	if remediationType != infrav1.RemediationTypeReboot {
+	if remediationType != infrav2.RemediationTypeReboot {
 		s.scope.Info("unsupported remediation strategy")
 		record.Warnf(s.scope.HCloudRemediation, "UnsupportedRemdiationStrategy", "remediation strategy %q is unsupported", remediationType)
 		return reconcile.Result{}, nil
@@ -120,13 +122,13 @@ func (s *Service) Reconcile(ctx context.Context) (reconcile.Result, error) {
 
 	// If no phase set, default to running
 	if s.scope.HCloudRemediation.Status.Phase == "" {
-		s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseRunning
+		s.scope.HCloudRemediation.Status.Phase = infrav2.PhaseRunning
 	}
 
 	switch s.scope.HCloudRemediation.Status.Phase {
-	case infrav1.PhaseRunning:
+	case infrav2.PhaseRunning:
 		return s.handlePhaseRunning(ctx, server)
-	case infrav1.PhaseWaiting:
+	case infrav2.PhaseWaiting:
 		return s.handlePhaseWaiting(ctx)
 	}
 
@@ -138,7 +140,7 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 
 	// retryLimit 0 disables reboots (see RemediationStrategy.RetryLimit), so there
 	// is no remediation to perform. Mark the machine for deletion by CAPI.
-	if !s.scope.HasRetriesLeft() && s.scope.HCloudRemediation.Status.LastRemediated == nil {
+	if !s.scope.HasRetriesLeft() && s.scope.HCloudRemediation.Status.LastRemediated.IsZero() {
 		if err := s.setOwnerRemediatedConditionToFailed(ctx, "exit remediation because retryLimit is 0 (no reboot performed)"); err != nil {
 			record.Warn(s.scope.HCloudRemediation, "FailedSettingConditionOnMachine", err.Error())
 			return reconcile.Result{}, fmt.Errorf("failed to set conditions on CAPI machine: %w", err)
@@ -147,21 +149,21 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 	}
 
 	// if server has never been remediated, then do that now
-	if s.scope.HCloudRemediation.Status.LastRemediated == nil {
+	if s.scope.HCloudRemediation.Status.LastRemediated.IsZero() {
 		if err := s.scope.HCloudClient.RebootServer(ctx, server); err != nil {
-			hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudRemediation, err, "RebootServer")
+			hcloudutil.HandleRateLimitExceeded(s.scope.HCloudRemediation, err, "RebootServer")
 			record.Warn(s.scope.HCloudRemediation, "FailedRebootServer", err.Error())
 			return reconcile.Result{}, fmt.Errorf("failed to reboot server %s with ID %d: %w", server.Name, server.ID, err)
 		}
 		record.Event(s.scope.HCloudRemediation, "ServerRebooted", "Server has been rebooted")
 
-		s.scope.HCloudRemediation.Status.LastRemediated = &now
-		s.scope.HCloudRemediation.Status.RetryCount++
+		s.scope.HCloudRemediation.Status.LastRemediated = now
+		s.scope.HCloudRemediation.Status.RetryCount = ptr.To(ptr.Deref(s.scope.HCloudRemediation.Status.RetryCount, 0) + 1)
 	}
 
 	// check whether retry limit has been reached
 	if !s.scope.HasRetriesLeft() {
-		s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseWaiting
+		s.scope.HCloudRemediation.Status.Phase = infrav2.PhaseWaiting
 	}
 
 	// check when next remediation should be scheduled
@@ -174,14 +176,14 @@ func (s *Service) handlePhaseRunning(ctx context.Context, server *hcloud.Server)
 
 	// remediate now
 	if err := s.scope.HCloudClient.RebootServer(ctx, server); err != nil {
-		hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudRemediation, err, "RebootServer")
+		hcloudutil.HandleRateLimitExceeded(s.scope.HCloudRemediation, err, "RebootServer")
 		record.Warn(s.scope.HCloudRemediation, "FailedRebootServer", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reboot server %s with ID %d: %w", server.Name, server.ID, err)
 	}
 	record.Event(s.scope.HCloudRemediation, "ServerRebooted", "Server has been rebooted")
 
-	s.scope.HCloudRemediation.Status.LastRemediated = &now
-	s.scope.HCloudRemediation.Status.RetryCount++
+	s.scope.HCloudRemediation.Status.LastRemediated = now
+	s.scope.HCloudRemediation.Status.RetryCount = ptr.To(ptr.Deref(s.scope.HCloudRemediation.Status.RetryCount, 0) + 1)
 
 	return res, nil
 }
@@ -226,7 +228,7 @@ func (s *Service) findServer(ctx context.Context) (*hcloud.Server, error) {
 
 	server, err := s.scope.HCloudClient.GetServer(ctx, serverID)
 	if err != nil {
-		hcloudutil.HandleRateLimitExceededV1Beta1(s.scope.HCloudRemediation, err, "GetServer")
+		hcloudutil.HandleRateLimitExceeded(s.scope.HCloudRemediation, err, "GetServer")
 		return nil, fmt.Errorf("failed to get server: %w", err)
 	}
 
@@ -265,7 +267,7 @@ func (s *Service) setOwnerRemediatedConditionToFailed(ctx context.Context, msg s
 
 	record.Event(s.scope.HCloudRemediation, "ExitRemediation", msg)
 
-	s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseDeleting
+	s.scope.HCloudRemediation.Status.Phase = infrav2.PhaseDeleting
 	return nil
 }
 
@@ -305,7 +307,7 @@ func (s *Service) markRemediationSucceeded(ctx context.Context, msg string) erro
 
 	record.Event(s.scope.HCloudRemediation, "RemediationSucceeded", msg)
 
-	s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseSucceeded
+	s.scope.HCloudRemediation.Status.Phase = infrav2.PhaseSucceeded
 	return nil
 }
 
@@ -340,16 +342,16 @@ func (s *Service) markRemediationSkipped(ctx context.Context, msg string) error 
 
 	record.Event(s.scope.HCloudRemediation, "RemediationSkipped", msg)
 
-	s.scope.HCloudRemediation.Status.Phase = infrav1.PhaseDeleting
+	s.scope.HCloudRemediation.Status.Phase = infrav2.PhaseDeleting
 	return nil
 }
 
 // timeUntilNextRemediation checks if it is time to execute a next remediation step
 // and returns seconds to next remediation time.
 func (s *Service) timeUntilNextRemediation(now time.Time) time.Duration {
-	timeout := s.scope.HCloudRemediation.Spec.Strategy.Timeout.Duration
+	timeout := time.Duration(s.scope.HCloudRemediation.Spec.Strategy.TimeoutSeconds) * time.Second
 	// status is not updated yet
-	if s.scope.HCloudRemediation.Status.LastRemediated == nil {
+	if s.scope.HCloudRemediation.Status.LastRemediated.IsZero() {
 		return timeout
 	}
 

--- a/pkg/services/hcloud/remediation/remediation.go
+++ b/pkg/services/hcloud/remediation/remediation.go
@@ -325,14 +325,14 @@ func (s *Service) markRemediationSkipped(ctx context.Context, msg string) error 
 	deprecatedv1beta1conditions.MarkFalse(
 		s.scope.Machine,
 		clusterv1.MachineOwnerRemediatedV1Beta1Condition,
-		infrav1.RemediationCooldownTriggeredReason,
+		infrav2.RemediationCooldownTriggeredReason,
 		clusterv1.ConditionSeverityWarning,
 		"Remediation cooldown active (machine will be deleted): %s", msg,
 	)
 	conditions.Set(s.scope.Machine, metav1.Condition{
 		Type:    clusterv1.MachineOwnerRemediatedCondition,
 		Status:  metav1.ConditionFalse,
-		Reason:  infrav1.RemediationCooldownTriggeredReason,
+		Reason:  infrav2.RemediationCooldownTriggeredReason,
 		Message: fmt.Sprintf("Remediation cooldown active (machine will be deleted): %s", msg),
 	})
 

--- a/pkg/services/hcloud/remediation/remediation_test.go
+++ b/pkg/services/hcloud/remediation/remediation_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
+	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 
 	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
@@ -112,5 +113,8 @@ var _ = Describe("Test rate limit condition", func() {
 		c := conditions.Get(hcloudRemediation, infrav2.HCloudRateLimitExceededCondition)
 		Expect(c).NotTo(BeNil())
 		Expect(c.Status).To(Equal(metav1.ConditionTrue))
+
+		// and the deprecated HetznerAPIReachable counterpart, kept for the v1beta1 API.
+		Expect(deprecatedv1beta1conditions.IsFalse(hcloudRemediation, infrav2.HetznerAPIReachableV1Beta1Condition)).To(BeTrue())
 	})
 })

--- a/pkg/services/hcloud/remediation/remediation_test.go
+++ b/pkg/services/hcloud/remediation/remediation_test.go
@@ -26,9 +26,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
+	"k8s.io/utils/ptr"
+	conditions "sigs.k8s.io/cluster-api/util/conditions"
 
-	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
+	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/scope"
 	"github.com/syself/cluster-api-provider-hetzner/pkg/services/hcloud/client/mocks"
 )
@@ -49,12 +50,12 @@ var _ = Describe("Test TimeUntilNextRemediation", func() {
 
 	DescribeTable("Test TimeUntilNextRemediation",
 		func(tc testCaseTimeUntilNextRemediation) {
-			var bmRemediation infrav1.HCloudRemediation
+			var bmRemediation infrav2.HCloudRemediation
 
-			bmRemediation.Spec.Strategy = &infrav1.RemediationStrategy{Timeout: &metav1.Duration{Duration: time.Minute}}
+			bmRemediation.Spec.Strategy = &infrav2.RemediationStrategy{TimeoutSeconds: 60}
 
 			if tc.lastRemediated != nullTime {
-				bmRemediation.Status.LastRemediated = &metav1.Time{Time: tc.lastRemediated}
+				bmRemediation.Status.LastRemediated = metav1.Time{Time: tc.lastRemediated}
 			}
 
 			service := Service{scope: &scope.HCloudRemediationScope{
@@ -81,17 +82,17 @@ var _ = Describe("Test TimeUntilNextRemediation", func() {
 })
 
 var _ = Describe("Test rate limit condition", func() {
-	It("sets HetznerAPIReachable to false on the HCloudRemediation when a reboot hits the rate limit", func() {
-		hcloudRemediation := &infrav1.HCloudRemediation{
+	It("sets HCloudRateLimitExceeded on the HCloudRemediation when a reboot hits the rate limit", func() {
+		hcloudRemediation := &infrav2.HCloudRemediation{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-remediation", Namespace: "default"},
-			Spec: infrav1.HCloudRemediationSpec{
-				Strategy: &infrav1.RemediationStrategy{
-					Type:       infrav1.RemediationTypeReboot,
-					RetryLimit: 1,
-					Timeout:    &metav1.Duration{Duration: time.Minute},
+			Spec: infrav2.HCloudRemediationSpec{
+				Strategy: &infrav2.RemediationStrategy{
+					Type:           infrav2.RemediationTypeReboot,
+					RetryLimit:     ptr.To(int32(1)),
+					TimeoutSeconds: 60,
 				},
 			},
-			Status: infrav1.HCloudRemediationStatus{Phase: infrav1.PhaseRunning},
+			Status: infrav2.HCloudRemediationStatus{Phase: infrav2.PhaseRunning},
 		}
 
 		hcloudClient := mocks.NewClient(GinkgoT())
@@ -107,7 +108,9 @@ var _ = Describe("Test rate limit condition", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded)).To(BeTrue())
 
-		// the controller reads HetznerAPIReachable on the HCloudRemediation to back off while rate limited.
-		Expect(v1beta1conditions.IsFalse(hcloudRemediation, infrav1.HetznerAPIReachableCondition)).To(BeTrue())
+		// the controller reads HCloudRateLimitExceeded on the HCloudRemediation to back off while rate limited.
+		c := conditions.Get(hcloudRemediation, infrav2.HCloudRateLimitExceededCondition)
+		Expect(c).NotTo(BeNil())
+		Expect(c.Status).To(Equal(metav1.ConditionTrue))
 	})
 })

--- a/pkg/services/hcloud/util/utils.go
+++ b/pkg/services/hcloud/util/utils.go
@@ -77,10 +77,18 @@ func ServerIDFromProviderID(providerID *string) (int64, error) {
 	return id, nil
 }
 
+// conditionsObject is an API object that owns both the conditions and the deprecated v1beta1
+// conditions. HandleRateLimitExceeded accepts it so the v1beta2 resources that call the HCloud API
+// (HetznerCluster, HCloudRemediation) can share it.
+type conditionsObject interface {
+	conditions.Setter
+	deprecatedv1beta1conditions.Setter
+}
+
 // HandleRateLimitExceeded sets the rate-limit conditions if err is an HCloud rate-limit error, and
 // reports whether it was. Controllers and services still on v1beta1 use
 // HandleRateLimitExceededV1Beta1.
-func HandleRateLimitExceeded(cluster *infrav2.HetznerCluster, err error, functionName string) bool {
+func HandleRateLimitExceeded(obj conditionsObject, err error, functionName string) bool {
 	if !hcloud.IsError(err, hcloud.ErrorCodeRateLimitExceeded) {
 		return false
 	}
@@ -88,21 +96,21 @@ func HandleRateLimitExceeded(cluster *infrav2.HetznerCluster, err error, functio
 	msg := fmt.Sprintf("exceeded hcloud rate limit with calling function %q", functionName)
 
 	deprecatedv1beta1conditions.MarkFalse(
-		cluster,
+		obj,
 		infrav2.HetznerAPIReachableV1Beta1Condition,
 		infrav2.RateLimitExceededV1Beta1Reason,
 		clusterv1.ConditionSeverityWarning,
 		"%s",
 		msg,
 	)
-	conditions.Set(cluster, metav1.Condition{
+	conditions.Set(obj, metav1.Condition{
 		Type:    infrav2.HCloudRateLimitExceededCondition,
 		Status:  metav1.ConditionTrue,
 		Reason:  infrav2.HCloudRateLimitExceededReason,
 		Message: msg,
 	})
 
-	record.Warnf(cluster, "RateLimitExceeded", msg)
+	record.Warnf(obj, "RateLimitExceeded", msg)
 	return true
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This switches the HCloudRemediation controller, scope, and service from the v1beta1 API types to the v1beta2 types. The v1beta2 shape already landed in PR #2057, so this pass only moves the controller code onto the new types and off the deprecated CAPI condition and patch packages. It follows the decisions from the HetznerCluster controller switch in PR #2079.

The controller keeps writing both condition sets during the compatibility window, the native conditions on status.conditions and the deprecated v1beta1 conditions on status.deprecated.v1beta1.conditions. The CRD storage version stays v1beta1.

HCloudMachine is still on v1beta1, so the controller reads its conditions through the old condition package and writes the remediation through the new one. That mixed state goes away when HCloudMachine is switched.

**Which issue(s) this PR fixes:**

Fixes #2078

**Special notes for your reviewer**:
We are using `infrav1` and `infrav2` as aliases for v1beta1 and v1beta2. We plan to change them to `infrav1beta1` for v1beta1 and `infrav1` for v1beta2, to make it similar to CAPI, in issue #2092.