### PR TITLE
🌱 Clean up leftovers from the CAPI and HetznerCluster v1beta2 migration

### DIFF
--- a/controllers/hcloudmachine_controller_test.go
+++ b/controllers/hcloudmachine_controller_test.go
@@ -37,7 +37,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"
-	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -691,7 +691,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 
 				By("setting the bootstrap data")
 
-				ph, err := v1beta1patch.NewHelper(capiMachine, testEnv)
+				ph, err := patch.NewHelper(capiMachine, testEnv)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{
@@ -699,7 +699,7 @@ var _ = Describe("HCloudMachineReconciler", func() {
 				}
 
 				Eventually(func() error {
-					return ph.Patch(ctx, capiMachine, v1beta1patch.WithStatusObservedGeneration{})
+					return ph.Patch(ctx, capiMachine, patch.WithStatusObservedGeneration{})
 				}, timeout, interval).Should(BeNil())
 
 				By("checking that bootstrap condition is ready")

--- a/controllers/hetznerbaremetalmachine_controller_test.go
+++ b/controllers/hetznerbaremetalmachine_controller_test.go
@@ -43,6 +43,7 @@ import (
 	deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -278,14 +279,14 @@ var _ = Describe("HetznerBareMetalMachineReconciler", func() {
 			It("sets bootstrap condition on true if bootstrap available", func() {
 				By("setting bootstrap information in capi machine")
 
-				ph, err := v1beta1patch.NewHelper(capiMachine, testEnv)
+				ph, err := patch.NewHelper(capiMachine, testEnv)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				capiMachine.Spec.Bootstrap = clusterv1.Bootstrap{
 					DataSecretName: ptr.To("bootstrap-secret"),
 				}
 				Eventually(func() error {
-					return ph.Patch(ctx, capiMachine, v1beta1patch.WithStatusObservedGeneration{})
+					return ph.Patch(ctx, capiMachine, patch.WithStatusObservedGeneration{})
 				}, timeout, time.Second).Should(BeNil())
 
 				By("checking that bootstrap condition is set on true")

--- a/controllers/hetznercluster_controller.go
+++ b/controllers/hetznercluster_controller.go
@@ -1060,10 +1060,8 @@ func (r *HetznerClusterReconciler) machineToHetznerCluster(ctx context.Context, 
 // watched object without an extra Get of the owning Machine — the same way clusterv1.ClusterNameLabel is
 // already read directly off these objects elsewhere in this file.
 //
-// The condition type is read via the v1beta1 constants (infrav1) rather than a v1beta2 (infrav2) one:
-// server.go and baremetal.go still set the condition through the v1beta1-typed scope, so infrav1 is the
-// actual source of truth today. Reading the same constant that's written keeps the two in sync by
-// construction, instead of relying on a separate v1beta2 constant that happens to hold the same string.
+// The condition is matched by string. Use the same constant that server.go and baremetal.go write,
+// so a change to its value on one side cannot silently stop the predicate from firing.
 func controlPlaneMachineToHetznerClusterPredicate() predicate.Funcs {
 	isControlPlaneMachine := func(o client.Object) bool {
 		_, ok := o.GetLabels()[clusterv1.MachineControlPlaneLabel]

--- a/pkg/scope/workloadclusterclient.go
+++ b/pkg/scope/workloadclusterclient.go
@@ -27,33 +27,11 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	infrav1 "github.com/syself/cluster-api-provider-hetzner/api/v1beta1"
-	infrav2 "github.com/syself/cluster-api-provider-hetzner/api/v1beta2"
 	secretutil "github.com/syself/cluster-api-provider-hetzner/pkg/secrets"
 )
 
 // workloadClientConfigFromKubeconfigSecret creates a kubernetes client config from kubeconfig secret.
-func workloadClientConfigFromKubeconfigSecret(ctx context.Context, logger logr.Logger, cl client.Client, apiReader client.Reader, cluster *clusterv1.Cluster, hetznerCluster *infrav2.HetznerCluster) (clientcmd.ClientConfig, error) {
-	secretKey := client.ObjectKey{
-		Name:      fmt.Sprintf("%s-%s", cluster.Name, secret.Kubeconfig),
-		Namespace: cluster.Namespace,
-	}
-
-	secretManager := secretutil.NewSecretManager(logger, cl, apiReader)
-	kubeconfigSecret, err := secretManager.AcquireSecret(ctx, secretKey, hetznerCluster, false, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to acquire secret: %w", err)
-	}
-	kubeconfigBytes, ok := kubeconfigSecret.Data[secret.KubeconfigDataName]
-	if !ok {
-		return nil, fmt.Errorf("missing key %q in secret data (WorkloadClientConfigFromKubeconfigSecret)", secret.KubeconfigDataName)
-	}
-	return clientcmd.NewClientConfigFromBytes(kubeconfigBytes)
-}
-
-// workloadClientConfigFromKubeconfigSecretV1Beta1 is the still-v1beta1 counterpart of
-// workloadClientConfigFromKubeconfigSecret.
-func workloadClientConfigFromKubeconfigSecretV1Beta1(ctx context.Context, logger logr.Logger, cl client.Client, apiReader client.Reader, cluster *clusterv1.Cluster, hetznerCluster *infrav1.HetznerCluster) (clientcmd.ClientConfig, error) {
+func workloadClientConfigFromKubeconfigSecret(ctx context.Context, logger logr.Logger, cl client.Client, apiReader client.Reader, cluster *clusterv1.Cluster, hetznerCluster client.Object) (clientcmd.ClientConfig, error) {
 	secretKey := client.ObjectKey{
 		Name:      fmt.Sprintf("%s-%s", cluster.Name, secret.Kubeconfig),
 		Namespace: cluster.Namespace,
@@ -82,11 +60,11 @@ type realWorkloadClusterClientFactory struct {
 	logger         logr.Logger
 	client         client.Client
 	cluster        *clusterv1.Cluster
-	hetznerCluster *infrav1.HetznerCluster
+	hetznerCluster client.Object
 }
 
 func (f *realWorkloadClusterClientFactory) NewWorkloadClient(ctx context.Context) (client.Client, error) {
-	wlConfig, err := workloadClientConfigFromKubeconfigSecretV1Beta1(ctx, f.logger,
+	wlConfig, err := workloadClientConfigFromKubeconfigSecret(ctx, f.logger,
 		f.client, f.client, f.cluster, f.hetznerCluster)
 	if err != nil {
 		return nil, fmt.Errorf("actionProvisioned (Reboot via Annotation),WorkloadClientConfigFromKubeconfigSecret failed: %w",


### PR DESCRIPTION
**What this PR does / why we need it**:

A few things were missed when the HetznerCluster controller moved to v1beta2 and when the CAPI core types moved to v1beta2. This PR cleans them up.

- Two tests patched a CAPI `Machine` through the deprecated `util/deprecated/v1beta1/patch` helper. CAPI core objects are `core/v1beta2`, so they now use `util/patch`. 
- `workloadClientConfigFromKubeconfigSecret` had a duplicate that differed only in the type of the `HetznerCluster` parameter. That parameter is only the owner the secret is acquired for, and `AcquireSecret` already takes `client.Object`, so the duplicate is gone and both callers use one function.

This does not change behavior.

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer**:

None

**TODOs**:
- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests