### PR TITLE
🌱 Improve the load balancer health check comments and tests

### DIFF
--- a/api/v1beta2/conditions_const.go
+++ b/api/v1beta2/conditions_const.go
@@ -33,6 +33,8 @@ const (
 	LoadBalancerFailedToOwnV1Beta1Reason = "LoadBalancerFailedToOwn"
 	// LoadBalancerWaitingToActivateProxyProtocolV1Beta1Reason used while proxy protocol activation waits for all control-plane machines to be annotated.
 	LoadBalancerWaitingToActivateProxyProtocolV1Beta1Reason = "LoadBalancerWaitingToActivateProxyProtocol"
+	// LoadBalancerWaitingToActivateHTTPHealthCheckV1Beta1Reason used while the switch to an http health check waits for all control-plane machines to be annotated.
+	LoadBalancerWaitingToActivateHTTPHealthCheckV1Beta1Reason = "LoadBalancerWaitingToActivateHTTPHealthCheck"
 )
 
 const (
@@ -349,6 +351,9 @@ const (
 	// HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason indicates that proxy protocol activation is
 	// waiting for all control-plane machines to be annotated.
 	HetznerClusterLoadBalancerWaitingToActivateProxyProtocolReason = "WaitingToActivateProxyProtocol"
+	// HetznerClusterLoadBalancerWaitingToActivateHTTPHealthCheckReason indicates that the switch to an http
+	// health check is waiting for all control-plane machines to be annotated.
+	HetznerClusterLoadBalancerWaitingToActivateHTTPHealthCheckReason = "WaitingToActivateHTTPHealthCheck"
 )
 
 const (

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -429,8 +429,25 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 				return reconcile.Result{}, errors.Join(multierr, err)
 			}
 			if !allReady {
+				const msg = "waiting for all control-plane machines to be annotated before switching to an http health check"
 				s.scope.V(1).Info("health check: not all control-plane infrastructure machines annotated yet, requeueing")
-				return reconcile.Result{RequeueAfter: 10 * time.Second}, multierr
+
+				deprecatedv1beta1conditions.MarkFalse(
+					s.scope.HetznerCluster,
+					infrav2.LoadBalancerReadyV1Beta1Condition,
+					infrav2.LoadBalancerWaitingToActivateHTTPHealthCheckV1Beta1Reason,
+					clusterv1.ConditionSeverityInfo,
+					msg,
+				)
+
+				conditions.Set(s.scope.HetznerCluster, metav1.Condition{
+					Type:    infrav2.HetznerClusterLoadBalancerReadyCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav2.HetznerClusterLoadBalancerWaitingToActivateHTTPHealthCheckReason,
+					Message: msg,
+				})
+
+				return reconcile.Result{RequeueAfter: 2 * time.Minute}, multierr
 			}
 		}
 

--- a/pkg/services/hcloud/loadbalancer/loadbalancer.go
+++ b/pkg/services/hcloud/loadbalancer/loadbalancer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	conditions "sigs.k8s.io/cluster-api/util/conditions"
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
@@ -407,8 +408,12 @@ func (s *Service) reconcileServices(ctx context.Context, lb *hcloud.LoadBalancer
 	}
 
 	// If the kube-API service already exists and its health check no longer matches the spec,
-	// update it in place.
+	// update it in place. The health check runs against this port on the control-plane machine,
+	// unless healthCheck.port sets another one. kubeAPIServicePort is a different port:
+	// the one the load balancer listens on. UpdateServiceOnLoadBalancer takes it to pick the
+	// service to update.
 	kubeAPIDestinationPort := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.Port
+
 	if wantHealthCheck := s.scope.HetznerCluster.Spec.ControlPlaneLoadBalancer.HealthCheck; wantHealthCheck != nil &&
 		kubeAPIServiceExists && healthCheckDiffers(existingKubeAPIService.HealthCheck, wantHealthCheck, kubeAPIDestinationPort) {
 		// Switching a live service from a tcp check to an http or https check can mark every
@@ -473,8 +478,12 @@ func (s *Service) createLoadBalancer(ctx context.Context) (*hcloud.LoadBalancer,
 	return lb, nil
 }
 
-func healthCheckCreateOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerCreateOptsServiceHealthCheck {
-	f := healthCheckOptsFromSpec(hc, servicePort)
+// healthCheckCreateOpts builds the hcloud health-check options for the kube-apiserver service
+// when the load balancer is created. It returns nil when spec is nil, and CAPH then sends no
+// health check, so the load balancer keeps its own default. A new cluster gets its health check
+// here, so it never goes through the tcp to http wait in reconcileServices.
+func healthCheckCreateOpts(spec *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerCreateOptsServiceHealthCheck {
+	f := healthCheckOptsFromSpec(spec, servicePort)
 	if f == nil {
 		return nil
 	}
@@ -498,8 +507,11 @@ func healthCheckCreateOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort 
 	return opts
 }
 
-func healthCheckAddOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerAddServiceOptsHealthCheck {
-	f := healthCheckOptsFromSpec(hc, servicePort)
+// healthCheckAddOpts builds the hcloud health-check options for a kube-apiserver service that is
+// added to an existing load balancer. It returns nil when spec is nil, and CAPH then sends no
+// health check, so the load balancer keeps its own default.
+func healthCheckAddOpts(spec *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerAddServiceOptsHealthCheck {
+	f := healthCheckOptsFromSpec(spec, servicePort)
 	if f == nil {
 		return nil
 	}
@@ -523,8 +535,10 @@ func healthCheckAddOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort int
 	return opts
 }
 
-func healthCheckUpdateOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerUpdateServiceOptsHealthCheck {
-	f := healthCheckOptsFromSpec(hc, servicePort)
+// healthCheckUpdateOpts builds the hcloud health-check options for updating the health check on
+// a kube-apiserver service that already exists. It mirrors healthCheckAddOpts for the update API.
+func healthCheckUpdateOpts(spec *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *hcloud.LoadBalancerUpdateServiceOptsHealthCheck {
+	f := healthCheckOptsFromSpec(spec, servicePort)
 	if f == nil {
 		return nil
 	}
@@ -552,7 +566,6 @@ func healthCheckUpdateOpts(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort 
 // health-check options types used for creating, adding and updating a load balancer service.
 // Go doesn't let one type be reused across all three request builders, so this is converted
 // into each of them by healthCheckCreateOpts, healthCheckAddOpts and healthCheckUpdateOpts.
-// servicePort is the fallback Port for the health check when the spec doesn't set one.
 type healthCheckOpts struct {
 	Protocol    hcloud.LoadBalancerServiceProtocol
 	Port        *int
@@ -563,43 +576,45 @@ type healthCheckOpts struct {
 	Path        *string
 	Response    *string
 	StatusCodes []string
-	TLS         *bool
+	// TLS is set only for an http or https check, so it also marks whether the HTTP
+	// sub-options have to be built at all.
+	TLS *bool
 }
 
-func healthCheckOptsFromSpec(hc *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *healthCheckOpts {
-	if hc == nil {
+// healthCheckOptsFromSpec reads spec into the fields the three hcloud option types share. It
+// returns nil when spec is nil. servicePort is the port the health check runs against when spec
+// sets no port of its own.
+func healthCheckOptsFromSpec(spec *infrav2.LoadBalancerHealthCheckSpec, servicePort int) *healthCheckOpts {
+	if spec == nil {
 		return nil
 	}
 
 	protocol := hcloud.LoadBalancerServiceProtocolTCP
-	if hc.Protocol != "" {
-		protocol = hcloud.LoadBalancerServiceProtocol(hc.Protocol)
+	if spec.Protocol != "" {
+		protocol = hcloud.LoadBalancerServiceProtocol(spec.Protocol)
 	}
 
-	port := servicePort
-	if hc.Port != nil {
-		port = *hc.Port
-	}
+	port := ptr.Deref(spec.Port, servicePort)
 
 	opts := &healthCheckOpts{
 		Protocol: protocol,
 		Port:     &port,
-		Retries:  hc.Retries,
+		Retries:  spec.Retries,
 	}
-	if hc.IntervalSeconds != nil {
-		interval := time.Duration(*hc.IntervalSeconds) * time.Second
+	if spec.IntervalSeconds != nil {
+		interval := time.Duration(*spec.IntervalSeconds) * time.Second
 		opts.Interval = &interval
 	}
-	if hc.TimeoutSeconds != nil {
-		timeout := time.Duration(*hc.TimeoutSeconds) * time.Second
+	if spec.TimeoutSeconds != nil {
+		timeout := time.Duration(*spec.TimeoutSeconds) * time.Second
 		opts.Timeout = &timeout
 	}
 
-	if protocol == hcloud.LoadBalancerServiceProtocolHTTP || protocol == hcloud.LoadBalancerServiceProtocolHTTPS {
-		opts.Domain = hc.Domain
-		opts.Path = hc.Path
-		opts.Response = hc.Response
-		opts.StatusCodes = hc.StatusCodes
+	if isHTTPHealthCheckProtocol(protocol) {
+		opts.Domain = spec.Domain
+		opts.Path = spec.Path
+		opts.Response = spec.Response
+		opts.StatusCodes = spec.StatusCodes
 		tls := protocol == hcloud.LoadBalancerServiceProtocolHTTPS
 		opts.TLS = &tls
 	}
@@ -613,10 +628,10 @@ func isHTTPHealthCheckProtocol(protocol hcloud.LoadBalancerServiceProtocol) bool
 	return protocol == hcloud.LoadBalancerServiceProtocolHTTP || protocol == hcloud.LoadBalancerServiceProtocolHTTPS
 }
 
-// healthCheckDiffers reports whether the load balancer's observed health check differs from the
-// fields set in desired. Fields left unset in desired are not compared, since CAPH only manages
-// the sub-fields the user explicitly configured and otherwise leaves Hetzner's behavior alone.
-// servicePort is the default Port when desired.Port is unset.
+// healthCheckDiffers reports whether the load balancer's observed health check differs from
+// desired. Protocol and Port are always compared, falling back to tcp and servicePort when
+// desired leaves them unset. Interval, timeout, retries, domain, path, response and status
+// codes are compared only when desired sets them, since CAPH leaves the rest to Hetzner.
 func healthCheckDiffers(observed hcloud.LoadBalancerServiceHealthCheck, desired *infrav2.LoadBalancerHealthCheckSpec, servicePort int) bool {
 	if desired == nil {
 		return false
@@ -630,10 +645,7 @@ func healthCheckDiffers(observed hcloud.LoadBalancerServiceHealthCheck, desired 
 		return true
 	}
 
-	desiredPort := servicePort
-	if desired.Port != nil {
-		desiredPort = *desired.Port
-	}
+	desiredPort := ptr.Deref(desired.Port, servicePort)
 	if desiredPort != observed.Port {
 		return true
 	}

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -529,7 +529,13 @@ func TestReconcileServices_HealthCheckMigration_MachinesNotReady_Requeues(t *tes
 
 	res, err := svc.reconcileServices(context.Background(), hcloudLB)
 	require.NoError(t, err)
-	require.NotZero(t, res.RequeueAfter, "should requeue while a control-plane machine is not annotated")
+	require.Equal(t, 2*time.Minute, res.RequeueAfter, "should requeue after 2 minutes while a control-plane machine is not annotated")
+
+	cond := conditions.Get(svc.scope.HetznerCluster, infrav2.HetznerClusterLoadBalancerReadyCondition)
+	require.NotNil(t, cond, "LoadBalancerReady condition should report the http health check wait")
+	require.Equal(t, metav1.ConditionFalse, cond.Status)
+	require.Equal(t, infrav2.HetznerClusterLoadBalancerWaitingToActivateHTTPHealthCheckReason, cond.Reason)
+
 	// No UpdateServiceOnLoadBalancer expectation was set up, so AssertExpectations fails here if
 	// the tcp check got switched to http anyway.
 	mockClient.AssertExpectations(t)
@@ -688,7 +694,7 @@ func TestReconcileServices_HealthCheckMigration_MachinesNotReady_StillEnablesPro
 
 	res, err := svc.reconcileServices(context.Background(), hcloudLB)
 	require.NoError(t, err)
-	require.Equal(t, 10*time.Second, res.RequeueAfter, "should requeue while the health-check migration waits, without blocking proxy protocol")
+	require.Equal(t, 2*time.Minute, res.RequeueAfter, "should requeue while the health-check migration waits, without blocking proxy protocol")
 	require.True(t, svc.scope.HetznerCluster.Status.ControlPlaneLoadBalancer.ProxyProtocolEnabled, "proxy protocol should still be enabled in this reconcile")
 
 	require.Len(t, updateCalls, 1, "only the proxy-protocol update should have been sent")

--- a/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
+++ b/pkg/services/hcloud/loadbalancer/reconcile_services_test.go
@@ -251,6 +251,8 @@ func TestReconcileServices_HealthCheckSet_AddsKubeAPIServiceWithHealthCheck(t *t
 	require.NotNil(t, capturedOpts.HealthCheck)
 	require.Equal(t, hcloud.LoadBalancerServiceProtocolHTTP, capturedOpts.HealthCheck.Protocol)
 	require.Equal(t, "/readyz", *capturedOpts.HealthCheck.HTTP.Path)
+	require.NotNil(t, capturedOpts.HealthCheck.Port)
+	require.Equal(t, testLBDestPort, *capturedOpts.HealthCheck.Port)
 	mockClient.AssertExpectations(t)
 }
 
@@ -564,6 +566,51 @@ func TestReconcileServices_HealthCheckMigration_MachinesReady_SwitchesInPlace(t 
 	require.NotNil(t, capturedOpts.HealthCheck)
 	require.Equal(t, hcloud.LoadBalancerServiceProtocolHTTP, capturedOpts.HealthCheck.Protocol)
 	require.Equal(t, "/readyz", *capturedOpts.HealthCheck.HTTP.Path)
+	require.NotNil(t, capturedOpts.HealthCheck.Port)
+	require.Equal(t, testLBDestPort, *capturedOpts.HealthCheck.Port)
+	mockClient.AssertExpectations(t)
+}
+
+// TestReconcileServices_HealthCheckBackToTCP_UpdatesInPlaceWithoutGate verifies that switching
+// the health check from http back to tcp is applied right away, without waiting for the
+// control-plane rollout. Only a switch away from tcp can mark a backend that does not answer
+// the path unhealthy.
+func TestReconcileServices_HealthCheckBackToTCP_UpdatesInPlaceWithoutGate(t *testing.T) {
+	hetznerCluster := newTestHetznerCluster()
+	hetznerCluster.Spec.ControlPlaneLoadBalancer.HealthCheck = &infrav2.LoadBalancerHealthCheckSpec{
+		Protocol: "tcp",
+	}
+
+	mockClient := &mocks.Client{}
+	// scope.Client is intentionally left nil: reaching it would panic, so this also proves the
+	// gate is never consulted for a switch back to tcp.
+	svc := newTestService(t, hetznerCluster, mockClient)
+	hcloudLB := &hcloud.LoadBalancer{
+		Services: []hcloud.LoadBalancerService{
+			{
+				ListenPort: testKubeAPIListenPort,
+				HealthCheck: hcloud.LoadBalancerServiceHealthCheck{
+					Protocol: hcloud.LoadBalancerServiceProtocolHTTP,
+					Port:     testLBDestPort,
+					HTTP:     &hcloud.LoadBalancerServiceHealthCheckHTTP{Path: "/readyz"},
+				},
+			},
+		},
+	}
+
+	var capturedOpts hcloud.LoadBalancerUpdateServiceOpts
+	mockClient.On("UpdateServiceOnLoadBalancer", mock.Anything, hcloudLB, testKubeAPIListenPort, mock.Anything).
+		Run(func(args mock.Arguments) {
+			capturedOpts = args.Get(3).(hcloud.LoadBalancerUpdateServiceOpts)
+		}).
+		Return(nil)
+
+	res, err := svc.reconcileServices(context.Background(), hcloudLB)
+	require.NoError(t, err)
+	require.Zero(t, res.RequeueAfter)
+	require.NotNil(t, capturedOpts.HealthCheck)
+	require.Equal(t, hcloud.LoadBalancerServiceProtocolTCP, capturedOpts.HealthCheck.Protocol)
+	require.Nil(t, capturedOpts.HealthCheck.HTTP)
 	mockClient.AssertExpectations(t)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Two things on the control plane load balancer health check.

1. Before CAPH switches the check from tcp to http it waits for every control plane machine to carry the http health check annotation. That wait requeues every 10 seconds. #2213 raised the proxy protocol wait next to it to 2 minutes so we call the API less often, and left this one alone, so this raises it the same way. That PR also gave the proxy protocol wait a reason on `LoadBalancerReady`. This wait only wrote a debug log, so the condition stayed True and a user switching to an http check saw nothing. It now sets `WaitingToActivateHTTPHealthCheck`, which clears once the wait ends.

2. Comments and tests on the same code. The four `healthCheck*Opts` helpers get a doc comment saying what a nil return means, the `healthCheckDiffers` comment is corrected because `Protocol` and `Port` are always compared and not only when set, and `TLS` and `kubeAPIDestinationPort` get a line explaining what they are for. `healthCheckOptsFromSpec` now calls `isHTTPHealthCheckProtocol` instead of repeating the comparison, takes `spec` instead of `hc` so `hc` keeps meaning the `HetznerCluster`, and reads the optional port with `ptr.Deref`. On the test side, the health check port is now asserted against the service destination port, and switching the check back from http to tcp has a reconcile test.

**Which issue(s) this PR fixes:**
None.

**Special notes for your reviewer**:

None.

**TODOs**:
- [ ] squash commits
- [x] include documentation
- [x] add unit tests'