### PR TITLE
:bug: Stop requeuing HetznerBareMetalHost when the corresponding Node is not found

### DIFF
--- a/api/v1beta1/conditions_const.go
+++ b/api/v1beta1/conditions_const.go
@@ -301,6 +301,8 @@ const (
 	GetWorkloadClusterClientFailedReason = "GetWorkloadClusterClientFailed"
 	// GetNodeInWorkloadClusterFailedReason indicates failure in fetching the node object from the workload cluster.
 	GetNodeInWorkloadClusterFailedReason = "GetNodeInWorkloadClusterFailed"
+	// NodeNotFoundReason indicates the node object does not exist in the workload cluster.
+	NodeNotFoundReason = "NodeNotFound"
 	// BootIDEmptyReason indicates that an empty boot ID is present on the node object.
 	BootIDEmptyReason = "BootIDEmpty"
 )
@@ -694,6 +696,8 @@ const (
 	HetznerBareMetalHostGettingWorkloadClusterClientFailedV1Beta2Reason = "GettingWorkloadClusterClientFailed"
 	// HetznerBareMetalHostGettingNodeInWorkloadClusterFailedV1Beta2Reason indicates fetching the node object from the workload cluster failed.
 	HetznerBareMetalHostGettingNodeInWorkloadClusterFailedV1Beta2Reason = "GettingNodeInWorkloadClusterFailed"
+	// HetznerBareMetalHostNodeNotFoundV1Beta2Reason indicates the node object does not exist in the workload cluster.
+	HetznerBareMetalHostNodeNotFoundV1Beta2Reason = "NodeNotFound"
 	// HetznerBareMetalHostBootIDEmptyV1Beta2Reason indicates the boot ID on the node object is empty.
 	HetznerBareMetalHostBootIDEmptyV1Beta2Reason = "BootIDEmpty"
 )

--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -288,6 +288,8 @@ const (
 	GetWorkloadClusterClientFailedV1Beta1Reason = "GetWorkloadClusterClientFailed"
 	// GetNodeInWorkloadClusterFailedV1Beta1Reason indicates failure in fetching the node object from the workload cluster.
 	GetNodeInWorkloadClusterFailedV1Beta1Reason = "GetNodeInWorkloadClusterFailed"
+	// NodeNotFoundV1Beta1Reason indicates the node object does not exist in the workload cluster.
+	NodeNotFoundV1Beta1Reason = "NodeNotFound"
 	// BootIDEmptyV1Beta1Reason indicates that an empty boot ID is present on the node object.
 	BootIDEmptyV1Beta1Reason = "BootIDEmpty"
 )
@@ -603,6 +605,8 @@ const (
 	HetznerBareMetalHostGettingWorkloadClusterClientFailedReason = "GettingWorkloadClusterClientFailed"
 	// HetznerBareMetalHostGettingNodeInWorkloadClusterFailedReason indicates fetching the node object from the workload cluster failed.
 	HetznerBareMetalHostGettingNodeInWorkloadClusterFailedReason = "GettingNodeInWorkloadClusterFailed"
+	// HetznerBareMetalHostNodeNotFoundReason indicates the node object does not exist in the workload cluster.
+	HetznerBareMetalHostNodeNotFoundReason = "NodeNotFound"
 	// HetznerBareMetalHostBootIDEmptyReason indicates the boot ID on the node object is empty.
 	HetznerBareMetalHostBootIDEmptyReason = "BootIDEmpty"
 )

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -2340,7 +2340,7 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 	node := &corev1.Node{}
 	err = wlClient.Get(ctx, client.ObjectKey{Name: nodeName}, node)
 	if err != nil {
-		// A NotFound is a definitive answer, not a transient failure, so retrying cannot change it.
+		// The API server answered, the node just isn't there, so asking again won't help.
 		if apierrors.IsNotFound(err) {
 			msg := fmt.Sprintf("node %q not found in the workload cluster", nodeName)
 

--- a/pkg/services/baremetal/host/host.go
+++ b/pkg/services/baremetal/host/host.go
@@ -34,6 +34,7 @@ import (
 	"github.com/syself/hrobot-go/models"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -2339,6 +2340,28 @@ func (s *Service) actionProvisioned(ctx context.Context) actionResult {
 	node := &corev1.Node{}
 	err = wlClient.Get(ctx, client.ObjectKey{Name: nodeName}, node)
 	if err != nil {
+		// A NotFound is a definitive answer, not a transient failure, so retrying cannot change it.
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("node %q not found in the workload cluster", nodeName)
+
+			v1beta1conditions.MarkFalse(
+				host,
+				infrav1.NodeBootIDRetrievedCondition,
+				infrav1.NodeNotFoundReason,
+				clusterv1beta1.ConditionSeverityWarning,
+				"%s",
+				msg)
+			v1beta2conditions.Set(host, metav1.Condition{
+				Type:    infrav1.HetznerBareMetalHostNodeBootIDRetrievedV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  infrav1.HetznerBareMetalHostNodeNotFoundV1Beta2Reason,
+				Message: msg,
+			})
+			record.Warn(host, infrav1.HetznerBareMetalHostNodeNotFoundV1Beta2Reason, msg)
+
+			return actionStop{}
+		}
+
 		err = fmt.Errorf("failed to get corresponding Node object from the workload cluster: %w", err)
 		v1beta1conditions.MarkFalse(
 			host,

--- a/pkg/services/baremetal/host/host_test.go
+++ b/pkg/services/baremetal/host/host_test.go
@@ -2268,3 +2268,57 @@ var _ = Describe("actionProvisioned NoSSHAfterInstallImage=true", func() {
 		Expect(host.GetAnnotations()).To(BeEmpty())
 	})
 })
+
+var _ = Describe("actionProvisioned when the Node is missing in the workload cluster", func() {
+	It("stops reconciling instead of erroring forever", func() {
+		ctx := context.Background()
+
+		// drain events from previous tests
+		for len(testEventRecorder.Events) > 0 {
+			<-testEventRecorder.Events
+		}
+
+		host := helpers.BareMetalHost(
+			"test-host",
+			"default",
+			helpers.WithSSHSpecInclPorts(23),
+			helpers.WithIPv4(),
+			helpers.WithConsumerRef(),
+		)
+
+		service := newTestService(host, nil, nil,
+			helpers.GetDefaultSSHSecret(osSSHKeyName, "default"),
+			helpers.GetDefaultSSHSecret(rescueSSHKeyName, "default"))
+
+		// newTestService seeds a Node named after the host. Remove it so the
+		// workload-cluster Get returns NotFound.
+		Expect(service.scope.Client.Delete(ctx, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: host.Name},
+		})).To(Succeed())
+
+		actResult := service.actionProvisioned(ctx)
+
+		// actionStop returns no error and schedules no requeue.
+		Expect(actResult).Should(BeAssignableToTypeOf(actionStop{}))
+		res, err := actResult.Result()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+
+		c := v1beta1conditions.Get(host, infrav1.NodeBootIDRetrievedCondition)
+		Expect(c).ToNot(BeNil())
+		Expect(c.Status).To(Equal(corev1.ConditionFalse))
+		Expect(c.Reason).To(Equal(infrav1.NodeNotFoundReason))
+		Expect(c.Message).To(ContainSubstring(host.Name))
+
+		c2 := v1beta2conditions.Get(host, infrav1.HetznerBareMetalHostNodeBootIDRetrievedV1Beta2Condition)
+		Expect(c2).ToNot(BeNil())
+		Expect(c2.Status).To(Equal(metav1.ConditionFalse))
+		Expect(c2.Reason).To(Equal(infrav1.HetznerBareMetalHostNodeNotFoundV1Beta2Reason))
+
+		var events []string
+		for len(testEventRecorder.Events) > 0 {
+			events = append(events, <-testEventRecorder.Events)
+		}
+		Expect(events).To(ContainElement(ContainSubstring(infrav1.HetznerBareMetalHostNodeNotFoundV1Beta2Reason)))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

### What this PR does
Adds a `NotFound` branch to the workload-cluster Node lookup in `actionProvisioned`.

When the Node is not found, the `NodeBootIDRetrieved` condition is now reported as `False`
with a `NodeNotFound` reason on both the v1beta1 and v1beta2 halves, a warning event is
emitted, and the action returns `actionStop{}` so nothing is self-scheduled.

Every other error path is unchanged. Genuinely transient failures still report `Unknown`
and still return `actionError`.

### Why we need it
A `NotFound` was treated like any other `Get` error, so the action returned `actionError`.
controller-runtime then logged at ERROR and re-enqueued with exponential backoff, forever, 
once per affected host.

But a `NotFound` is a successful query with a negative result. The network, the auth, and
the API server all worked, and the answer was that the Node does not exist. Retrying cannot
change that, so the old behaviour was permanent log noise with no path to recovery.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2236

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

